### PR TITLE
ci: gate launch_ephemeral_runners on ephemeral-launch environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,11 @@ jobs:
     name: Launch Ephemeral Runners
     needs: lint
     runs-on: ubuntu-latest
+    # Gates on environment-scoped secrets (OCI_* + RELEASE_PAT). Required
+    # reviewers on the `ephemeral-launch` environment unblock fork PRs whose
+    # default permissions cannot see repo-level secrets. Internal pushes from
+    # protected branches also pause for one approval click per run.
+    environment: ephemeral-launch
     permissions:
       actions: write  # needed for gh api ... actions/runners/registration-token
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,11 +278,12 @@ jobs:
     name: Launch Ephemeral Runners
     needs: lint
     runs-on: ubuntu-latest
-    # Gates on environment-scoped secrets (OCI_* + RELEASE_PAT). Required
-    # reviewers on the `ephemeral-launch` environment unblock fork PRs whose
-    # default permissions cannot see repo-level secrets. Internal pushes from
-    # protected branches also pause for one approval click per run.
-    environment: ephemeral-launch
+    # Conditional environment: gate only fork PRs. Fork PR workflows can't see
+    # repo-scoped secrets, so OCI_* + RELEASE_PAT live in the `ephemeral-launch`
+    # environment and the required-reviewer approval unlocks them. Internal
+    # pushes and internal-branch PRs resolve the expression to '' (no
+    # environment) and run unattended.
+    environment: ${{ github.event.pull_request.head.repo.fork && 'ephemeral-launch' || '' }}
     permissions:
       actions: write  # needed for gh api ... actions/runners/registration-token
     timeout-minutes: 10


### PR DESCRIPTION
Adds environment: ephemeral-launch to the launch_ephemeral_runners job so fork PRs (and internal pushes) pause for required-reviewer approval before OCI secrets flow. Unblocks #58 and any future fork PR that hits the OCI launch step.