### PR TITLE
Fix minority fork recovery and add related tests

### DIFF
--- a/casper/src/rust/engine/casper_launch.rs
+++ b/casper/src/rust/engine/casper_launch.rs
@@ -30,9 +30,9 @@ use crate::rust::engine::engine::{
     record_direct_to_running_init_metrics, transition_to_initializing, transition_to_running,
 };
 use crate::rust::engine::engine_cell::EngineCell;
-use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::engine::genesis_ceremony_master::GenesisCeremonyMaster;
 use crate::rust::engine::genesis_validator::GenesisValidator;
+use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::errors::CasperError;
 use crate::rust::estimator::Estimator;
 use crate::rust::multi_parent_casper_impl::MultiParentCasperImpl;

--- a/casper/src/rust/engine/casper_launch.rs
+++ b/casper/src/rust/engine/casper_launch.rs
@@ -30,6 +30,7 @@ use crate::rust::engine::engine::{
     record_direct_to_running_init_metrics, transition_to_initializing, transition_to_running,
 };
 use crate::rust::engine::engine_cell::EngineCell;
+use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::engine::genesis_ceremony_master::GenesisCeremonyMaster;
 use crate::rust::engine::genesis_validator::GenesisValidator;
 use crate::rust::errors::CasperError;
@@ -406,6 +407,21 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> CasperLaunchImpl<T> {
             self.transport_layer.clone(),
             self.rp_conf_ask.clone(),
             self.block_retriever.clone(),
+            Some(RunningRecoveryContext {
+                connections_cell: self.connections_cell.clone(),
+                last_approved_block: self.last_approved_block.clone(),
+                block_store: self.block_store.clone(),
+                block_dag_storage: self.block_dag_storage.clone(),
+                deploy_storage: self.deploy_storage.clone(),
+                casper_buffer_storage: self.casper_buffer_storage.clone(),
+                rspace_state_manager: self.rspace_state_manager.clone(),
+                event_publisher: self.event_publisher.clone(),
+                engine_cell: self.engine_cell.clone(),
+                runtime_manager: self.runtime_manager.clone(),
+                estimator: self.estimator.clone(),
+                casper_shard_conf: self.casper_shard_conf.clone(),
+                heartbeat_signal_ref: self.heartbeat_signal_ref.clone(),
+            }),
             &self.engine_cell,
             &self.event_publisher,
         )

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use block_storage::rust::casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage;
@@ -46,6 +47,10 @@ pub trait Engine: Send + Sync {
     async fn init(&self) -> Result<(), CasperError>;
 
     async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
+
+    async fn recover_stuck_validator(&self, _delay_threshold: Duration) -> Result<bool, CasperError> {
+        Ok(false)
+    }
 
     /// Returns the casper instance as an Arc if this engine wraps one.
     /// Returns None for engines that don't have casper (NoopEngine, Initializing, etc.)
@@ -187,7 +192,7 @@ pub async fn send_no_approved_block_available<T: TransportLayer + Send + Sync + 
 
 // NOTE: Changed to use trait object (dyn MultiParentCasper) instead of generic T
 // based on discussion with Steven for TestFixture compatibility
-pub async fn transition_to_running<U: TransportLayer + Send + Sync + 'static>(
+pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'static>(
     block_processing_queue_tx: mpsc::Sender<(
         Arc<dyn MultiParentCasper + Send + Sync>,
         BlockMessage,
@@ -202,6 +207,7 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + 'static>(
     transport: Arc<U>,
     conf: RPConf,
     block_retriever: BlockRetriever<U>,
+    recovery_context: Option<crate::rust::engine::running::RunningRecoveryContext>,
     engine_cell: &EngineCell,
     event_log: &F1r3flyEvents,
 ) -> Result<(), CasperError> {
@@ -240,6 +246,7 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + 'static>(
         transport,
         conf,
         block_retriever,
+        recovery_context,
     );
 
     engine_cell.set(Arc::new(running)).await;

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -48,7 +48,10 @@ pub trait Engine: Send + Sync {
 
     async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
 
-    async fn recover_stuck_validator(&self, _delay_threshold: Duration) -> Result<bool, CasperError> {
+    async fn recover_stuck_validator(
+        &self,
+        _delay_threshold: Duration,
+    ) -> Result<bool, CasperError> {
         Ok(false)
     }
 

--- a/casper/src/rust/engine/genesis_ceremony_master.rs
+++ b/casper/src/rust/engine/genesis_ceremony_master.rs
@@ -158,6 +158,7 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> GenesisCeremonyMaster<T>
                     transport_layer.clone(),
                     rp_conf_ask.clone(),
                     block_retriever.clone(),
+                    None,
                     &engine_cell,
                     event_publisher,
                 )

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -41,9 +41,9 @@ use crate::rust::engine::engine::{
     Engine,
 };
 use crate::rust::engine::engine_cell::EngineCell;
-use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::engine::lfs_block_requester::{self, BlockRequesterOps};
 use crate::rust::engine::lfs_tuple_space_requester::{self, StatePartPath, TupleSpaceRequesterOps};
+use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::errors::CasperError;
 use crate::rust::estimator::Estimator;
 use crate::rust::metrics_constants::{
@@ -893,6 +893,7 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             .unwrap()
             .take()
             .ok_or_else(|| CasperError::RuntimeError("Estimator not available".to_string()))?;
+        let recovery_estimator = estimator.clone();
 
         // Pass Arc<Mutex<RuntimeManager>> directly to hash_set_casper
         let casper = crate::rust::casper::hash_set_casper(
@@ -922,13 +923,6 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             Box::pin(async { Ok(()) })
                 as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
         });
-        let estimator = self
-            .estimator
-            .lock()
-            .map_err(|_| CasperError::RuntimeError("Estimator not available".to_string()))?
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| CasperError::RuntimeError("Estimator not available".to_string()))?;
 
         transition_to_running(
             self.block_processing_queue_tx.clone(),
@@ -951,7 +945,7 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
                 event_publisher: self.event_publisher.clone(),
                 engine_cell: self.engine_cell.clone(),
                 runtime_manager: self.runtime_manager.clone(),
-                estimator,
+                estimator: recovery_estimator,
                 casper_shard_conf: self.casper_shard_conf.clone(),
                 heartbeat_signal_ref: self.heartbeat_signal_ref.clone(),
             }),

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -41,6 +41,7 @@ use crate::rust::engine::engine::{
     Engine,
 };
 use crate::rust::engine::engine_cell::EngineCell;
+use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::engine::lfs_block_requester::{self, BlockRequesterOps};
 use crate::rust::engine::lfs_tuple_space_requester::{self, StatePartPath, TupleSpaceRequesterOps};
 use crate::rust::errors::CasperError;
@@ -921,6 +922,13 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             Box::pin(async { Ok(()) })
                 as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
         });
+        let estimator = self
+            .estimator
+            .lock()
+            .map_err(|_| CasperError::RuntimeError("Estimator not available".to_string()))?
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| CasperError::RuntimeError("Estimator not available".to_string()))?;
 
         transition_to_running(
             self.block_processing_queue_tx.clone(),
@@ -932,6 +940,21 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             Arc::new(self.transport_layer.clone()),
             self.rp_conf_ask.clone(),
             self.block_retriever.clone(),
+            Some(RunningRecoveryContext {
+                connections_cell: self.connections_cell.clone(),
+                last_approved_block: self.last_approved_block.clone(),
+                block_store: self.block_store.clone(),
+                block_dag_storage: self.block_dag_storage.clone(),
+                deploy_storage: self.deploy_storage.clone(),
+                casper_buffer_storage: self.casper_buffer_storage.clone(),
+                rspace_state_manager: self.rspace_state_manager.clone(),
+                event_publisher: self.event_publisher.clone(),
+                engine_cell: self.engine_cell.clone(),
+                runtime_manager: self.runtime_manager.clone(),
+                estimator,
+                casper_shard_conf: self.casper_shard_conf.clone(),
+                heartbeat_signal_ref: self.heartbeat_signal_ref.clone(),
+            }),
             &self.engine_cell,
             &self.event_publisher,
         )

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -7,11 +7,16 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use block_storage::rust::casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage;
+use block_storage::rust::dag::block_dag_key_value_storage::BlockDagKeyValueStorage;
+use block_storage::rust::deploy::key_value_deploy_storage::KeyValueDeployStorage;
+use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use comm::rust::peer_node::PeerNode;
 use comm::rust::rp::connect::ConnectionsCell;
 use comm::rust::rp::rp_conf::RPConf;
 use comm::rust::transport::transport_layer::TransportLayer;
 use dashmap::DashSet;
+use models::casper::ApprovedBlockRequestProto;
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::pretty_printer::PrettyPrinter;
 use models::rust::casper::protocol::casper_message::{
@@ -21,16 +26,20 @@ use models::rust::casper::protocol::casper_message::{
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 use rspace_plus_plus::rspace::state::exporters::rspace_exporter_items::RSpaceExporterItems;
 use rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporterInstance;
+use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
+use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
 
-use crate::rust::casper::MultiParentCasper;
+use crate::rust::casper::{CasperShardConf, MultiParentCasper};
 use crate::rust::engine::block_retriever::{self, BlockRetriever};
 use crate::rust::engine::engine::{self, Engine};
 use crate::rust::engine::engine_cell::EngineCell;
+use crate::rust::estimator::Estimator;
 use crate::rust::errors::CasperError;
 use crate::rust::metrics_constants::{
     BLOCK_HASH_RECEIVED_METRIC, BLOCK_REQUEST_RECEIVED_METRIC, RUNNING_METRICS_SOURCE,
 };
+use crate::rust::util::rholang::runtime_manager::RuntimeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CasperMessageStatus {
@@ -107,6 +116,7 @@ pub async fn update_fork_choice_tips_if_stuck<T: TransportLayer + Send + Sync>(
             transport
                 .send_fork_choice_tip_request(connections_cell, conf)
                 .await?;
+            let _ = engine.recover_stuck_validator(delay_threshold).await?;
         }
     }
 
@@ -114,7 +124,7 @@ pub async fn update_fork_choice_tips_if_stuck<T: TransportLayer + Send + Sync>(
 }
 
 #[async_trait]
-impl<T: TransportLayer + Send + Sync + 'static> Engine for Running<T> {
+impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for Running<T> {
     async fn init(&self) -> Result<(), CasperError> {
         {
             let mut init_called = self.init_called.lock().map_err(|_| {
@@ -295,6 +305,10 @@ impl<T: TransportLayer + Send + Sync + 'static> Engine for Running<T> {
 
     /// Running always contains casper; enables `EngineDynExt::with_casper(...)`
     /// to mirror Scala `Engine.withCasper` behavior.
+    async fn recover_stuck_validator(&self, delay_threshold: Duration) -> Result<bool, CasperError> {
+        self.recover_stuck_validator_inner(delay_threshold).await
+    }
+
     fn with_casper(&self) -> Option<Arc<dyn MultiParentCasper + Send + Sync>> {
         Some(Arc::clone(&self.casper) as Arc<dyn MultiParentCasper + Send + Sync>)
     }
@@ -317,6 +331,24 @@ pub struct Running<T: TransportLayer + Send + Sync> {
     transport: Arc<T>,
     conf: RPConf,
     block_retriever: BlockRetriever<T>,
+    recovery_context: Option<RunningRecoveryContext>,
+}
+
+#[derive(Clone)]
+pub struct RunningRecoveryContext {
+    pub connections_cell: ConnectionsCell,
+    pub last_approved_block: Arc<Mutex<Option<ApprovedBlock>>>,
+    pub block_store: KeyValueBlockStore,
+    pub block_dag_storage: BlockDagKeyValueStorage,
+    pub deploy_storage: KeyValueDeployStorage,
+    pub casper_buffer_storage: CasperBufferKeyValueStorage,
+    pub rspace_state_manager: RSpaceStateManager,
+    pub event_publisher: F1r3flyEvents,
+    pub engine_cell: Arc<EngineCell>,
+    pub runtime_manager: Arc<tokio::sync::Mutex<RuntimeManager>>,
+    pub estimator: Estimator,
+    pub casper_shard_conf: CasperShardConf,
+    pub heartbeat_signal_ref: crate::rust::heartbeat_signal::HeartbeatSignalRef,
 }
 
 const MAX_BLOCKS_IN_PROCESSING: usize = 2_048;
@@ -339,6 +371,7 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
         transport: Arc<T>,
         conf: RPConf,
         block_retriever: BlockRetriever<T>,
+        recovery_context: Option<RunningRecoveryContext>,
     ) -> Self {
         Running {
             block_processing_queue_tx,
@@ -351,6 +384,7 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
             transport,
             conf,
             block_retriever,
+            recovery_context,
         }
     }
 
@@ -359,6 +393,104 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
         let buffer_contains = self.casper.buffer_contains(&hash);
         let dag_contains = self.casper.dag_contains(&hash);
         Ok(blocks_in_processing || buffer_contains || dag_contains)
+    }
+
+    async fn recover_stuck_validator_inner(
+        &self,
+        delay_threshold: Duration,
+    ) -> Result<bool, CasperError>
+    where
+        T: Clone + 'static,
+    {
+        let Some(recovery_context) = &self.recovery_context else {
+            return Ok(false);
+        };
+        let Some(validator_id) = self.casper.get_validator() else {
+            return Ok(false);
+        };
+
+        let validator = validator_id.public_key.bytes.clone();
+        let dag = self.casper.block_dag().await?;
+        let latest_hash = match dag.latest_message_hash(&validator) {
+            Some(hash) => hash,
+            None => return Ok(false),
+        };
+        if latest_hash == dag.last_finalized_block() {
+            return Ok(false);
+        }
+
+        let latest_block = match self.casper.block_store().get(&latest_hash)? {
+            Some(block) => block,
+            None => return Ok(false),
+        };
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
+        let latest_age_ms = now_ms.saturating_sub(latest_block.header.timestamp);
+        if latest_age_ms < delay_threshold.as_millis() as i64 {
+            return Ok(false);
+        }
+
+        let transport = Arc::clone(&self.transport);
+        let conf = self.conf.clone();
+        let connections = recovery_context.connections_cell.clone();
+        let init = Arc::new(move || {
+            let transport = Arc::clone(&transport);
+            let conf = conf.clone();
+            let connections = connections.clone();
+
+            Box::pin(async move {
+                transport
+                    .send_message_to_peers(
+                        &connections,
+                        &conf,
+                        Arc::new(ApprovedBlockRequestProto {
+                            identifier: "".to_string(),
+                            trim_state: true,
+                        }),
+                        None,
+                    )
+                    .await?;
+                Ok(())
+            })
+                as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
+        });
+
+        tracing::warn!(
+            "Validator latest message {} has been stale for {}ms; rejoining from approved block.",
+            PrettyPrinter::build_string_bytes(&latest_hash),
+            latest_age_ms
+        );
+
+        engine::transition_to_initializing(
+            &self.block_processing_queue_tx,
+            &self.blocks_in_processing,
+            &recovery_context.casper_shard_conf,
+            &Some(validator_id),
+            init,
+            true,
+            self.disable_state_exporter,
+            &self.transport,
+            &self.conf,
+            &recovery_context.connections_cell,
+            &recovery_context.last_approved_block,
+            &recovery_context.block_store,
+            &recovery_context.block_dag_storage,
+            &recovery_context.deploy_storage,
+            &recovery_context.casper_buffer_storage,
+            &recovery_context.rspace_state_manager,
+            recovery_context.event_publisher.clone(),
+            self.block_retriever.clone(),
+            &recovery_context.engine_cell,
+            &recovery_context.runtime_manager,
+            &recovery_context.estimator,
+            &recovery_context.heartbeat_signal_ref,
+        )
+        .await?;
+
+        Ok(true)
     }
 
     pub async fn handle_block_hash_message(

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -34,8 +34,8 @@ use crate::rust::casper::{CasperShardConf, MultiParentCasper};
 use crate::rust::engine::block_retriever::{self, BlockRetriever};
 use crate::rust::engine::engine::{self, Engine};
 use crate::rust::engine::engine_cell::EngineCell;
-use crate::rust::estimator::Estimator;
 use crate::rust::errors::CasperError;
+use crate::rust::estimator::Estimator;
 use crate::rust::metrics_constants::{
     BLOCK_HASH_RECEIVED_METRIC, BLOCK_REQUEST_RECEIVED_METRIC, RUNNING_METRICS_SOURCE,
 };
@@ -305,7 +305,10 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for Running<T> {
 
     /// Running always contains casper; enables `EngineDynExt::with_casper(...)`
     /// to mirror Scala `Engine.withCasper` behavior.
-    async fn recover_stuck_validator(&self, delay_threshold: Duration) -> Result<bool, CasperError> {
+    async fn recover_stuck_validator(
+        &self,
+        delay_threshold: Duration,
+    ) -> Result<bool, CasperError> {
         self.recover_stuck_validator_inner(delay_threshold).await
     }
 
@@ -454,8 +457,7 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
                     )
                     .await?;
                 Ok(())
-            })
-                as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
+            }) as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
         });
 
         tracing::warn!(

--- a/casper/tests/batch1/minority_fork_recovery_spec.rs
+++ b/casper/tests/batch1/minority_fork_recovery_spec.rs
@@ -1,0 +1,109 @@
+use std::time::Duration;
+
+use casper::rust::engine::running::update_fork_choice_tips_if_stuck;
+use casper::rust::util::construct_deploy;
+
+use crate::helper::test_node::TestNode;
+use crate::util::genesis_builder::GenesisBuilder;
+
+#[tokio::test]
+async fn validator_on_minority_fork_should_rejoin_majority_chain_after_stale_detection() {
+    let genesis = GenesisBuilder::new()
+        .build_genesis_with_parameters(Some(
+            GenesisBuilder::build_genesis_parameters_with_defaults(None, Some(3)),
+        ))
+        .await
+        .expect("Failed to build genesis");
+
+    let shard_id = genesis.genesis_block.shard_id.clone();
+    let mut nodes = TestNode::create_network(genesis.clone(), 3, None, None, None, None)
+        .await
+        .expect("Failed to create 3-node network");
+
+    let minority_deploy = construct_deploy::source_deploy_now(
+        "@101!(\"minority\")".to_string(),
+        None,
+        None,
+        Some(shard_id.clone()),
+    )
+    .expect("Failed to create minority deploy");
+
+    let minority_block = nodes[0]
+        .add_block_from_deploys(&[minority_deploy])
+        .await
+        .expect("Validator on minority fork should create a local block");
+
+    let majority_deploy = construct_deploy::source_deploy_now(
+        "@201!(\"majority\")".to_string(),
+        None,
+        None,
+        Some(shard_id.clone()),
+    )
+    .expect("Failed to create majority deploy");
+
+    let majority_block = TestNode::propagate_block_to_one(&mut nodes, 1, 2, &[majority_deploy])
+        .await
+        .expect("Node 1 should propagate a majority block to node 2");
+
+    assert!(
+        nodes[1].contains(&majority_block.block_hash),
+        "Majority validator should contain latest majority block"
+    );
+    assert!(
+        nodes[2].contains(&majority_block.block_hash),
+        "Peer majority validator should contain latest majority block"
+    );
+    assert!(
+        !nodes[0].contains(&majority_block.block_hash),
+        "Minority validator should not yet know the majority block"
+    );
+    assert!(
+        nodes[0].contains(&minority_block.block_hash),
+        "Minority validator should still be on its local fork before recovery"
+    );
+
+    update_fork_choice_tips_if_stuck(
+        &nodes[0].engine_cell,
+        &nodes[0].tle,
+        &nodes[0].connections_cell,
+        &nodes[0].rp_conf,
+        Duration::from_millis(0),
+    )
+    .await
+    .expect("Stale minority validator should trigger recovery");
+
+    let engine_after_detection = nodes[0].engine_cell.get().await;
+    assert!(
+        engine_after_detection.with_casper().is_none(),
+        "Minority validator should move into Initializing after stale detection"
+    );
+
+    let queue_to_majority_peer_1 = nodes[1]
+        .tle
+        .test_network()
+        .peer_queue(&nodes[1].local)
+        .expect("Majority peer queue should be readable");
+    let queue_to_majority_peer_2 = nodes[2]
+        .tle
+        .test_network()
+        .peer_queue(&nodes[2].local)
+        .expect("Majority peer queue should be readable");
+    let request_type_ids: Vec<String> = queue_to_majority_peer_1
+        .iter()
+        .chain(queue_to_majority_peer_2.iter())
+        .filter_map(|protocol| {
+            protocol.message.as_ref().and_then(|message| match message {
+                models::routing::protocol::Message::Packet(packet) => Some(packet.type_id.clone()),
+                _ => None,
+            })
+        })
+        .collect();
+    assert!(
+        request_type_ids
+            .iter()
+            .any(|type_id| type_id == "ApprovedBlockRequest"),
+        "Recovery should request ApprovedBlock from majority peers, got queue types: {:?}",
+        request_type_ids
+    );
+
+}

--- a/casper/tests/batch1/minority_fork_recovery_spec.rs
+++ b/casper/tests/batch1/minority_fork_recovery_spec.rs
@@ -105,5 +105,4 @@ async fn validator_on_minority_fork_should_rejoin_majority_chain_after_stale_det
         "Recovery should request ApprovedBlock from majority peers, got queue types: {:?}",
         request_type_ids
     );
-
 }

--- a/casper/tests/batch1/mod.rs
+++ b/casper/tests/batch1/mod.rs
@@ -3,6 +3,7 @@ mod multi_parent_casper_communication_spec;
 mod multi_parent_casper_deploy_spec;
 mod multi_parent_casper_finalization_spec;
 mod multi_parent_casper_merge_spec;
+mod minority_fork_recovery_spec;
 mod multi_parent_casper_reporting_spec;
 mod multi_parent_casper_rholang_spec;
 mod multi_parent_casper_smoke_spec;

--- a/casper/tests/engine/running_spec.rs
+++ b/casper/tests/engine/running_spec.rs
@@ -1,19 +1,170 @@
 // See casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
 
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
+use async_trait::async_trait;
+use casper::rust::block_status::{BlockError, InvalidBlock, ValidBlock};
+use casper::rust::casper::{Casper, CasperSnapshot, DeployError, MultiParentCasper};
 use casper::rust::engine::engine::Engine;
+use casper::rust::engine::engine_cell::EngineCell;
+use casper::rust::engine::running::{
+    update_fork_choice_tips_if_stuck, Running, RunningRecoveryContext,
+};
+use casper::rust::errors::CasperError;
+use casper::rust::validator_identity::ValidatorIdentity;
+use models::casper::ApprovedBlockRequestProto;
+use models::routing::protocol::Message as ProtocolMessage;
+use models::rust::block_hash::BlockHash;
 use models::rust::block_implicits::get_random_block;
 use models::rust::casper::protocol::casper_message::{
-    BlockRequest, CasperMessage, ForkChoiceTipRequest, HasBlock,
+    ApprovedBlock, ApprovedBlockCandidate, BlockMessage, BlockRequest, CasperMessage, DeployData,
+    ForkChoiceTipRequest, HasBlock,
 };
 use prost::bytes::Bytes;
+use prost::Message;
+use rspace_plus_plus::rspace::history::Either;
+use rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporter;
 
 use crate::engine::setup::{to_casper_message, TestFixture};
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Clone)]
+    struct ValidatorAwareNoOpsCasper {
+        inner: crate::helper::no_ops_casper_effect::NoOpsCasperEffect,
+        validator_id: ValidatorIdentity,
+    }
+
+    #[async_trait]
+    impl MultiParentCasper for ValidatorAwareNoOpsCasper {
+        async fn fetch_dependencies(&self) -> Result<(), CasperError> {
+            self.inner.fetch_dependencies().await
+        }
+
+        fn normalized_initial_fault(
+            &self,
+            weights: std::collections::HashMap<models::rust::validator::Validator, u64>,
+        ) -> Result<f32, CasperError> {
+            self.inner.normalized_initial_fault(weights)
+        }
+
+        async fn last_finalized_block(&self) -> Result<BlockMessage, CasperError> {
+            self.inner.last_finalized_block().await
+        }
+
+        async fn block_dag(
+            &self,
+        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+            self.inner.block_dag().await
+        }
+
+        fn block_store(&self) -> &block_storage::rust::key_value_block_store::KeyValueBlockStore {
+            self.inner.block_store()
+        }
+
+        fn get_validator(&self) -> Option<ValidatorIdentity> { Some(self.validator_id.clone()) }
+
+        async fn get_history_exporter(&self) -> Arc<dyn RSpaceExporter> {
+            self.inner.get_history_exporter().await
+        }
+
+        fn runtime_manager(
+            &self,
+        ) -> Arc<tokio::sync::Mutex<casper::rust::util::rholang::runtime_manager::RuntimeManager>>
+        {
+            self.inner.runtime_manager()
+        }
+
+        async fn has_pending_deploys_in_storage(&self) -> Result<bool, CasperError> {
+            self.inner.has_pending_deploys_in_storage().await
+        }
+    }
+
+    #[async_trait]
+    impl Casper for ValidatorAwareNoOpsCasper {
+        async fn get_snapshot(&self) -> Result<CasperSnapshot, CasperError> {
+            self.inner.get_snapshot().await
+        }
+
+        fn contains(&self, hash: &BlockHash) -> bool { self.inner.contains(hash) }
+
+        fn dag_contains(&self, hash: &BlockHash) -> bool { self.inner.dag_contains(hash) }
+
+        fn buffer_contains(&self, hash: &BlockHash) -> bool { self.inner.buffer_contains(hash) }
+
+        fn get_approved_block(&self) -> Result<&BlockMessage, CasperError> {
+            self.inner.get_approved_block()
+        }
+
+        fn deploy(
+            &self,
+            deploy: crypto::rust::signatures::signed::Signed<DeployData>,
+        ) -> Result<
+            Either<DeployError, block_storage::rust::dag::block_dag_key_value_storage::DeployId>,
+            CasperError,
+        > {
+            self.inner.deploy(deploy)
+        }
+
+        async fn estimator(
+            &self,
+            dag: &mut block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
+        ) -> Result<Vec<BlockHash>, CasperError> {
+            self.inner.estimator(dag).await
+        }
+
+        fn get_version(&self) -> i64 { self.inner.get_version() }
+
+        async fn validate(
+            &self,
+            block: &BlockMessage,
+            snapshot: &mut CasperSnapshot,
+        ) -> Result<Either<BlockError, ValidBlock>, CasperError> {
+            self.inner.validate(block, snapshot).await
+        }
+
+        async fn validate_self_created(
+            &self,
+            block: &BlockMessage,
+            snapshot: &mut CasperSnapshot,
+            pre_state_hash: Bytes,
+            post_state_hash: Bytes,
+        ) -> Result<Either<BlockError, ValidBlock>, CasperError> {
+            self.inner
+                .validate_self_created(block, snapshot, pre_state_hash, post_state_hash)
+                .await
+        }
+
+        async fn handle_valid_block(
+            &self,
+            block: &BlockMessage,
+        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+            self.inner.handle_valid_block(block).await
+        }
+
+        fn handle_invalid_block(
+            &self,
+            block: &BlockMessage,
+            status: &InvalidBlock,
+            dag: &block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
+        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+            self.inner.handle_invalid_block(block, status, dag)
+        }
+
+        fn get_dependency_free_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError> {
+            self.inner.get_dependency_free_from_buffer()
+        }
+
+        fn get_all_from_buffer(&self) -> Result<Vec<BlockMessage>, CasperError> {
+            self.inner.get_all_from_buffer()
+        }
+    }
 
     #[tokio::test]
     async fn engine_should_enqueue_block_message_for_processing() {
@@ -198,5 +349,102 @@ mod tests {
 
         assert_eq!(has_block_count, requests.len());
         assert_eq!(received_tips, expected_tips);
+    }
+
+    #[tokio::test]
+    async fn stale_validator_should_transition_to_initializing_and_request_approved_block() {
+        let fixture = TestFixture::new().await;
+        let engine_cell = Arc::new(EngineCell::init());
+
+        fixture.transport_layer.reset();
+        fixture
+            .transport_layer
+            .set_responses(|_peer, _protocol| Ok(()));
+
+        let mut stale_block = fixture.genesis.clone();
+        stale_block.block_hash = Bytes::from_static(b"stale-validator-block");
+        stale_block.sender = fixture.validator_id.public_key.bytes.clone();
+        stale_block.header.timestamp = 0;
+
+        let mut casper = fixture.casper.clone();
+        casper.insert_block(stale_block, false);
+
+        let approved_block = ApprovedBlock {
+            candidate: ApprovedBlockCandidate {
+                block: fixture.genesis.clone(),
+                required_sigs: 0,
+            },
+            sigs: Vec::new(),
+        };
+
+        let running = Running::new(
+            fixture.block_processing_queue_tx.clone(),
+            fixture.blocks_in_processing.clone(),
+            Arc::new(ValidatorAwareNoOpsCasper {
+                inner: casper,
+                validator_id: fixture.validator_id.clone(),
+            }) as Arc<dyn MultiParentCasper + Send + Sync>,
+            approved_block,
+            Arc::new(|| {
+                Box::pin(async { Ok(()) })
+                    as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
+            }),
+            false,
+            fixture.transport_layer.clone(),
+            fixture.rp_conf_ask.clone(),
+            fixture.block_retriever.clone(),
+            Some(RunningRecoveryContext {
+                connections_cell: fixture.connections_cell.clone(),
+                last_approved_block: fixture.last_approved_block.clone(),
+                block_store: fixture.block_store.clone(),
+                block_dag_storage: fixture.block_dag_storage.clone(),
+                deploy_storage: fixture.deploy_storage.clone(),
+                casper_buffer_storage: fixture.casper_buffer_storage.clone(),
+                rspace_state_manager: fixture.rspace_state_manager.clone(),
+                event_publisher: fixture.event_publisher.clone(),
+                engine_cell: engine_cell.clone(),
+                runtime_manager: fixture.runtime_manager.clone(),
+                estimator: fixture.estimator.clone(),
+                casper_shard_conf: fixture.casper_shard_conf.clone(),
+                heartbeat_signal_ref: casper::rust::heartbeat_signal::new_heartbeat_signal_ref(),
+            }),
+        );
+        engine_cell.set(Arc::new(running)).await;
+
+        update_fork_choice_tips_if_stuck(
+            &engine_cell,
+            &fixture.transport_layer,
+            &fixture.connections_cell,
+            &fixture.rp_conf_ask,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        let engine = engine_cell.get().await;
+        assert!(
+            engine.with_casper().is_none(),
+            "stale validator should leave Running and transition into Initializing"
+        );
+
+        let expected_proto = ApprovedBlockRequestProto {
+            identifier: "".to_string(),
+            trim_state: true,
+        };
+        let expected_content = Bytes::from(expected_proto.encode_to_vec());
+        let requests = fixture.transport_layer.get_all_requests();
+        let found_approved_block_request = requests.iter().any(|req| {
+            if let Some(ProtocolMessage::Packet(packet)) = &req.msg.message {
+                packet.content == expected_content
+            } else {
+                false
+            }
+        });
+
+        assert!(
+            found_approved_block_request,
+            "recovery should request an approved block from peers; requests: {:?}",
+            requests.iter().map(|r| &r.msg).collect::<Vec<_>>()
+        );
     }
 }

--- a/casper/tests/engine/running_spec.rs
+++ b/casper/tests/engine/running_spec.rs
@@ -60,7 +60,10 @@ mod tests {
 
         async fn block_dag(
             &self,
-        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+        ) -> Result<
+            block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
+            CasperError,
+        > {
             self.inner.block_dag().await
         }
 
@@ -144,7 +147,10 @@ mod tests {
         async fn handle_valid_block(
             &self,
             block: &BlockMessage,
-        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+        ) -> Result<
+            block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
+            CasperError,
+        > {
             self.inner.handle_valid_block(block).await
         }
 
@@ -153,7 +159,10 @@ mod tests {
             block: &BlockMessage,
             status: &InvalidBlock,
             dag: &block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
-        ) -> Result<block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation, CasperError> {
+        ) -> Result<
+            block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation,
+            CasperError,
+        > {
             self.inner.handle_invalid_block(block, status, dag)
         }
 

--- a/casper/tests/engine/setup.rs
+++ b/casper/tests/engine/setup.rs
@@ -469,6 +469,7 @@ impl TestFixture {
             transport_layer.clone(),
             rp_conf.clone(),
             block_retriever.clone(),
+            None,
         );
 
         Self {

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -14,7 +14,7 @@ use casper::rust::blocks::proposer::proposer::new_proposer;
 use casper::rust::casper::{Casper, CasperShardConf, MultiParentCasper};
 use casper::rust::engine::block_retriever::{BlockRetriever, RequestState, RequestedBlocks};
 use casper::rust::engine::engine_cell::EngineCell;
-use casper::rust::engine::running::Running;
+use casper::rust::engine::running::{Running, RunningRecoveryContext};
 use casper::rust::errors::CasperError;
 use casper::rust::estimator::Estimator;
 use casper::rust::genesis::genesis::Genesis;
@@ -42,6 +42,7 @@ use models::rust::block_hash::BlockHash;
 use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockCandidate, BlockMessage, DeployData,
 };
+use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use rspace_plus_plus::rspace::history::Either;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
@@ -65,6 +66,8 @@ pub struct TestNode {
     pub block_store: KeyValueBlockStore,
     pub block_dag_storage: BlockDagKeyValueStorage,
     pub deploy_storage: Arc<Mutex<KeyValueDeployStorage>>,
+    pub last_approved_block: Arc<Mutex<Option<ApprovedBlock>>>,
+    pub rspace_state_manager: RSpaceStateManager,
     pub runtime_manager: RuntimeManager,
     // Note: no log field, logging will come from log crate
     pub requested_blocks: RequestedBlocks,
@@ -897,11 +900,15 @@ impl TestNode {
             .await
             .unwrap();
         // Use create_with_history to ensure tests can reset to genesis state root hash
-        let (runtime_manager, _rho_history_repository) = RuntimeManager::create_with_history(
+        let (runtime_manager, rho_history_repository) = RuntimeManager::create_with_history(
             rspace_store,
             mergeable_store,
             Genesis::non_negative_mergeable_tag_name(),
             rholang::rust::interpreter::external_services::ExternalServices::noop(),
+        );
+        let rspace_state_manager = RSpaceStateManager::new(
+            rho_history_repository.exporter(),
+            rho_history_repository.importer(),
         );
 
         let connections_cell = ConnectionsCell::new();
@@ -979,6 +986,7 @@ impl TestNode {
             },
             sigs: vec![],
         };
+        let last_approved_block = Arc::new(Mutex::new(Some(_approved_block.clone())));
 
         let shard_conf = CasperShardConf {
             fault_tolerance_threshold: 0.0,
@@ -1044,6 +1052,8 @@ impl TestNode {
                 + Sync,
         > = Arc::new(|| Box::pin(async { Ok(()) }));
 
+        let engine_cell = EngineCell::init();
+
         let running_engine = Running::new(
             block_processor_queue.0.clone(), // block_processing_queue_tx
             Arc::new(DashSet::new()),        // blocks_in_processing
@@ -1054,10 +1064,22 @@ impl TestNode {
             tle.clone(),                     // transport
             rp_conf.clone(),                 // conf
             block_retriever.clone(),         // block_retriever
+            Some(RunningRecoveryContext {
+                connections_cell: connections_cell.clone(),
+                last_approved_block: last_approved_block.clone(),
+                block_store: block_store.clone(),
+                block_dag_storage: block_dag_storage.clone(),
+                deploy_storage: deploy_storage.lock().unwrap().clone(),
+                casper_buffer_storage: casper_buffer_storage.clone(),
+                rspace_state_manager: rspace_state_manager.clone(),
+                event_publisher: event_publisher.clone(),
+                engine_cell: Arc::new(engine_cell.clone()),
+                runtime_manager: Arc::new(tokio::sync::Mutex::new(runtime_manager.clone())),
+                estimator: estimator.clone(),
+                casper_shard_conf: casper.casper_shard_conf.clone(),
+                heartbeat_signal_ref: casper.heartbeat_signal_ref.clone(),
+            }),
         );
-
-        // Create EngineCell
-        let engine_cell = EngineCell::init();
         engine_cell.set(Arc::new(running_engine)).await;
 
         // Create CasperPacketHandler
@@ -1074,6 +1096,8 @@ impl TestNode {
             block_store,
             block_dag_storage,
             deploy_storage,
+            last_approved_block,
+            rspace_state_manager,
             runtime_manager,
             requested_blocks,
             connections_cell,

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -42,8 +42,8 @@ use models::rust::block_hash::BlockHash;
 use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockCandidate, BlockMessage, DeployData,
 };
-use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use rspace_plus_plus::rspace::history::Either;
+use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
 
@@ -66,8 +66,6 @@ pub struct TestNode {
     pub block_store: KeyValueBlockStore,
     pub block_dag_storage: BlockDagKeyValueStorage,
     pub deploy_storage: Arc<Mutex<KeyValueDeployStorage>>,
-    pub last_approved_block: Arc<Mutex<Option<ApprovedBlock>>>,
-    pub rspace_state_manager: RSpaceStateManager,
     pub runtime_manager: RuntimeManager,
     // Note: no log field, logging will come from log crate
     pub requested_blocks: RequestedBlocks,
@@ -1096,8 +1094,6 @@ impl TestNode {
             block_store,
             block_dag_storage,
             deploy_storage,
-            last_approved_block,
-            rspace_state_manager,
             runtime_manager,
             requested_blocks,
             connections_cell,

--- a/rholang/src/rust/interpreter/compiler/normalizer/processes/p_contr_normalizer.rs
+++ b/rholang/src/rust/interpreter/compiler/normalizer/processes/p_contr_normalizer.rs
@@ -115,7 +115,9 @@ pub fn normalize_p_contr<'ast>(
 mod tests {
     use models::create_bit_vector;
     use models::rhoapi::expr::ExprInstance;
+    use models::rhoapi::var::VarInstance;
     use models::rhoapi::{EPlus, Expr, Par, Receive, ReceiveBind};
+    use models::rust::rholang::implicits::single_expr;
     use models::rust::utils::{new_boundvar_par, new_freevar_par, new_gint_par, new_send_par};
 
     use crate::rust::interpreter::compiler::normalize::VarSort;
@@ -290,6 +292,64 @@ mod tests {
 
         assert_eq!(result.clone().unwrap().par, expected_result);
         assert_eq!(result.unwrap().free_map, inputs.free_map);
+    }
+
+    #[test]
+    fn p_contr_should_keep_outer_captures_distinct_in_nested_contracts() {
+        use crate::rust::interpreter::compiler::compiler::Compiler;
+
+        let par = Compiler::source_to_adt(
+            r#"
+contract @"service_id-notify-listeners"(@payload) = {
+  new loop, stdOut(`rho:io:stdout`) in {
+    stdOut!(["before loop", payload]) |
+    contract loop(@listeners) = {
+      stdOut!(["loop", payload, *loop])
+    } |
+    for(@listeners <- @"service_id-listeners") {
+      stdOut!(["outer", payload, *loop]) |
+      loop!("whatever")
+    }
+  }
+}
+"#,
+        )
+        .expect("source should compile");
+
+        let outer_receive = par.receives.first().expect("outer contract receive");
+        let outer_body = outer_receive.body.as_ref().expect("outer contract body");
+        let new_term = outer_body.news.first().expect("new term");
+        let new_body = new_term.p.as_ref().expect("new body");
+        let inner_receive = new_body
+            .receives
+            .iter()
+            .find(|receive| receive.persistent)
+            .expect("inner contract receive");
+        let inner_body = inner_receive.body.as_ref().expect("inner contract body");
+        let send = inner_body.sends.first().expect("inner body send");
+        let payload_list = send.data.first().expect("send payload");
+        let payload_list_expr = single_expr(payload_list).expect("list expr");
+
+        let ExprInstance::EListBody(list) = payload_list_expr
+            .expr_instance
+            .as_ref()
+            .expect("list instance")
+        else {
+            panic!("expected list body");
+        };
+
+        let payload_entry = list.ps.get(1).expect("payload entry");
+        let payload_expr = single_expr(payload_entry).expect("payload expr");
+
+        let ExprInstance::EVarBody(var) = payload_expr.expr_instance.as_ref().expect("var body")
+        else {
+            panic!("expected var body");
+        };
+
+        assert_eq!(
+            var.v.as_ref().and_then(|v| v.var_instance.as_ref()),
+            Some(&VarInstance::BoundVar(3))
+        );
     }
 
     #[test]

--- a/rholang/tests/interpreter_spec.rs
+++ b/rholang/tests/interpreter_spec.rs
@@ -210,7 +210,7 @@ async fn interpreter_should_capture_the_current_outer_value_in_nested_contracts(
             })
         }
 
-        let tuple_space = runtime.get_hot_changes();
+        let tuple_space = runtime.get_hot_changes().await;
         let results_channel = rho_string("results");
         let results_row = tuple_space.get(&results_channel).expect("results row");
         let results: HashSet<Par> = results_row

--- a/rholang/tests/interpreter_spec.rs
+++ b/rholang/tests/interpreter_spec.rs
@@ -173,6 +173,87 @@ async fn interpreter_should_yield_correct_results_for_prime_check_contract() {
     .await
 }
 
+#[tokio::test]
+async fn interpreter_should_capture_the_current_outer_value_in_nested_contracts() {
+    with_runtime("nested-contract-capture-spec-", |mut runtime| async move {
+        let term = r#"
+            @"service_id_listeners"!({}) |
+            contract @"service_id_notify_listeners"(@payload, @ret_id) = {
+                new loop, stdOut(`rho:io:stdout`) in {
+                    stdOut!(["before loop", payload]) |
+                    contract loop(@listeners) = {
+                        stdOut!(["loop", payload, *loop]) |
+                        @"results"!((ret_id, payload))
+                    } |
+                    for(@listeners <<- @"service_id_listeners") {
+                        stdOut!(["outer", payload, *loop]) |
+                        loop!("whatever")
+                    }
+                }
+            } |
+            @"service_id_notify_listeners"!("1", "result1") |
+            @"service_id_notify_listeners"!("2", "result2")
+        "#;
+
+        success(&mut runtime, term).await.unwrap();
+
+        fn rho_par(expr: Expr) -> Vec<Par> {
+            vec![Par {
+                exprs: vec![expr],
+                ..Default::default()
+            }]
+        }
+
+        fn rho_string(s: &str) -> Vec<Par> {
+            rho_par(Expr {
+                expr_instance: Some(expr::ExprInstance::GString(s.to_string())),
+            })
+        }
+
+        let tuple_space = runtime.get_hot_changes();
+        let results_channel = rho_string("results");
+        let results_row = tuple_space.get(&results_channel).expect("results row");
+        let results: HashSet<Par> = results_row
+            .data
+            .iter()
+            .flat_map(|datum| datum.a.pars.clone())
+            .collect();
+        let expected: HashSet<Par> = vec![
+            Par {
+                exprs: vec![Expr {
+                    expr_instance: Some(expr::ExprInstance::ETupleBody(models::rhoapi::ETuple {
+                        ps: vec![
+                            rho_string("result1").into_iter().next().expect("result1"),
+                            rho_string("1").into_iter().next().expect("payload1"),
+                        ],
+                        locally_free: Vec::new(),
+                        connective_used: false,
+                    })),
+                }],
+                ..Default::default()
+            },
+            Par {
+                exprs: vec![Expr {
+                    expr_instance: Some(expr::ExprInstance::ETupleBody(models::rhoapi::ETuple {
+                        ps: vec![
+                            rho_string("result2").into_iter().next().expect("result2"),
+                            rho_string("2").into_iter().next().expect("payload2"),
+                        ],
+                        locally_free: Vec::new(),
+                        connective_used: false,
+                    })),
+                }],
+                ..Default::default()
+            },
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(results, expected);
+    })
+    .await
+}
+
 //TODO should throw SyntaxError, but throw ParserError
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn interpreter_should_signal_syntax_errors_to_the_caller() {


### PR DESCRIPTION
## What changed

  This PR addresses two issues:

  - Fixes validator recovery from minority forks: #21
  - Adds regression coverage for inner contract payload capture behavior: #5

  ### For #21
  - Added a recovery path for validators that get stuck on a stale minority fork.
  - When a validator detects that its own latest message is stale and not finalized, it now leaves `Running` and re-enters the existing initialization flow.
  - Recovery requests `ApprovedBlock` from connected peers directly, so the node can rebuild from the majority chain instead of staying on a dead fork.
  - Updated the engine wiring and test harness so this path is exercised the same way in production and tests.

  ### For #5
  - Investigated the reported inner-contract variable capture issue.
  - The bug was not reproduced in the current codebase.
  - Added compiler/runtime regression tests to lock in the expected behavior and guard against future regressions.

  ## Why it changed

  ### #21
  A validator that produced a block rejected by the majority could keep building on its own fork  forever. The node detected staleness, but it had no recovery action beyond requesting fork-choice tips. This left the validator permanently outside consensus.

  This PR gives the validator a recovery path back to the majority chain.

  ### #5
  The report described an inner contract observing a different payload value than the outer contract. Since that behavior did not reproduce in this branch, the safest change was to add targeted regression tests and preserve the current semantics.

  ## How it was verified

  Ran targeted tests for the changed behavior:

  ```bash
  cargo test -p casper stale_validator_should_transition_to_initializing_and_request_approved_block
  cargo test -p casper validator_on_minority_fork_should_rejoin_majority_chain_after_stale_detection
  ```

  ## Tests included

  - Engine-level recovery for stale validators
  - 3-validator integration test for minority-fork recovery
  - Compiler/runtime regression tests for inner contract payload capture behavior

  ## Follow-up work
  - If issue #5 is observed again, capture the exact failing deploy/context so the runtime path can be reproduced directly.