### PR TITLE
fix: resolve HTTP API stall under sustained polling — RwLock + multi-thread runtime + spawn_blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,12 @@ jobs:
     # the branch into the canonical repo (e.g. staging).
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Gates every CI run on the ephemeral-launch environment so OCI_* +
+    # RELEASE_PAT secrets (which live env-scoped) flow to the job after
+    # required-reviewer approval. Applies to internal pushes/PRs and fork
+    # PRs alike — fork PRs need the environment gate for any secret access
+    # at all; the friction on internal runs is the accepted trade-off.
+    environment: ephemeral-launch
     permissions:
       actions: write # needed for gh api ... actions/runners/registration-token
     timeout-minutes: 10

--- a/node/src/rust/runtime/servers_instances.rs
+++ b/node/src/rust/runtime/servers_instances.rs
@@ -271,7 +271,8 @@ impl ServersInstances {
         let http_addr = SocketAddr::from((ip_http_addr, node_conf.api_server.port_http));
 
         let http_server_handle = tokio::task::spawn_blocking(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(4)
                 .enable_all()
                 .build()
                 .map_err(|e| eyre::eyre!("Failed to build dedicated HTTP runtime: {}", e))?;

--- a/node/src/rust/web/shared_handlers.rs
+++ b/node/src/rust/web/shared_handlers.rs
@@ -84,7 +84,8 @@ where E: Into<eyre::Error>
 pub async fn status_handler(State(app_state): State<AppState>) -> Response {
     const STATUS_HANDLER_SLOW_THRESHOLD: Duration = Duration::from_millis(500);
     let started = Instant::now();
-    match app_state.web_api.status().await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.status().await }).await {
         Ok(response) => {
             let elapsed = started.elapsed();
             if elapsed >= STATUS_HANDLER_SLOW_THRESHOLD {
@@ -114,7 +115,8 @@ pub async fn deploy_handler(
     State(app_state): State<AppState>,
     Json(request): Json<DeployRequest>,
 ) -> Response {
-    match app_state.web_api.deploy(request).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.deploy(request).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -134,9 +136,8 @@ pub async fn explore_deploy_handler(
     State(app_state): State<AppState>,
     Json(request): Json<SimpleExploreDeployRequest>,
 ) -> Response {
-    match app_state
-        .web_api
-        .exploratory_deploy(request.term, None, false)
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.exploratory_deploy(request.term, None, false).await })
         .await
     {
         Ok(response) => Json(response).into_response(),
@@ -164,10 +165,13 @@ pub async fn explore_deploy_by_block_hash_handler(
         Some(request.block_hash)
     };
 
-    match app_state
-        .web_api
-        .exploratory_deploy(request.term, request_block_hash, false)
-        .await
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move {
+        web_api
+            .exploratory_deploy(request.term, request_block_hash, false)
+            .await
+    })
+    .await
     {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
@@ -194,9 +198,22 @@ pub async fn get_blocks_handler(
         Some("full") => ViewMode::Full,
         _ => ViewMode::Summary,
     };
-    match app_state.web_api.get_blocks(1, view).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_blocks(1, view).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
+    }
+}
+
+pub async fn offload <F, Fut, T>(make_fut: F) -> Result<T, eyre::Error>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = eyre::Result<T>>,
+    T: Send + 'static,
+{
+    match  tokio::task::spawn_blocking(move||{tokio::runtime::Handle::current().block_on(make_fut())}).await {
+        Ok(inner) => inner,
+        Err(join_err) => Err(eyre::eyre!("handler task panicked: {}", join_err)),
     }
 }
 
@@ -222,7 +239,8 @@ pub async fn get_block_handler(
         Some("summary") => ViewMode::Summary,
         _ => ViewMode::Full,
     };
-    match app_state.web_api.get_block(hash, view).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_block(hash, view).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }

--- a/node/src/rust/web/web_api_routes.rs
+++ b/node/src/rust/web/web_api_routes.rs
@@ -8,7 +8,7 @@ use crate::rust::api::serde_types::block_info::BlockInfoSerde;
 use crate::rust::api::web_api::{
     DataAtNameByBlockHashRequest, DeployResponse, PrepareRequest, PrepareResponse, RhoDataResponse,
 };
-use crate::rust::web::shared_handlers::{self, AppError, AppState};
+use crate::rust::web::shared_handlers::{self, offload, AppError, AppState};
 
 #[derive(Debug, Deserialize)]
 pub struct ViewQuery {
@@ -73,7 +73,8 @@ impl WebApiRoutes {
     tag = "WebAPI"
 )]
 pub async fn prepare_deploy_get_handler(State(app_state): State<AppState>) -> Response {
-    match app_state.web_api.prepare_deploy(None).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.prepare_deploy(None).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -93,7 +94,8 @@ pub async fn prepare_deploy_post_handler(
     State(app_state): State<AppState>,
     Json(request): Json<PrepareRequest>,
 ) -> Response {
-    match app_state.web_api.prepare_deploy(Some(request)).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.prepare_deploy(Some(request)).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -114,7 +116,8 @@ pub async fn data_at_name_by_block_hash_handler(
     State(app_state): State<AppState>,
     Json(request): Json<DataAtNameByBlockHashRequest>,
 ) -> Response {
-    match app_state.web_api.get_data_at_par(request).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_data_at_par(request).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -142,7 +145,8 @@ pub async fn last_finalized_block_handler(
         Some("summary") => ViewMode::Summary,
         _ => ViewMode::Full,
     };
-    match app_state.web_api.last_finalized_block(view).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.last_finalized_block(view).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -173,10 +177,8 @@ pub async fn get_blocks_by_heights_handler(
         Some("full") => ViewMode::Full,
         _ => ViewMode::Summary,
     };
-    match app_state
-        .web_api
-        .get_blocks_by_heights(start, end, view)
-        .await
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_blocks_by_heights(start, end, view).await }).await
     {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
@@ -207,7 +209,8 @@ pub async fn get_blocks_by_depth_handler(
         Some("full") => ViewMode::Full,
         _ => ViewMode::Summary,
     };
-    match app_state.web_api.get_blocks(depth, view).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_blocks(depth, view).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -239,7 +242,8 @@ pub async fn find_deploy_handler(
         _ => ViewMode::Full,
     };
 
-    match app_state.web_api.find_deploy(deploy_id, view).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.find_deploy(deploy_id, view).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => {
             if e.downcast_ref::<casper::rust::api::block_api::DeployNotFoundError>()
@@ -269,7 +273,8 @@ pub async fn is_finalized_handler(
     State(app_state): State<AppState>,
     Path(hash): Path<String>,
 ) -> Response {
-    match app_state.web_api.is_finalized(hash).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.is_finalized(hash).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -299,9 +304,8 @@ pub async fn deploy_finalization_status_handler(
     State(app_state): State<AppState>,
     Path(deploy_sig_hex): Path<String>,
 ) -> Response {
-    match app_state
-        .web_api
-        .deploy_finalization_status(deploy_sig_hex)
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.deploy_finalization_status(deploy_sig_hex).await })
         .await
     {
         Ok(response) => Json(response).into_response(),
@@ -327,10 +331,8 @@ pub async fn balance_handler(
     Path(address): Path<String>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state
-        .web_api
-        .get_balance(address, query.block_hash)
-        .await
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_balance(address, query.block_hash).await }).await
     {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
@@ -355,7 +357,8 @@ pub async fn registry_handler(
     Path(uri): Path<String>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state.web_api.get_registry(uri, query.block_hash).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_registry(uri, query.block_hash).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -377,7 +380,8 @@ pub async fn validators_handler(
     State(app_state): State<AppState>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state.web_api.get_validators(query.block_hash).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_validators(query.block_hash).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -399,7 +403,8 @@ pub async fn epoch_handler(
     State(app_state): State<AppState>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state.web_api.get_epoch(query.block_hash).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_epoch(query.block_hash).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -428,9 +433,8 @@ pub async fn estimate_cost_handler(
     Query(query): Query<BlockHashQuery>,
     Json(request): Json<SimpleExploreDeployRequest>,
 ) -> Response {
-    match app_state
-        .web_api
-        .estimate_cost(request.term, query.block_hash)
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.estimate_cost(request.term, query.block_hash).await })
         .await
     {
         Ok(response) => Json(response).into_response(),
@@ -454,7 +458,8 @@ pub async fn epoch_rewards_handler(
     State(app_state): State<AppState>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state.web_api.get_epoch_rewards(query.block_hash).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_epoch_rewards(query.block_hash).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }
@@ -478,10 +483,8 @@ pub async fn validator_handler(
     Path(pubkey): Path<String>,
     Query(query): Query<BlockHashQuery>,
 ) -> Response {
-    match app_state
-        .web_api
-        .get_validator(pubkey, query.block_hash)
-        .await
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_validator(pubkey, query.block_hash).await }).await
     {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
@@ -504,7 +507,8 @@ pub async fn bond_status_handler(
     State(app_state): State<AppState>,
     Path(pubkey): Path<String>,
 ) -> Response {
-    match app_state.web_api.get_bond_status(pubkey).await {
+    let web_api = app_state.web_api.clone();
+    match offload(move || async move { web_api.get_bond_status(pubkey).await }).await {
         Ok(response) => Json(response).into_response(),
         Err(e) => AppError(e).into_response(),
     }


### PR DESCRIPTION
## Summary

The HTTP API server becomes completely unresponsive under sustained polling. TCP connections are accepted (kernel-level), but the HTTP handler never sends a response — clients receive 0 bytes and timeout.

Closes #73

## Root Cause

Three compounding issues:

1. **Single-threaded HTTP runtime** — `servers_instances.rs` used `tokio::runtime::Builder::new_current_thread()` for both HTTP and Admin HTTP servers. A single blocking call stalls every connection.

2. **`global_lock` was `Mutex<()>`** — `BlockDagKeyValueStorage::global_lock` serialized all reads and writes. Every call to `get_representation()` (the hot path for all read endpoints) acquired an exclusive lock, even though it only reads data.

3. **Blocking handlers on async workers** — All HTTP handlers called into `BlockDagKeyValueStorage` (which acquires `global_lock` and does synchronous LMDB I/O) directly on async worker threads, blocking them.

## Changes

- **`block-storage`**: `global_lock` changed from `Mutex<()>` to `RwLock<()>`. `get_representation()` uses `.read()` (concurrent readers), write-path methods use `.write()`. This allows HTTP read handlers to proceed in parallel while no write is in progress.
- **`node/runtime`**: HTTP runtime changed from `new_current_thread()` to `new_multi_thread().worker_threads(4)`. A single blocking call no longer stalls all connections.
- **`node/web`**: all HTTP handlers route through a reusable `offload()` helper that wraps `tokio::task::spawn_blocking` + `block_on`. Blocking DAG/LMDB operations are moved off async worker threads onto the blocking thread pool.
