### PR TITLE
[TEST] fork CI: validate ephemeral-runner access via pull_request_target

### DIFF
--- a/CI_FORK_TEST.md
+++ b/CI_FORK_TEST.md
@@ -1,0 +1,3 @@
+CI fork-runner plumbing test. Throwaway PR to validate that fork PRs can
+run the ephemeral OCI integration matrix via gated pull_request_target.
+Delete this file and the PR after validation.


### PR DESCRIPTION
Throwaway test PR — do not merge.

Validates that fork PRs can run the ephemeral OCI integration matrix through the gated `pull_request_target` path on the `ci/fork-runner-fix` branch. Expected: cheap checks run unprivileged via ci.yml; the **CI (fork PRs)** workflow pauses on the `ephemeral-launch` environment, and after maintainer approval the heavy pipeline launches runners and runs the matrix against this fork's head.

Close and delete the branch after validation.

Co-Authored-By: Claude <noreply@anthropic.com>