### PR TITLE
[agent] build: rename local Docker image to f1r3fly-rust

### DIFF
--- a/node/docker-commands.sh
+++ b/node/docker-commands.sh
@@ -6,7 +6,7 @@ set -e
 
 # Configuration
 DOCKER_REPOSITORY="f1r3flyindustries"
-IMAGE_NAME="f1r3node-rust"
+IMAGE_NAME="f1r3fly-rust"
 FULL_IMAGE_NAME="${DOCKER_REPOSITORY}/${IMAGE_NAME}"
 # Auto-detect version from Cargo.toml if not set via env
 if [ -z "${VERSION:-}" ]; then


### PR DESCRIPTION
Update `node/docker-commands.sh` IMAGE_NAME from `f1r3node-rust` to `f1r3fly-rust` so locally-built images tag under the same name CI publishes (`DOCKER_IMAGE_NAME` in `.github/workflows/ci.yml:36`). Eliminates the mismatch where `./node/docker-commands.sh build-local` produced `f1r3flyindustries/f1r3node-rust:local` while downstream consumers pull `f1r3flyindustries/f1r3fly-rust:*`.