### PR TITLE
ci: aggregator skip-guard, full releases, runner-watchdog pin + OCI-auth hardening

### DIFF
--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2082717906d633870d6812c2a3d126fced12e088  # pinned system-integration main
+          ref: a50eeb198c6e542504af8db92389de5c02500422  # pinned system-integration main
           path: system-integration
           persist-credentials: false
 
@@ -165,7 +165,7 @@ jobs:
           oci --version
 
       - name: Configure OCI auth from secrets
-        shell: bash -ex {0}
+        shell: bash -e {0}   # no -x: never trace the multi-line private key
         env:
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2082717906d633870d6812c2a3d126fced12e088  # pinned system-integration main
+          ref: a50eeb198c6e542504af8db92389de5c02500422  # pinned system-integration main
           path: system-integration
           persist-credentials: false
 

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -69,7 +69,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi
@@ -98,7 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi
@@ -260,7 +260,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi
@@ -501,20 +501,6 @@ jobs:
           docker rm "$CONTAINER_ID"
           test -f /tmp/artifacts/f1r3node-linux-arm64 || { echo 'arm64 binary extraction failed'; exit 1; }
 
-      - name: Determine release type
-        id: release_type
-        shell: bash -ex {0}
-        run: |
-          # Tag format: refs/tags/v{MAJOR}.{MINOR}.{PATCH}
-          # PATCH == 0 → stable (prerelease=false); PATCH > 0 → prerelease=true
-          TAG="${GITHUB_REF#refs/tags/v}"
-          PATCH=$(echo "$TAG" | cut -d. -f3)
-          if [ "$PATCH" = "0" ]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Extract release notes for this version
         shell: bash -ex {0}
         run: |
@@ -525,7 +511,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: /tmp/artifacts/f1r3node-linux-amd64,/tmp/artifacts/f1r3node-linux-arm64
-          prerelease: ${{ steps.release_type.outputs.prerelease }}
+          prerelease: false
           draft: false
           allowUpdates: true
           omitBodyDuringUpdate: true


### PR DESCRIPTION
Bundled CI fixes:

- **Aggregator skip-guard**: `Integration Tests` aggregators now fail only on `failure`/`cancelled`, not `skipped`. The `chore(release)` commit false-failed the required checks because `build_base` skips `chore(release)` pushes → pipeline `skipped` → the old `!= success` guard tripped.
- **Full releases**: drop the "Determine release type" step and set `prerelease: false` (patch releases were wrongly marked pre-release).
- **Runner idle-watchdog pin bump**: bump the pinned system-integration ref to `a50eeb19` (post-system-integration #61) so the launch job renders the new cloud-init with the idle-watchdog self-terminate — engaging the primary runner self-reap (the scheduled reaper already backstops it).
- **OCI-auth hardening**: drop `-x` from the launch job's OCI-auth step so the multi-line private key is never expanded into the run trace.

Co-Authored-By: Claude <noreply@anthropic.com>
