### PR TITLE
ci: make ephemeral-launch environment gate unconditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,12 @@ jobs:
     name: Launch Ephemeral Runners
     needs: lint
     runs-on: ubuntu-latest
-    # Conditional environment: gate only fork PRs. Fork PR workflows can't see
-    # repo-scoped secrets, so OCI_* + RELEASE_PAT live in the `ephemeral-launch`
-    # environment and the required-reviewer approval unlocks them. Internal
-    # pushes and internal-branch PRs resolve the expression to '' (no
-    # environment) and run unattended.
-    environment: ${{ github.event.pull_request.head.repo.fork && 'ephemeral-launch' || '' }}
+    # Gates every CI run on the ephemeral-launch environment so OCI_* +
+    # RELEASE_PAT secrets (which live env-scoped) flow to the job after
+    # required-reviewer approval. Applies to internal pushes/PRs and fork
+    # PRs alike — fork PRs need the environment gate for any secret access
+    # at all; the friction on internal runs is the accepted trade-off.
+    environment: ephemeral-launch
     permissions:
       actions: write  # needed for gh api ... actions/runners/registration-token
     timeout-minutes: 10


### PR DESCRIPTION
Switches the launch_ephemeral_runners environment gate from a conditional ternary (which evaluated to empty for fork PRs and left secrets inaccessible) to unconditional. Every CI run gates on the environment — one approval click. Unblocks #58.