### PR TITLE
ci(release): push release commit via RELEASE_PAT (protected master)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y $(cat .github/apt-dependencies.txt)
+          xargs -r -a .github/apt-dependencies.txt sudo apt-get install -y
 
       - name: Install git-cliff
         uses: orhun/git-cliff-action@v4
@@ -80,9 +80,11 @@ jobs:
         run: |
           source scripts/version.sh
           bump_version patch
-          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_OUTPUT"
-          echo "BRANCH=master" >> "$GITHUB_OUTPUT"
+          {
+            echo "NEXT_VERSION=$NEXT_VERSION"
+            echo "TAG_NAME=$TAG_NAME"
+            echo "BRANCH=master"
+          } >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT_VERSION (tag: $TAG_NAME)"
 
       - name: Update node/Cargo.toml version
@@ -109,9 +111,14 @@ jobs:
           git add node/Cargo.toml node/Dockerfile Cargo.lock CHANGELOG.md
           git commit -m "chore(release): ${{ steps.version.outputs.TAG_NAME }}"
 
-      - name: Push commit (GITHUB_TOKEN — no workflow triggers)
+      - name: Push commit (RELEASE_PAT — required to push to protected master)
         run: |
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          # master's rulesets require a pull request for everyone except admins,
+          # so GITHUB_TOKEN (github-actions[bot], not a bypass actor) cannot push
+          # here. RELEASE_PAT is an org-admin token and bypasses both rulesets.
+          # The chore(release) commit message trips ci.yml's build_base skip-guard,
+          # so this push does not kick off a redundant pipeline.
+          git remote set-url origin https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}.git
           git push origin ${{ steps.version.outputs.BRANCH }}
 
       - name: Create tag via API (PAT — triggers downstream CI)


### PR DESCRIPTION
`release.yml` was ported from f1r3node, which pushes the version-bump commit with `GITHUB_TOKEN`. That works there because f1r3node's release branches are **unprotected** — but f1r3node-rust's `master` has strict rulesets (`pull_request` required) and `github-actions[bot]` isn't a bypass actor, so the bot push would be rejected and the first auto-release would fail *before* tagging.

Fix: push the bump commit via `RELEASE_PAT` (org-admin, already used for the tag), which bypasses both master rulesets. The `chore(release)` commit message trips `ci.yml`'s `build_base` skip-guard, so no redundant pipeline runs; the tag still triggers the publish jobs.

Also cleans two pre-existing shellcheck nits in the file (xargs for the apt list, grouped `$GITHUB_OUTPUT` writes).

Needed before `staging → master` so the first auto-release (`v0.4.16`) actually cuts instead of failing at the push.

Co-Authored-By: Claude <noreply@anthropic.com>
