### PR TITLE
Add PeTTa/MeTTa smart contract execution integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PeTTa"]
+	path = PeTTa
+	url = https://github.com/trueagi-io/PeTTa.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "PeTTa"]
-	path = PeTTa
-	url = https://github.com/trueagi-io/PeTTa.git

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -6,6 +6,15 @@ This repository is built with Cargo, Docker, and system packages only.
 
 ## Required Tooling
 
+**SWI-Prolog** - Required runtime dependency for MeTTa smart contract execution via PeTTa submodule
+- Nix/direnv users: Already provisioned in the development shell
+- Manual installation:
+  - macOS: `brew install swi-prolog`
+  - Ubuntu/Debian: `apt-get install swi-prolog`
+  - Fedora: `dnf install pl`
+- The `swipl` binary must be in your PATH
+- PeTTa submodule must be initialized: `git submodule update --init --recursive`
+
 ### macOS
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -95,6 +95,55 @@ cargo install just
 
 The workspace is pinned to `nightly-2026-02-09` in `rust-toolchain.toml`.
 
+
+### (Optional) MeTTa / PeTTa (for the `rho:petta:execute` system service)
+
+The `rho:petta:execute` system service runs MeTTa code through
+[PeTTa](https://github.com/trueagi-io/PeTTa) (a MeTTa interpreter written in
+SWI-Prolog). When running the node locally (outside Docker) you must make it
+available on your system yourself.
+
+1. Install SWI-Prolog (`swipl`), version `9.3.x` or newer, **with the janus
+   Python bridge**. PeTTa uses this functionality which only exists in recent
+   SWI-Prolog builds. Older interpreters may fail at load time with:
+
+   ``` source_sink `library(janus)' does not exist ```
+
+   > ⚠️ The `swi-prolog` package on Debian bookworm (and matching Ubuntu releases)
+   > is **9.0.4**, which predates janus and will not work. Use a newer build from
+   > one of the sources below.
+
+   Ubuntu (SWI-Prolog stable PPA — ships a recent janus-capable build):
+   ```bash
+   sudo apt-add-repository ppa:swi-prolog/stable
+   sudo apt update
+   sudo apt install swi-prolog
+   ```
+
+   macOS (Homebrew — recent versions include janus):
+   ```bash
+   brew install swi-prolog
+   ```
+
+   Verify janus is available:
+   ```bash
+   swipl -g "use_module(library(janus)), halt" -t "halt(1)"
+   ```
+   The command should exit silently (status 0); an error means janus is missing.
+
+2. Clone PeTTa somewhere on your machine and point `PETTA_PATH` at it. If this
+   is not done, the node will assume it is located in `./PeTTa`.
+
+   For example:
+   
+   ```bash
+   git clone https://github.com/trueagi-io/PeTTa.git ~/PeTTa
+   export PETTA_PATH=~/PeTTa
+   ```
+
+   Add the `export PETTA_PATH=...` line to your shell profile (`~/.bashrc`,
+   `~/.zshrc`, ...) so it persists across sessions.
+
 ### Git Hooks (Required)
 
 The pre-commit and pre-push hooks gate every commit and every push. **Install them before your first commit:**

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -62,9 +62,6 @@ COPY rho-pure-eval/ ./rho-pure-eval/
 COPY rholang/ ./rholang/
 COPY node/ ./node/
 
-# Copy PeTTa submodule (required for MeTTa contract execution)
-COPY PeTTa/ ./PeTTa/
-
 # Configure pkg-config for cross-compilation to find target OpenSSL libraries
 # xx-apt installs target libs in the xx sysroot, we need to tell pkg-config where they are
 # Enable AES CPU features for gxhash dependency (required by PathMap crate).
@@ -93,6 +90,66 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cp ./build/${TARGET_TRIPLE}/release/node /build/node_binary && \
     chmod +x /build/node_binary
 
+# Fetch PeTTa (MeTTa interpreter, required at runtime for the `rho:petta:execute`
+# system service).
+#
+# PeTTa is pure Prolog and is not needed to compile the node, so cloning after
+# the cargo build keeps the build cache intact.
+# 
+# Bump PETTA_REF to upgrade the bundled interpreter.
+ARG PETTA_REPO=https://github.com/trueagi-io/PeTTa.git
+ARG PETTA_REF=52e85c6d02d016a4734559a64b2a69e8fdc385fc
+RUN git clone "${PETTA_REPO}" /build/PeTTa && \
+    git -C /build/PeTTa checkout --detach "${PETTA_REF}" && \
+    rm -rf /build/PeTTa/.git
+
+# ============================================================================
+# Stage: swipl-extract - Upstream SWI-Prolog with the janus (Python) bridge
+# ============================================================================
+# PeTTa's `src/metta.pl` requires `library(janus)` and the full JSON libraries.
+# Debian bookworm only ships SWI-Prolog 9.0.4, which predates janus and omits
+# those libraries, so `rho:petta:execute` fails on the packaged interpreter.
+# The official `swipl` image ships a recent build (>= 9.3.x, currently 10.x) with
+# janus included; we copy its interpreter and library into the images that need
+# to actually execute MeTTa (the runtime image and the petta-test stage).
+FROM swipl:stable AS swipl-extract
+
+# ============================================================================
+# Optional stage: petta-test - Run the PeTTa/MeTTa test suite in-container
+# ============================================================================
+# NOT part of the default build (the runtime stage below stays the default
+# target). It reuses the Rust toolchain, the workspace source, and the pinned
+# PeTTa already present in the builder; only `swipl` is added on top. Build and
+# run it explicitly:
+#   docker build --target petta-test -t f1r3fly-petta-test -f node/Dockerfile .
+#   docker run --rm f1r3fly-petta-test
+# Add `-v petta-cargo:/usr/local/cargo/registry -v petta-target:/build/target`
+# to the run to cache crates and compiled artifacts across repeated runs.
+FROM builder AS petta-test
+
+# The Debian swi-prolog package pulls in the shared libraries the interpreter
+# needs; python3/libpython3.11 back the janus bridge. The interpreter itself is
+# then overlaid with the janus-capable build below.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    swi-prolog \
+    python3 \
+    libpython3.11 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Overlay the packaged 9.0.4 with the upstream janus-capable SWI-Prolog so the
+# tests exercise the same interpreter the runtime image ships.
+COPY --from=swipl-extract /usr/lib/swipl /usr/lib/swipl
+COPY --from=swipl-extract /usr/bin/swipl /usr/bin/swipl
+
+# The test script defaults PETTA_PATH to <repo-root>/PeTTa (i.e. /build/PeTTa),
+# which is exactly where the builder cloned it; set it explicitly anyway.
+ENV PETTA_PATH=/build/PeTTa
+WORKDIR /build
+
+# gxhash (via the PathMap crate) needs AES CPU features to compile, matching the
+# release build above. +sse2 is x86-only; on aarch64 only +aes is valid.
+ENTRYPOINT ["bash", "-c", "case \"$(uname -m)\" in aarch64) export RUSTFLAGS='-C target-feature=+aes' ;; *) export RUSTFLAGS='-C target-feature=+aes,+sse2' ;; esac; exec rholang/tests/RUN_PETTA_TESTS.sh"]
+
 # ============================================================================
 # Stage 2: Runtime base - Install runtime dependencies (cached independently)
 # ============================================================================
@@ -105,13 +162,18 @@ ARG PROFILING_BUILD=0
 
 # Install runtime dependencies
 # Note: grpcurl and jq for healthcheck (matching build.sbt healthcheck)
-# Note: swi-prolog is required for PeTTa/MeTTa contract execution
+# Note: swi-prolog is required for PeTTa/MeTTa contract execution. The Debian
+#       package provides the interpreter's shared-library dependencies; the
+#       interpreter binary/library are overlaid with the janus-capable upstream
+#       build in the final stage. python3/libpython3.11 back the janus bridge.
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     libc6 \
     libjemalloc2 \
     curl \
+    python3 \
+    libpython3.11 \
     swi-prolog \
     && if [ "${PROFILING_BUILD}" = "1" ]; then apt-get install -y linux-perf procps binutils; fi \
     && rm -rf /var/lib/apt/lists/*
@@ -161,8 +223,20 @@ RUN mkdir -p /opt/docker/bin
 
 COPY --from=builder --chmod=755 /build/node_binary /opt/docker/bin/node
 
-# Copy PeTTa submodule (required for MeTTa contract execution at runtime)
+# Copy PeTTa (cloned in the builder stage) for MeTTa contract execution at runtime
 COPY --from=builder /build/PeTTa ./PeTTa
+
+# Overlay the packaged SWI-Prolog with the upstream janus-capable build so that
+# PeTTa's `use_module(library(janus))` (and the JSON libraries) resolve. The
+# Debian swi-prolog installed in runtime-base still supplies the required shared
+# libraries; here we only replace the interpreter binary and its library home.
+COPY --from=swipl-extract /usr/lib/swipl /usr/lib/swipl
+COPY --from=swipl-extract /usr/bin/swipl /usr/bin/swipl
+
+# Build-time self-test: fail the build if janus or the JSON libraries are missing.
+RUN /usr/bin/swipl -g "use_module(library(janus)), py_call(builtins:int('5'), X), X == 5, halt." -t "halt(1)" && \
+    /usr/bin/swipl -g "use_module(library(http/json)), halt." -t "halt(1)" && \
+    echo "=== SWI-Prolog/janus self-test PASSED ==="
 
 # Create entrypoint script for Rust (adapted from docker-entrypoint.sh)
 # Copy the Rust-specific entrypoint script from node directory

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -62,6 +62,9 @@ COPY rho-pure-eval/ ./rho-pure-eval/
 COPY rholang/ ./rholang/
 COPY node/ ./node/
 
+# Copy PeTTa submodule (required for MeTTa contract execution)
+COPY PeTTa/ ./PeTTa/
+
 # Configure pkg-config for cross-compilation to find target OpenSSL libraries
 # xx-apt installs target libs in the xx sysroot, we need to tell pkg-config where they are
 # Enable AES CPU features for gxhash dependency (required by PathMap crate).
@@ -102,12 +105,14 @@ ARG PROFILING_BUILD=0
 
 # Install runtime dependencies
 # Note: grpcurl and jq for healthcheck (matching build.sbt healthcheck)
+# Note: swi-prolog is required for PeTTa/MeTTa contract execution
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     libc6 \
     libjemalloc2 \
     curl \
+    swi-prolog \
     && if [ "${PROFILING_BUILD}" = "1" ]; then apt-get install -y linux-perf procps binutils; fi \
     && rm -rf /var/lib/apt/lists/*
 
@@ -156,6 +161,9 @@ RUN mkdir -p /opt/docker/bin
 
 COPY --from=builder --chmod=755 /build/node_binary /opt/docker/bin/node
 
+# Copy PeTTa submodule (required for MeTTa contract execution at runtime)
+COPY --from=builder /build/PeTTa ./PeTTa
+
 # Create entrypoint script for Rust (adapted from docker-entrypoint.sh)
 # Copy the Rust-specific entrypoint script from node directory
 # Note: This Dockerfile should be built from workspace root
@@ -185,6 +193,9 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 ARG VERSION=unknown
 LABEL maintainer="F1r3fly.io LCA https://f1r3fly.io/"
 LABEL version="0.4.45"
+
+# Set PETTA_PATH environment variable for MeTTa contract execution
+ENV PETTA_PATH=/opt/docker/PeTTa
 
 # Switch to daemon user (matching build.sbt: daemonUser in Docker := "daemon")
 USER daemon

--- a/node/src/rust/web/shared_handlers.rs
+++ b/node/src/rust/web/shared_handlers.rs
@@ -413,6 +413,7 @@ fn classify_interpreter_error(ie: &InterpreterError) -> (StatusCode, &'static st
         OpenAIError(_)
         | OllamaError(_)
         | ChromaDBError(_)
+        | SwiplError(_)
         | NonDeterministicProcessFailure { .. }
         | ProduceFailureWithOutput { .. } => {
             (S::BAD_GATEWAY, "external_service_error", ie.to_string())

--- a/rholang/examples/system-contract/swipl/01-swap.metta
+++ b/rholang/examples/system-contract/swipl/01-swap.metta
@@ -1,0 +1,5 @@
+(= (swap (Pair $x $y)) (Pair $y $x))
+
+!(swap (Pair 1 2))
+
+!(swap (Pair x y))

--- a/rholang/examples/system-contract/swipl/01-swap.rho
+++ b/rholang/examples/system-contract/swipl/01-swap.rho
@@ -1,0 +1,6 @@
+new executePetta(`rho:petta:execute`), stdout(`rho:io:stdout`), retCh in {
+  executePetta!("(= (swap (Pair $x $y)) (Pair $y $x)) !(swap (Pair 1 3)) !(swap (Pair x y))", *retCh) |
+  for(@ok <- retCh) {
+      stdout!(ok)
+  }
+}

--- a/rholang/examples/system-contract/swipl/02-fib-long.metta
+++ b/rholang/examples/system-contract/swipl/02-fib-long.metta
@@ -1,0 +1,13 @@
+(= (fib-tr $n $a $b)
+   (if (== $n 0)
+       $a
+       (fib-tr (- $n 1) $b (+ $a $b))))
+
+(= (fib $n)
+   (fib-tr $n 0 1))
+
+(= (main $_) (fib 1000000))
+
+!(main dummy)
+
+

--- a/rholang/examples/system-contract/swipl/02-fib-long.rho
+++ b/rholang/examples/system-contract/swipl/02-fib-long.rho
@@ -1,0 +1,6 @@
+new executePetta(`rho:petta:execute`), stdout(`rho:io:stdout`), retCh in {
+  executePetta!("(= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b)))) (= (fib $n) (fib-tr $n 0 1)) (= (main $x) (fib 1000000)) !(main dummy)", *retCh) |
+  for(@ok <- retCh) {
+      stdout!(ok)
+  }
+}

--- a/rholang/examples/system-contract/swipl/README.md
+++ b/rholang/examples/system-contract/swipl/README.md
@@ -1,0 +1,143 @@
+# PeTTa (SWI-Prolog + MeTTa) Examples
+
+This directory contains Rholang examples demonstrating the `rho:petta:execute`
+system contract, which provides access to the MeTTA language.
+
+## What is PeTTa?
+
+**PeTTa** is an interpreter for MeTTa written in SWI-Prolog.
+
+This integration allows Rholang contracts to perform advanced symbolic reasoning,
+pattern matching, and AI-style computations.
+
+## Prerequisites
+
+See the prerequisites section in the DEVELOPER.md file located in the project's
+folder.
+
+## MeTTa entry point
+
+Standard MeTTa programs do not require an entry point. Any definitions and queries
+are added and executed (respectively) in the order of the program.
+
+However, programs provided to the `rho::petta::execute` contract MUST contain
+an entry point called `main`. This entry point MUST be defined as a function
+with a single parameter (which serves no purpose and should be ignored).
+
+## Examples Overview
+
+### 01-swap.rho - Pattern Matching Basics
+
+Demonstrates basic MeTTa pattern matching by defining a `swap` function that reverses a pair.
+
+### 02-fib-long.rho - Recursive Computation
+
+Computes a large Fibonacci number (fib(1000000)) using tail recursion,
+which on consumer hardware should exceed the timeout of 10 seconds currently
+defined for all MeTTa computations.
+
+
+**MeTTa code:**
+```metta
+(= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b))))
+(= (fib $n) (fib-tr $n 0 1))
+!(fib 1000000)
+```
+
+### Return Value Structure
+
+PeTTa always returns results wrapped in a `{"results": [...]}` JSON object, which is converted to a Rholang map:
+
+```rholang
+{
+  "results": [result1, result2, ...]  // Rholang list
+}
+```
+
+## Common Patterns
+
+### Pattern 1: Simple Computation
+
+```rholang
+new executePetta(`rho:petta:execute`), retCh in {
+  executePetta!("!(+ 1 2)", *retCh) |
+  for(@result <- retCh) {
+    // result = {"results": [3]}
+    match result {
+      {"results": [answer]} => {
+        stdout!(answer)  // Prints: 3
+      }
+    }
+  }
+}
+```
+
+### Pattern 2: Multiple Calls
+
+```rholang
+new executePetta(`rho:petta:execute`), ret1, ret2 in {
+  executePetta!("!(+ 1 2)", *ret1) |
+  executePetta!("!(* 3 4)", *ret2) |
+  
+  for(@r1 <- ret1; @r2 <- ret2) {
+    stdout!([r1, r2])
+  }
+}
+```
+
+## Troubleshooting
+
+### Error: "Can't find PeTTa"
+
+**Cause:** `$PETTA_PATH` points to invalid location
+
+**Solution:**
+```bash
+# Check PeTTa location
+ls ./PeTTa/src/metta.pl
+
+# Or set explicitly
+export PETTA_PATH=/full/path/to/PeTTa
+```
+
+### Error: "swipl: command not found"
+
+**Cause:** SWI-Prolog not installed or not in PATH
+
+**Solution:**
+```bash
+# Install SWI-Prolog
+brew install swi-prolog  # macOS
+apt-get install swi-prolog  # Ubuntu/Debian
+
+# Verify
+which swipl
+```
+
+### Timeout Errors
+
+**Cause:** Computation exceeded 10-second limit
+
+**Solutions:**
+1. Break computation into smaller steps
+2. Use more efficient algorithms
+3. Pre-compute complex results off-chain
+
+### No Output
+
+**Cause:** Error occurred (doesn't send on ack channel)
+
+**Solution:** Check node logs for error details:
+```bash
+tail -f ~/.rnode/rnode.log
+```
+
+## Security Notes
+
+⚠️ **Important Security Considerations: this feature is EXPERIMENTAL.**
+
+1. **Untrusted Code:** Never execute untrusted MeTTa code - there is currently
+   no sandboxing at language level
+2. **Timeouts:** All execution limited to 10 seconds to prevent DoS
+3. **Non-Deterministic:** Results are cached for replay (consensus safety)
+4. **Resource Limits:** System memory limits apply

--- a/rholang/examples/system-contract/swipl/README.md
+++ b/rholang/examples/system-contract/swipl/README.md
@@ -15,14 +15,12 @@ pattern matching, and AI-style computations.
 See the prerequisites section in the DEVELOPER.md file located in the project's
 folder.
 
-## MeTTa entry point
+## MeTTa Execution Model
 
-Standard MeTTa programs do not require an entry point. Any definitions and queries
-are added and executed (respectively) in the order of the program.
-
-However, programs provided to the `rho::petta::execute` contract MUST contain
-an entry point called `main`. This entry point MUST be defined as a function
-with a single parameter (which serves no purpose and should be ignored).
+MeTTa programs provided to the `rho:petta:execute` contract are executed as a
+sequence of definitions and queries in the order they appear. There is no
+required entry point - definitions are loaded and queries are evaluated as
+encountered.
 
 ## Examples Overview
 

--- a/rholang/examples/system-contract/swipl/README.md
+++ b/rholang/examples/system-contract/swipl/README.md
@@ -130,6 +130,42 @@ which swipl
 tail -f ~/.rnode/rnode.log
 ```
 
+## Error Handling and Replay Behavior
+
+### Non-Deterministic Operation
+
+`rho:petta:execute` is a **non-deterministic operation**. This means:
+
+1. **During play execution:** PeTTa is invoked and the result (or error) is cached
+2. **During replay:** The cached result is used without re-invoking PeTTa
+3. **Consensus safety:** All validators must agree on both successes and failures
+
+### Error Recording
+
+When PeTTa execution fails (timeout, syntax error, etc.):
+- The error is wrapped in `NonDeterministicProcessFailure`
+- The failure is recorded in the event log
+- No output is produced to the acknowledgment channel
+- During replay, the same error is reproduced from the event log
+
+This ensures that:
+- Validators reach consensus on failures as well as successes
+- Failed operations don't cause replay divergence
+- Contract behavior is deterministic across all validators
+
+### Failure Modes
+
+| Error Type | Description | Replay Behavior |
+|------------|-------------|-----------------|
+| Timeout | Execution exceeds 10 seconds | Cached failure replayed |
+| Syntax Error | Invalid MeTTa code | Cached failure replayed |
+| PeTTa Not Found | Missing SWI-Prolog or PeTTa | Cached failure replayed |
+| Number Overflow | Result number exceeds i64 | Cached failure replayed |
+| Floating Point | Non-integer JSON number | Cached failure replayed |
+
+All failures prevent output from being sent on the acknowledgment channel,
+which may cause the calling contract to deadlock or timeout.
+
 ## Security Notes
 
 ⚠️ **Important Security Considerations: this feature is EXPERIMENTAL.**

--- a/rholang/examples/system-contract/swipl/README.md
+++ b/rholang/examples/system-contract/swipl/README.md
@@ -12,8 +12,11 @@ pattern matching, and AI-style computations.
 
 ## Prerequisites
 
-See the prerequisites section in the DEVELOPER.md file located in the project's
-folder.
+PeTTa (the MeTTa interpreter) and `swipl` must be available on your system for
+`rho:petta:execute` to work when running the node locally. See the "MeTTa /
+PeTTa" prerequisites section in the top-level
+[README.md](../../../../README.md#source-development) for installation instructions.
+When running the node in Docker, PeTTa is already included in the image.
 
 ## MeTTa Execution Model
 

--- a/rholang/src/rust/interpreter/errors.rs
+++ b/rholang/src/rust/interpreter/errors.rs
@@ -110,6 +110,8 @@ pub enum InterpreterError {
     },
     /// Raised during replay when we encounter a failed non-deterministic produce that we cannot replay.
     CanNotReplayFailedNonDeterministicProcess,
+    /// Raised while executing a MeTTa program with PeTTa/SWI-Prolog
+    SwiplError(String),
 }
 
 pub fn illegal_argument_error(method_name: &str) -> InterpreterError {
@@ -339,6 +341,10 @@ impl fmt::Display for InterpreterError {
 
             InterpreterError::CanNotReplayFailedNonDeterministicProcess => {
                 write!(f, "Cannot replay failed non-deterministic process")
+            }
+
+            InterpreterError::SwiplError(err) => {
+                write!(f, "Cannot execute MeTTa program: {}", err)
             }
         }
     }

--- a/rholang/src/rust/interpreter/mod.rs
+++ b/rholang/src/rust/interpreter/mod.rs
@@ -6,6 +6,7 @@ pub mod chromadb_service;
 #[cfg(not(feature = "chromadb"))]
 #[path = "chromadb_service_stub.rs"]
 pub mod chromadb_service;
+pub mod swi_prolog_service;
 pub mod compiler;
 pub mod contract_call;
 pub mod deploy_parameters;

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -1005,7 +1005,7 @@ fn std_rho_chroma_processes() -> Vec<Definition> {
 #[cfg(not(feature = "chromadb"))]
 fn std_rho_chroma_processes() -> Vec<Definition> { vec![] }
 
-fn std_swipl_processes() -> Vec<Definition> {
+fn std_petta_processes() -> Vec<Definition> {
     vec![Definition {
         urn: "rho:petta:execute".to_string(),
         fixed_channel: FixedChannels::swipl_execute_petta(),
@@ -1014,9 +1014,7 @@ fn std_swipl_processes() -> Vec<Definition> {
         handler: Box::new(|ctx| {
             Box::new(move |args| {
                 let ctx = ctx.clone();
-                Box::pin(
-                    async move { ctx.system_processes.clone().swipl_execute_petta(args).await },
-                )
+                Box::pin(async move { ctx.system_processes.clone().petta_execute(args).await })
             })
         }),
         remainder: None,
@@ -1045,7 +1043,7 @@ fn dispatch_table_creator(
     all_processes.extend(std_rho_crypto_processes());
     all_processes.extend(std_rho_ai_processes());
     all_processes.extend(std_rho_chroma_processes());
-    all_processes.extend(std_swipl_processes());
+    all_processes.extend(std_petta_processes());
 
     all_processes.append(extra_system_processes);
 
@@ -1210,7 +1208,7 @@ fn setup_maps_and_refs(
     // When OpenAI is disabled, the NoOp service handles calls gracefully.
     let rho_ai_binding = std_rho_ai_processes();
     let rho_chroma_binding = std_rho_chroma_processes();
-    let swipl_binding = std_swipl_processes();
+    let rho_swipl_binding = std_petta_processes();
 
     let combined_processes = system_binding
         .iter()
@@ -1218,7 +1216,7 @@ fn setup_maps_and_refs(
         .chain(rho_ai_binding.iter())
         .chain(extra_system_processes.iter())
         .chain(rho_chroma_binding.iter())
-        .chain(swipl_binding.iter())
+        .chain(rho_swipl_binding.iter())
         .collect::<Vec<&Definition>>();
 
     let mut urn_map: HashMap<_, _> = basic_processes();

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -1005,6 +1005,24 @@ fn std_rho_chroma_processes() -> Vec<Definition> {
 #[cfg(not(feature = "chromadb"))]
 fn std_rho_chroma_processes() -> Vec<Definition> { vec![] }
 
+fn std_swipl_processes() -> Vec<Definition> {
+    vec![Definition {
+        urn: "rho:petta:execute".to_string(),
+        fixed_channel: FixedChannels::swipl_execute_petta(),
+        arity: 2,
+        body_ref: BodyRefs::SWIPL_EXECUTE_PETTA,
+        handler: Box::new(|ctx| {
+            Box::new(move |args| {
+                let ctx = ctx.clone();
+                Box::pin(
+                    async move { ctx.system_processes.clone().swipl_execute_petta(args).await },
+                )
+            })
+        }),
+        remainder: None,
+    }]
+}
+
 fn dispatch_table_creator(
     space: RhoISpace,
     dispatcher: RhoDispatch,
@@ -1027,6 +1045,7 @@ fn dispatch_table_creator(
     all_processes.extend(std_rho_crypto_processes());
     all_processes.extend(std_rho_ai_processes());
     all_processes.extend(std_rho_chroma_processes());
+    all_processes.extend(std_swipl_processes());
 
     all_processes.append(extra_system_processes);
 
@@ -1191,6 +1210,7 @@ fn setup_maps_and_refs(
     // When OpenAI is disabled, the NoOp service handles calls gracefully.
     let rho_ai_binding = std_rho_ai_processes();
     let rho_chroma_binding = std_rho_chroma_processes();
+    let swipl_binding = std_swipl_processes();
 
     let combined_processes = system_binding
         .iter()
@@ -1198,6 +1218,7 @@ fn setup_maps_and_refs(
         .chain(rho_ai_binding.iter())
         .chain(extra_system_processes.iter())
         .chain(rho_chroma_binding.iter())
+        .chain(swipl_binding.iter())
         .collect::<Vec<&Definition>>();
 
     let mut urn_map: HashMap<_, _> = basic_processes();

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -1,0 +1,481 @@
+use std::env;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use models::rhoapi::Par;
+use serde_json::Value;
+use tempfile::NamedTempFile;
+use tokio::process::Command;
+
+use super::errors::InterpreterError;
+use crate::rust::interpreter::rho_type::{
+    RhoBoolean, RhoList, RhoMap, RhoNil, RhoNumber, RhoString,
+};
+
+/// Executes MeTTa code through the PeTTa (SWI-Prolog) interpreter and returns the result as a Rholang Par.
+///
+/// # Overview
+///
+/// This function provides low-level access to the PeTTa interpreter, which
+/// provides MeTTa execution with SWI-Prolog. The execution is sandboxed with
+/// a 10-second timeout to prevent runaway computations.
+///
+/// # Arguments
+///
+/// * `metta_code` - A string containing valid MeTTa code to execute
+///
+/// # Returns
+///
+/// Returns `Ok(Par)` containing the execution result as a Rholang Par structure, or an
+/// `InterpreterError::SwiplError` if execution fails.
+///
+/// # JSON Output Schema
+///
+/// PeTTa returns results as JSON in the following envelope:
+/// ```json
+/// {"results": [...]}
+/// ```
+///
+/// The `results` field contains a JSON array of MeTTa execution results. This entire JSON
+/// structure is converted to a Rholang Par using the following mapping:
+///
+/// - `null` → `RhoNil`
+/// - `true`/`false` → `RhoBoolean`
+/// - Numbers → `RhoNumber` (must fit in i64, otherwise error)
+/// - Strings → `RhoString`
+/// - Arrays → `RhoList` (recursive conversion of elements)
+/// - Objects → `RhoMap` (keys converted to RhoString, values recursively converted)
+///
+/// # Error Conditions
+///
+/// - `InterpreterError::SwiplError("Can't find PeTTa.")` - PeTTa installation not found at `$PETTA_PATH`
+/// - `InterpreterError::SwiplError("Can't open temp file")` - Failed to create temporary file
+/// - `InterpreterError::SwiplError("MeTTa execution timed out...")` - Execution exceeded 10 seconds
+/// - `InterpreterError::SwiplError("PeTTa execution failed...")` - SWI-Prolog returned error
+/// - `InterpreterError::SwiplError("Can't parse JSON output...")` - Invalid JSON from PeTTa
+/// - `InterpreterError::SwiplError("Could not parse number as i64")` - Number exceeds i64 range
+///
+/// # Environment Variables
+///
+/// - `PETTA_PATH` - Path to PeTTa installation directory (default: `./PeTTa`)
+///
+/// # Timeout
+///
+/// Execution is limited to 10 seconds. Long-running computations will be terminated and return
+/// a timeout error. This prevents malicious or buggy MeTTa code from blocking the node.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Simple arithmetic
+/// let result = petta_execute("!(+ 1 2)").await?;
+///
+/// // Pattern matching
+/// let result = petta_execute(
+///     "(= (swap (Pair $x $y)) (Pair $y $x)) !(swap (Pair 1 3))"
+/// ).await?;
+/// ```
+///
+/// # See Also
+///
+/// - [`system_processes::swipl_execute_petta`] - System process wrapper for Rholang contracts
+/// - [`value_to_par`] - JSON to Par conversion logic
+pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
+    // Write the MeTTa code to a temp file
+    let mut metta_file = NamedTempFile::new()
+        .map_err(|_| InterpreterError::SwiplError("Can't open temp file".into()))?;
+    metta_file
+        .write(metta_code.as_bytes())
+        .map_err(|_| InterpreterError::SwiplError("Can't write MeTTa code to temp file".into()))?;
+
+    let metta_file_path = metta_file
+        .path()
+        .to_str()
+        .ok_or(InterpreterError::SwiplError(
+            "Can't convert metta_file path to string".into(),
+        ))?;
+
+    // Get the path to PeTTa
+    let metta_module_path: PathBuf = {
+        let petta_path = PathBuf::from(env::var("PETTA_PATH").unwrap_or("./PeTTa".into()));
+        [petta_path, PathBuf::from("src/metta.pl")].iter().collect()
+    };
+
+    if !metta_module_path.exists() {
+        return Err(InterpreterError::SwiplError("Can't find PeTTa.".into()));
+    }
+
+    let goal = format!(
+        r#"assertz(silent(true)),
+           load_metta_file('{metta_file_path}', Results),
+           use_module(library(json)),
+           json_write_dict(current_output, #{{results:Results}})."#
+    );
+
+    // TODO: Make this a configuration parameter
+    let timeout_secs: u64 = 10;
+    let proc_handle = tokio::spawn(tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        Command::new("swipl")
+            .arg("-s")
+            .arg(metta_module_path)
+            .arg("-g")
+            .arg(goal)
+            .arg("-t")
+            .arg("halt")
+            .kill_on_drop(true)
+            .output(),
+    ));
+
+    let output = proc_handle
+        .await
+        .map_err(|join_error| {
+            InterpreterError::SwiplError(
+                format!("Error while joining with the PeTTa task: {}", join_error).into(),
+            )
+        })?
+        .map_err(|elapsed| {
+            InterpreterError::SwiplError(
+                format!("MeTTa execution timed out after {}", elapsed).into(),
+            )
+        })?
+        .map_err(|e| {
+            InterpreterError::SwiplError(format!("MeTTa execution failed: {}", e).into())
+        })?;
+
+    if !output.status.success() {
+        return Err(InterpreterError::SwiplError(
+            format!("PeTTa execution failed. {:#?}", output.stderr.as_slice()).into(),
+        ));
+    }
+
+    // Get output as string
+    let str_output = String::from_utf8(output.stdout)
+        .map_err(|_| InterpreterError::SwiplError("Can't interpret PeTTa output".into()))?;
+
+    let value_output = serde_json::from_str::<Value>(str_output.as_str()).map_err(|_| {
+        InterpreterError::SwiplError("Can't parse JSON output from PeTTa execution".into())
+    })?;
+    let par_output = value_to_par(value_output)?;
+    Ok(par_output)
+}
+
+/// Converts a JSON Value to a Rholang Par structure.
+///
+/// This function recursively transforms JSON data returned by PeTTa into Rholang's internal
+/// representation (Par). It is used internally by [`petta_execute`] to convert PeTTa results.
+///
+/// # Type Mapping
+///
+/// | JSON Type | Rholang Type | Notes |
+/// |-----------|--------------|-------|
+/// | `null` | `RhoNil` | Represents absence of value |
+/// | `boolean` | `RhoBoolean` | Direct mapping |
+/// | `number` | `RhoNumber` | **Must fit in i64**, otherwise returns error |
+/// | `string` | `RhoString` | Direct mapping, supports Unicode |
+/// | `array` | `RhoList` | Elements recursively converted |
+/// | `object` | `RhoMap` | Keys stringified, values recursively converted |
+///
+/// # Important Constraints
+///
+/// - **Numbers must fit in i64**: JSON numbers that exceed `i64::MIN` to `i64::MAX` will cause
+///   an error. Floating-point numbers are truncated to integers.
+/// - **Object keys become strings**: All JSON object keys are converted to `RhoString` in the
+///   resulting `RhoMap`.
+/// - **Recursive conversion**: Nested structures (arrays in arrays, objects in objects, etc.)
+///   are fully supported and recursively converted.
+///
+/// # Arguments
+///
+/// * `v` - A `serde_json::Value` to convert
+///
+/// # Returns
+///
+/// Returns `Ok(Par)` with the converted structure, or `InterpreterError::SwiplError` if
+/// conversion fails (e.g., number doesn't fit in i64).
+///
+/// # Examples
+///
+/// ```ignore
+/// use serde_json::json;
+///
+/// // Simple values
+/// let nil = value_to_par(json!(null))?;
+/// let bool = value_to_par(json!(true))?;
+/// let num = value_to_par(json!(42))?;
+/// let str = value_to_par(json!("hello"))?;
+///
+/// // Collections
+/// let list = value_to_par(json!([1, 2, 3]))?;
+/// let map = value_to_par(json!({"key": "value"}))?;
+///
+/// // Nested structures
+/// let nested = value_to_par(json!({
+///     "list": [1, 2, 3],
+///     "map": {"inner": "value"}
+/// }))?;
+/// ```
+fn value_to_par(v: Value) -> Result<Par, InterpreterError> {
+    match v {
+        Value::Null => Ok(RhoNil::create_par()),
+        Value::Bool(b) => Ok(RhoBoolean::create_par(b)),
+        Value::Number(n) => {
+            let n64 = n.as_i64().ok_or(InterpreterError::SwiplError(
+                "Could not parse number as i64".into(),
+            ))?;
+            Ok(RhoNumber::create_par(n64))
+        }
+        Value::String(s) => Ok(RhoString::create_par(s)),
+        Value::Array(values) => {
+            let ps = values
+                .into_iter()
+                .map(value_to_par)
+                .collect::<Result<_, _>>()?;
+            Ok(RhoList::create_par(ps))
+        }
+        Value::Object(map) => {
+            let hashmap = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let p = value_to_par(v)?;
+                    Ok((RhoString::create_par(k), p))
+                })
+                .collect::<Result<_, InterpreterError>>()?;
+            Ok(RhoMap::create_par(hashmap))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    #[test]
+    fn test_value_to_par_null() {
+        let result = value_to_par(json!(null)).unwrap();
+        assert_eq!(result, RhoNil::create_par());
+    }
+    #[test]
+    fn test_value_to_par_boolean() {
+        let result = value_to_par(json!(true)).unwrap();
+        assert_eq!(result, RhoBoolean::create_par(true));
+    }
+    #[test]
+    fn test_value_to_par_small_number() {
+        let result = value_to_par(json!(42)).unwrap();
+        assert_eq!(result, RhoNumber::create_par(42));
+    }
+    #[test]
+    fn test_value_to_par_max_i64() {
+        let result = value_to_par(json!(i64::MAX)).unwrap();
+        assert_eq!(result, RhoNumber::create_par(i64::MAX));
+    }
+    #[test]
+    fn test_value_to_par_string() {
+        let result = value_to_par(json!("hello")).unwrap();
+        assert_eq!(result, RhoString::create_par("hello".into()));
+    }
+    #[test]
+    fn test_value_to_par_array() {
+        let result = value_to_par(json!([1, "two", true])).unwrap();
+        assert_eq!(
+            result,
+            RhoList::create_par(vec![
+                RhoNumber::create_par(1),
+                RhoString::create_par("two".into()),
+                RhoBoolean::create_par(true)
+            ])
+        );
+    }
+    #[test]
+    fn test_value_to_par_nested_array() {
+        let result = value_to_par(json!([[1, 2], [3, 4]])).unwrap();
+        assert_eq!(
+            result,
+            RhoList::create_par(vec![
+                RhoList::create_par(vec![RhoNumber::create_par(1), RhoNumber::create_par(2)]),
+                RhoList::create_par(vec![RhoNumber::create_par(3), RhoNumber::create_par(4)])
+            ])
+        );
+    }
+    #[test]
+    fn test_value_to_par_object() {
+        let result = value_to_par(json!({"key": "value", "num": 123})).unwrap();
+        assert_eq!(
+            result,
+            RhoMap::create_par(
+                vec![
+                    (
+                        RhoString::create_par("key".into()),
+                        RhoString::create_par("value".into())
+                    ),
+                    (
+                        RhoString::create_par("num".into()),
+                        RhoNumber::create_par(123)
+                    )
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
+    }
+    #[test]
+    fn test_value_to_par_nested_object() {
+        let result = value_to_par(json!({
+            "outer": {
+                "inner": "value"
+            }
+        }))
+        .unwrap();
+        assert_eq!(
+            result,
+            RhoMap::create_par(
+                vec![(
+                    RhoString::create_par("outer".into()),
+                    RhoMap::create_par(
+                        vec![(
+                            RhoString::create_par("inner".into()),
+                            RhoString::create_par("value".into())
+                        )]
+                        .into_iter()
+                        .collect()
+                    )
+                )]
+                .into_iter()
+                .collect()
+            )
+        );
+    }
+
+    #[test]
+    fn test_value_to_par_complex_nested_structure() {
+        let result = value_to_par(json!({
+            "list": [1, 2, 3],
+            "nested": {
+                "bool": true,
+                "null": null
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            result,
+            RhoMap::create_par(
+                vec![
+                    (
+                        RhoString::create_par("list".into()),
+                        RhoList::create_par(vec![
+                            RhoNumber::create_par(1),
+                            RhoNumber::create_par(2),
+                            RhoNumber::create_par(3)
+                        ])
+                    ),
+                    (
+                        RhoString::create_par("nested".into()),
+                        RhoMap::create_par(
+                            vec![
+                                (
+                                    RhoString::create_par("bool".into()),
+                                    RhoBoolean::create_par(true)
+                                ),
+                                (RhoString::create_par("null".into()), RhoNil::create_par())
+                            ]
+                            .into_iter()
+                            .collect()
+                        )
+                    )
+                ]
+                .into_iter()
+                .collect()
+            )
+        );
+    }
+
+    #[test]
+    fn test_value_to_par_empty_array() {
+        let result = value_to_par(json!([])).unwrap();
+        assert_eq!(result, RhoList::create_par(vec![]));
+    }
+
+    #[test]
+    fn test_value_to_par_empty_object() {
+        let result = value_to_par(json!({})).unwrap();
+        assert_eq!(result, RhoMap::create_par(std::collections::HashMap::new()));
+    }
+
+    #[test]
+    fn test_value_to_par_negative_number() {
+        let result = value_to_par(json!(-42)).unwrap();
+        assert_eq!(result, RhoNumber::create_par(-42));
+    }
+
+    #[test]
+    fn test_value_to_par_zero() {
+        let result = value_to_par(json!(0)).unwrap();
+        assert_eq!(result, RhoNumber::create_par(0));
+    }
+
+    #[test]
+    fn test_value_to_par_false_boolean() {
+        let result = value_to_par(json!(false)).unwrap();
+        assert_eq!(result, RhoBoolean::create_par(false));
+    }
+
+    #[test]
+    fn test_value_to_par_empty_string() {
+        let result = value_to_par(json!("")).unwrap();
+        assert_eq!(result, RhoString::create_par("".into()));
+    }
+
+    #[test]
+    fn test_value_to_par_unicode_string() {
+        let result = value_to_par(json!("Hello, 世界! 🌍")).unwrap();
+        assert_eq!(result, RhoString::create_par("Hello, 世界! 🌍".into()));
+    }
+
+    /// Test that petta_execute times out after 10 seconds for long-running computations.
+    /// This uses a large fibonacci number that should exceed the timeout.
+    #[tokio::test]
+    async fn test_petta_execute_timeout() {
+        use std::env;
+        use std::path::PathBuf;
+
+        // Check if PeTTa is available
+        let petta_path = PathBuf::from(env::var("PETTA_PATH").unwrap_or("./PeTTa".into()));
+        let metta_module_path: PathBuf =
+            [petta_path, PathBuf::from("src/metta.pl")].iter().collect();
+
+        if !metta_module_path.exists() {
+            eprintln!("Skipping timeout test: PeTTa not available");
+            return;
+        }
+
+        // Fibonacci of a very large number should timeout (10 second limit)
+        // fib(10000000) will take much longer than 10 seconds
+        let metta_code = r#"
+            (= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b))))
+            (= (fib $n) (fib-tr $n 0 1))
+            !(fib 10000000)
+        "#;
+
+        let result = petta_execute(metta_code).await;
+
+        // Should fail with a timeout error
+        assert!(
+            result.is_err(),
+            "Large fibonacci computation should timeout"
+        );
+
+        let err = result.unwrap_err();
+        let err_msg = format!("{:?}", err);
+
+        // Error should mention timeout
+        assert!(
+            err_msg.contains("timed out") || err_msg.contains("timeout"),
+            "Error should be a timeout error, got: {}",
+            err_msg
+        );
+    }
+}

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -99,6 +99,12 @@ pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
             "Can't convert metta_file path to string".into(),
         ))?;
 
+    if metta_file_path.contains('\'') {
+        return Err(InterpreterError::SwiplError(
+            "Temp file path contains unsafe character (single quote)".into(),
+        ));
+    }
+
     // Get the path to PeTTa
     let metta_module_path: PathBuf = {
         let petta_path = PathBuf::from(env::var("PETTA_PATH").unwrap_or("./PeTTa".into()));

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -79,7 +79,7 @@ use crate::rust::interpreter::rho_type::{
 ///
 /// # See Also
 ///
-/// - [`system_processes::swipl_execute_petta`] - System process wrapper for Rholang contracts
+/// - [`system_processes::petta_execute`] - System process wrapper for Rholang contracts
 /// - [`value_to_par`] - JSON to Par conversion logic
 pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
     // Write the MeTTa code to a temp file

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -86,8 +86,11 @@ pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
     let mut metta_file = NamedTempFile::new()
         .map_err(|_| InterpreterError::SwiplError("Can't open temp file".into()))?;
     metta_file
-        .write(metta_code.as_bytes())
+        .write_all(metta_code.as_bytes())
         .map_err(|_| InterpreterError::SwiplError("Can't write MeTTa code to temp file".into()))?;
+    metta_file
+        .flush()
+        .map_err(|_| InterpreterError::SwiplError("Can't flush MeTTa temp file".into()))?;
 
     let metta_file_path = metta_file
         .path()

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -138,9 +138,9 @@ pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
                 format!("Error while joining with the PeTTa task: {}", join_error).into(),
             )
         })?
-        .map_err(|elapsed| {
+        .map_err(|_elapsed| {
             InterpreterError::SwiplError(
-                format!("MeTTa execution timed out after {}", elapsed).into(),
+                format!("MeTTa execution timed out after {} seconds", timeout_secs).into(),
             )
         })?
         .map_err(|e| {

--- a/rholang/src/rust/interpreter/swi_prolog_service.rs
+++ b/rholang/src/rust/interpreter/swi_prolog_service.rs
@@ -175,15 +175,16 @@ pub async fn petta_execute(metta_code: &str) -> Result<Par, InterpreterError> {
 /// |-----------|--------------|-------|
 /// | `null` | `RhoNil` | Represents absence of value |
 /// | `boolean` | `RhoBoolean` | Direct mapping |
-/// | `number` | `RhoNumber` | **Must fit in i64**, otherwise returns error |
+/// | `number` | `RhoNumber` | **Must be integer in i64 range**, floats rejected |
 /// | `string` | `RhoString` | Direct mapping, supports Unicode |
 /// | `array` | `RhoList` | Elements recursively converted |
 /// | `object` | `RhoMap` | Keys stringified, values recursively converted |
 ///
 /// # Important Constraints
 ///
-/// - **Numbers must fit in i64**: JSON numbers that exceed `i64::MIN` to `i64::MAX` will cause
-///   an error. Floating-point numbers are truncated to integers.
+/// - **Only integers are supported**: JSON numbers must be integers in the range `i64::MIN` to
+///   `i64::MAX`. Floating-point numbers and integers outside this range are explicitly rejected
+///   with descriptive errors to prevent silent truncation and maintain consensus safety.
 /// - **Object keys become strings**: All JSON object keys are converted to `RhoString` in the
 ///   resulting `RhoMap`.
 /// - **Recursive conversion**: Nested structures (arrays in arrays, objects in objects, etc.)
@@ -224,9 +225,32 @@ fn value_to_par(v: Value) -> Result<Par, InterpreterError> {
         Value::Null => Ok(RhoNil::create_par()),
         Value::Bool(b) => Ok(RhoBoolean::create_par(b)),
         Value::Number(n) => {
-            let n64 = n.as_i64().ok_or(InterpreterError::SwiplError(
-                "Could not parse number as i64".into(),
-            ))?;
+            if !n.is_i64() {
+                if n.is_f64() {
+                    return Err(InterpreterError::SwiplError(
+                        format!(
+                            "Floating-point numbers are not supported. Got: {}. \
+                             Only integers in the range {} to {} are allowed.",
+                            n,
+                            i64::MIN,
+                            i64::MAX
+                        )
+                        .into(),
+                    ));
+                } else {
+                    return Err(InterpreterError::SwiplError(
+                        format!(
+                            "Number exceeds i64 range. Got: {}. \
+                             Only integers in the range {} to {} are allowed.",
+                            n,
+                            i64::MIN,
+                            i64::MAX
+                        )
+                        .into(),
+                    ));
+                }
+            }
+            let n64 = n.as_i64().unwrap();
             Ok(RhoNumber::create_par(n64))
         }
         Value::String(s) => Ok(RhoString::create_par(s)),
@@ -436,6 +460,42 @@ mod tests {
     fn test_value_to_par_unicode_string() {
         let result = value_to_par(json!("Hello, 世界! 🌍")).unwrap();
         assert_eq!(result, RhoString::create_par("Hello, 世界! 🌍".into()));
+    }
+
+    #[test]
+    fn test_value_to_par_float_rejected() {
+        let result = value_to_par(json!(3.14));
+        assert!(result.is_err(), "Floating-point numbers should be rejected");
+        let err = result.unwrap_err();
+        let err_msg = format!("{:?}", err);
+        assert!(
+            err_msg.contains("Floating-point") && err_msg.contains("not supported"),
+            "Error should mention floating-point not supported, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_value_to_par_large_uint_rejected() {
+        let large_uint = u64::MAX;
+        let result = value_to_par(json!(large_uint));
+        assert!(
+            result.is_err(),
+            "Numbers exceeding i64::MAX should be rejected"
+        );
+        let err = result.unwrap_err();
+        let err_msg = format!("{:?}", err);
+        assert!(
+            err_msg.contains("exceeds i64 range") || err_msg.contains("not supported"),
+            "Error should mention range exceeded, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_value_to_par_min_i64() {
+        let result = value_to_par(json!(i64::MIN)).unwrap();
+        assert_eq!(result, RhoNumber::create_par(i64::MIN));
     }
 
     /// Test that petta_execute times out after 10 seconds for long-running computations.

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2046,26 +2046,40 @@ impl SystemProcesses {
     /// 1. Execute `petta_execute()` to invoke SWI-Prolog with MeTTa code
     /// 2. On success: produce output to ack channel, return `Ok(output)`, output is logged
     /// 3. On PeTTa failure: return `NonDeterministicProcessFailure` (no produce, no output logged)
+    ///    The reducer marks the produce event `failed=true` in the event log (via `with_error()`).
+    ///    The original cause is NOT stored — only the boolean failed flag is recorded.
     /// 4. On produce failure: return `ProduceFailureWithOutput` (output captured but not stored)
     ///
     /// **Replay Mode (`is_replay = true`):**
-    /// 1. Retrieve cached output from event log (via `previous_output`)
-    /// 2. Produce cached output to ack channel
-    /// 3. Return `Ok(previous_output)` without invoking `petta_execute()`
-    /// 4. This path is taken for both successful and failed executions
+    ///
+    /// **For a successful play:** The event log contains the cached output (is_deterministic=false,
+    /// output_value=previous_output, failed=false). The handler is dispatched with is_replay=true,
+    /// reads previous_output, produces it to ack, and returns Ok(previous_output) without re-invoking
+    /// petta_execute().
+    ///
+    /// **For a failed play:** The event log contains a produce with failed=true and empty output_value.
+    /// The reducer's `continue_produce_process` (`reduce.rs:454-456`) checks `is_replay && trace_failed`
+    /// and short-circuits with `InterpreterError::CanNotReplayFailedNonDeterministicProcess` **before**
+    /// dispatching to this handler. Therefore swipl/PeTTa is NEVER re-invoked for failed executions
+    /// during replay. All replaying validators deterministically produce the same error, preventing
+    /// consensus divergence.
     ///
     /// # Error Handling and Replay Safety
     ///
     /// **Execution Errors (during play):**
     /// - Wrapped in `NonDeterministicProcessFailure` to signal the dispatcher
-    /// - The dispatcher marks the produce event as failed (see `DispatchType::FailedNonDeterministicCall`)
-    /// - Failed event is recorded in the event log for replay
+    /// - The dispatcher wraps it as `DispatchType::FailedNonDeterministicCall`
+    /// - The reducer marks the produce event `failed=true` via `produce_event.with_error()` and
+    ///   persists it to the event log. No output_value or cause is stored.
     /// - No output is produced (ack channel remains empty, contract may deadlock or timeout)
     ///
-    /// **During Replay:**
-    /// - Failed executions are replayed from the event log without re-invoking `petta_execute()`
-    /// - The same error is reproduced using cached failure information
-    /// - Ensures all validators agree on failures, preventing consensus divergence
+    /// **During Replay (for a previously failed produce):**
+    /// - The event log returns a produce event with `failed=true` and `output_value=vec![]`
+    /// - `continue_produce_process` is called with `is_replay=true`, `trace_failed=true`
+    /// - It returns `Err(InterpreterError::CanNotReplayFailedNonDeterministicProcess)` **before**
+    ///   dispatching — this handler is never reached, swipl/PeTTa is never re-invoked
+    /// - `evaluate()` returns `Ok(EvaluateResult { errors: [CanNotReplayFailedNonDeterministicProcess] })`
+    /// - All validators deterministically produce the same error → consensus is preserved
     ///
     /// # Error Conditions
     ///
@@ -2078,6 +2092,9 @@ impl SystemProcesses {
     ///   - Cause: RSpace produce error
     ///   - `output_not_produced`: The PeTTa result that couldn't be stored
     ///
+    /// During replay of a failed execution, the error `CanNotReplayFailedNonDeterministicProcess`
+    /// is surfaced in `EvaluateResult.errors` instead (dispatch and this handler are skipped).
+    ///
     /// All errors are propagated to the Rholang contract and captured in the evaluation result's
     /// error list.
     ///
@@ -2086,7 +2103,9 @@ impl SystemProcesses {
     /// - [`petta_execute`] - Low-level PeTTa execution (in `swi_prolog_service`)
     /// - [`non_deterministic_ops`] - Registry of non-deterministic body refs
     /// - [`InterpreterError::NonDeterministicProcessFailure`] - Error type for failed non-det ops
+    /// - [`InterpreterError::CanNotReplayFailedNonDeterministicProcess`] - Error raised during replay
     /// - [`DispatchType::FailedNonDeterministicCall`] - Dispatcher handling for failed ops
+    /// - `DebruijnInterpreter::continue_produce_process` — short-circuit for failed non-det replays
     /// - Tests: `swipl_petta_replay_spec.rs::test_petta_replay_error_consistency`
     pub async fn swipl_execute_petta(
         &self,

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2107,21 +2107,21 @@ impl SystemProcesses {
     /// - [`DispatchType::FailedNonDeterministicCall`] - Dispatcher handling for failed ops
     /// - `DebruijnInterpreter::continue_produce_process` — short-circuit for failed non-det replays
     /// - Tests: `swipl_petta_replay_spec.rs::test_petta_replay_error_consistency`
-    pub async fn swipl_execute_petta(
+    pub async fn petta_execute(
         &self,
         contract_args: (Vec<ListParWithRandom>, bool, Vec<Par>),
     ) -> Result<Vec<Par>, InterpreterError> {
         let Some((produce, is_replay, previous_output, args)) =
             self.is_contract_call().unapply(contract_args)
         else {
-            return Err(illegal_argument_error("swipl_execute_petta"));
+            return Err(illegal_argument_error("petta_execute"));
         };
 
         let [metta_code, ack] = args.as_slice() else {
-            return Err(illegal_argument_error("swipl_execute_petta"));
+            return Err(illegal_argument_error("petta_execute"));
         };
         let Some(metta_code) = RhoString::unapply(metta_code) else {
-            return Err(illegal_argument_error("swipl_execute_petta"));
+            return Err(illegal_argument_error("petta_execute"));
         };
 
         if is_replay {

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2066,17 +2066,27 @@ impl SystemProcesses {
             return Err(illegal_argument_error("swipl_execute_petta"));
         };
 
-        // Common piece of code.
         if is_replay {
             produce(&previous_output, ack).await?;
             return Ok(previous_output);
         }
 
-        // Perform the execution and wrap in vector
-        let output = petta_execute(&metta_code).await?;
-        let output = vec![output];
+        let output = match petta_execute(&metta_code).await {
+            Ok(par) => vec![par],
+            Err(e) => {
+                return Err(InterpreterError::NonDeterministicProcessFailure {
+                    cause: Box::new(e),
+                    output_not_produced: vec![],
+                });
+            }
+        };
 
-        produce(&output, ack).await?;
+        if let Err(e) = produce(&output, ack).await {
+            return Err(InterpreterError::ProduceFailureWithOutput {
+                cause: Box::new(e),
+                output_not_produced: output.iter().map(|p| p.encode_to_vec()).collect(),
+            });
+        }
         Ok(output)
     }
 }

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -37,6 +37,7 @@ use super::rho_type::{
     RhoBoolean, RhoByteArray, RhoDeployId, RhoDeployerId, RhoList, RhoName, RhoNumber, RhoString,
     RhoSysAuthToken, RhoUri,
 };
+use super::swi_prolog_service::petta_execute;
 use super::util::vault_address::VaultAddress;
 use crate::rust::interpreter::chromadb_service::SharedChromaDBService;
 #[cfg(feature = "chromadb")]
@@ -275,6 +276,8 @@ impl FixedChannels {
     /// future cleanup may hide it behind the byte_name once eval_new
     /// stops needing to resolve URNs through `urn_map` itself.
     pub fn registry_lookup() -> Par { byte_name(37) }
+
+    pub fn swipl_execute_petta() -> Par { byte_name(38) }
 }
 
 pub struct BodyRefs;
@@ -312,6 +315,7 @@ impl BodyRefs {
     pub const CHROMA_QUERY: i64 = 35;
     pub const CHROMA_DELETE_DOCUMENTS: i64 = 36;
     pub const REGISTRY_LOOKUP: i64 = 30;
+    pub const SWIPL_EXECUTE_PETTA: i64 = 37;
 }
 
 pub fn non_deterministic_ops() -> HashSet<i64> {
@@ -324,6 +328,7 @@ pub fn non_deterministic_ops() -> HashSet<i64> {
         BodyRefs::OLLAMA_MODELS,
         BodyRefs::GRPC_TELL,
         BodyRefs::CHROMA_QUERY,
+        BodyRefs::SWIPL_EXECUTE_PETTA,
     ])
 }
 
@@ -2008,6 +2013,72 @@ impl SystemProcesses {
     }
 
     // ChromaDB section end
+
+    // SWIPL section begin
+
+    /// System process handler for `rho:petta:execute` URN.
+    ///
+    /// Executes MeTTa code through the PeTTa (SWI-Prolog) interpreter and returns results
+    /// to the calling Rholang contract. This is a non-deterministic operation - results are
+    /// cached during play execution and replayed from cache during replay for consensus safety.
+    ///
+    /// # URN Specification
+    ///
+    /// **URN:** `rho:petta:execute`
+    ///
+    /// **Arity:** 2 arguments
+    ///
+    /// **Arguments:**
+    /// 1. `metta_code: String` - MeTTa code to execute
+    /// 2. `ack: Channel` - Acknowledgment channel to receive result
+    ///
+    /// # Return Shape
+    ///
+    /// Sends a single `Par` on the acknowledgment channel containing the execution result.
+    /// The structure matches PeTTa's JSON output converted to Rholang types.
+    ///
+    /// # Error Conditions
+    ///
+    /// Returns `InterpreterError` for:
+    /// - **Illegal argument error**: Wrong number of arguments or incorrect types
+    /// - **PeTTa not found**: `$PETTA_PATH` points to invalid location
+    /// - **Timeout**: Execution exceeds 10 seconds
+    /// - **MeTTa syntax error**: Invalid MeTTa code
+    /// - **JSON parse error**: PeTTa output is not valid JSON
+    /// - **Number overflow**: JSON number doesn't fit in i64
+    ///
+    /// Errors are propagated to the Rholang contract and captured in the evaluation result's
+    /// error list.
+    pub async fn swipl_execute_petta(
+        &self,
+        contract_args: (Vec<ListParWithRandom>, bool, Vec<Par>),
+    ) -> Result<Vec<Par>, InterpreterError> {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
+            return Err(illegal_argument_error("swipl_execute_petta"));
+        };
+
+        let [metta_code, ack] = args.as_slice() else {
+            return Err(illegal_argument_error("swipl_execute_petta"));
+        };
+        let Some(metta_code) = RhoString::unapply(metta_code) else {
+            return Err(illegal_argument_error("swipl_execute_petta"));
+        };
+
+        // Common piece of code.
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
+
+        // Perform the execution and wrap in vector
+        let output = petta_execute(&metta_code).await?;
+        let output = vec![output];
+
+        produce(&output, ack).await?;
+        Ok(output)
+    }
 }
 
 // See casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2037,18 +2037,57 @@ impl SystemProcesses {
     /// Sends a single `Par` on the acknowledgment channel containing the execution result.
     /// The structure matches PeTTa's JSON output converted to Rholang types.
     ///
+    /// # Non-Deterministic Operation Flow
+    ///
+    /// This operation is registered as non-deterministic (see [`non_deterministic_ops`]) and
+    /// follows the standard non-det pattern for replay safety:
+    ///
+    /// **Play Mode (`is_replay = false`):**
+    /// 1. Execute `petta_execute()` to invoke SWI-Prolog with MeTTa code
+    /// 2. On success: produce output to ack channel, return `Ok(output)`, output is logged
+    /// 3. On PeTTa failure: return `NonDeterministicProcessFailure` (no produce, no output logged)
+    /// 4. On produce failure: return `ProduceFailureWithOutput` (output captured but not stored)
+    ///
+    /// **Replay Mode (`is_replay = true`):**
+    /// 1. Retrieve cached output from event log (via `previous_output`)
+    /// 2. Produce cached output to ack channel
+    /// 3. Return `Ok(previous_output)` without invoking `petta_execute()`
+    /// 4. This path is taken for both successful and failed executions
+    ///
+    /// # Error Handling and Replay Safety
+    ///
+    /// **Execution Errors (during play):**
+    /// - Wrapped in `NonDeterministicProcessFailure` to signal the dispatcher
+    /// - The dispatcher marks the produce event as failed (see `DispatchType::FailedNonDeterministicCall`)
+    /// - Failed event is recorded in the event log for replay
+    /// - No output is produced (ack channel remains empty, contract may deadlock or timeout)
+    ///
+    /// **During Replay:**
+    /// - Failed executions are replayed from the event log without re-invoking `petta_execute()`
+    /// - The same error is reproduced using cached failure information
+    /// - Ensures all validators agree on failures, preventing consensus divergence
+    ///
     /// # Error Conditions
     ///
     /// Returns `InterpreterError` for:
     /// - **Illegal argument error**: Wrong number of arguments or incorrect types
-    /// - **PeTTa not found**: `$PETTA_PATH` points to invalid location
-    /// - **Timeout**: Execution exceeds 10 seconds
-    /// - **MeTTa syntax error**: Invalid MeTTa code
-    /// - **JSON parse error**: PeTTa output is not valid JSON
-    /// - **Number overflow**: JSON number doesn't fit in i64
+    /// - **NonDeterministicProcessFailure**: PeTTa execution failed (timeout, syntax error, etc.)
+    ///   - Cause: `SwiplError` with details (PeTTa not found, timeout, parse error, etc.)
+    ///   - `output_not_produced`: Empty (no output was generated)
+    /// - **ProduceFailureWithOutput**: PeTTa succeeded but produce failed
+    ///   - Cause: RSpace produce error
+    ///   - `output_not_produced`: The PeTTa result that couldn't be stored
     ///
-    /// Errors are propagated to the Rholang contract and captured in the evaluation result's
+    /// All errors are propagated to the Rholang contract and captured in the evaluation result's
     /// error list.
+    ///
+    /// # See Also
+    ///
+    /// - [`petta_execute`] - Low-level PeTTa execution (in `swi_prolog_service`)
+    /// - [`non_deterministic_ops`] - Registry of non-deterministic body refs
+    /// - [`InterpreterError::NonDeterministicProcessFailure`] - Error type for failed non-det ops
+    /// - [`DispatchType::FailedNonDeterministicCall`] - Dispatcher handling for failed ops
+    /// - Tests: `swipl_petta_replay_spec.rs::test_petta_replay_error_consistency`
     pub async fn swipl_execute_petta(
         &self,
         contract_args: (Vec<ListParWithRandom>, bool, Vec<Par>),

--- a/rholang/src/rust/interpreter/test_utils/utils.rs
+++ b/rholang/src/rust/interpreter/test_utils/utils.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 
 use models::rhoapi::Par;
 use rholang_parser::SourcePos;
@@ -8,6 +11,35 @@ use crate::rust::interpreter::compiler::exports::{
 };
 use crate::rust::interpreter::compiler::normalize::VarSort;
 use crate::rust::interpreter::compiler::normalize::VarSort::{NameSort, ProcSort};
+
+// Helper for skipping PeTTa tests if runtime pre-requisites are not met (or
+// panicking if tests are mandatory).
+pub fn should_skip_petta_test() -> bool {
+    let require = env::var_os("REQUIRE_PETTA_TESTS").is_some();
+
+    let petta_path = PathBuf::from(env::var("PETTA_PATH").unwrap_or("./PeTTa".into()));
+    let metta_module_path = petta_path.join("src/metta.pl");
+
+    let petta_missing = !metta_module_path.exists();
+    let swipl_missing = Command::new("swipl")
+        .arg("--version")
+        .output()
+        .map(|output| !output.status.success())
+        .unwrap_or(true);
+
+    let error_message = match (petta_missing, swipl_missing) {
+        (false, false) => return false,
+        (true, _) => "PeTTa test prerequisite unmet: PeTTa is missing".to_string(),
+        (_, true) => "PeTTa test prerequisite unmet: swipl is missing".to_string(),
+    };
+
+    if require {
+        panic!("{error_message}");
+    } else {
+        eprintln!("Skipping test: {error_message}");
+        true
+    }
+}
 
 pub fn name_visit_inputs_and_env() -> (NameVisitInputs, HashMap<String, Par>) {
     let input: NameVisitInputs = NameVisitInputs {

--- a/rholang/tests/PETTA_TESTS_SUMMARY.md
+++ b/rholang/tests/PETTA_TESTS_SUMMARY.md
@@ -1,0 +1,104 @@
+# PeTTa Tests Summary
+
+This document summarizes the test suite implemented for the PeTTa (MeTTa +
+SWI-Prolog) execution functionality in RNode.
+
+## Requirements
+
+For the PeTTa tests to run, the following requirements must be met:
+
+1. **The PeTTa installation must be available**.
+
+   See [DEVELOPER.md](../../DEVELOPER.md) for details on how to initialize this git
+   submodule.
+
+   The installation location must be specified in the `PETTA_PATH` environment
+   variable. If this variable is not set, the relative path `./PeTTa` will be used,
+   which may fail or not depending on how the tests are run. Therefore, setting this
+   variable is encouraged.
+
+2. **`swipl` must be available in the `PATH`**.
+
+   See [DEVELOPER.md](../../DEVELOPER.md) for details on how to install this
+   program.
+
+If these are not available, the tests will be skipped by default. If this behaviour
+is not desirable (e.g: all tests must be run as part of CI), then the environment
+variable `REQUIRE_PETTA_TESTS` must be set.
+
+## Test Coverage Overview
+
+The test suite consists of:
+1. Unit tests for `value_to_par` function
+2. Unit tests for `petta_execute` function  
+3. Integration tests with Rholang runtime
+4. Replay tests to verify non-deterministic operation handling
+
+## Test Files
+
+### 1. Unit Tests: `value_to_par` Function and `petta_execute`
+**Location:** `rholang/src/rust/interpreter/swi_prolog_service.rs` (lines 127-360)
+
+**Coverage:** 18 unit tests
+
+Tests JSON→Par conversion for all data types:
+- Basic types: `null`, `boolean`, `number`, `string`
+- Collections: `array`, `object`
+- Nested structures: nested arrays, nested objects.
+- **Timeout test:** Large fibonacci computation that exceeds 10-second timeout
+
+**Run:** `PETTA_PATH=/path/to/PeTTa cargo test --package rholang --lib swi_prolog_service::tests`
+
+### 2. Direct Execution Tests
+**Location:** `rholang/tests/swipl_petta_execution_spec.rs`
+
+**Coverage:** 6 tests
+
+Tests the `petta_execute` function directly:
+- `test_petta_execute_simple_swap` - Basic pattern matching
+- `test_petta_execute_fibonacci` - Recursive function execution
+- `test_petta_execute_simple_arithmetic` - Simple operations
+- `test_petta_execute_invalid_syntax` - Error handling
+- `test_petta_execute_empty_code` - Edge case handling
+- `test_petta_execute_timeout_large_fibonacci` - Timeout enforcement for long-running computations
+
+**Run:** `PETTA_PATH=/path/to/PeTTa cargo test --package rholang --test swipl_petta_execution_spec`
+
+### 3. Integration Tests with Rholang Runtime
+**Location:** `rholang/tests/swipl_petta_integration_spec.rs`
+
+**Coverage:** 6 tests
+
+Same tests as above, but using the Rholang runtime.
+
+**Run:** `PETTA_PATH=/path/to/PeTTa cargo test --package rholang --test swipl_petta_integration_spec`
+
+### 4. Replay Tests (Non-Deterministic Operation Verification)
+**Location:** `rholang/tests/swipl_petta_replay_spec.rs`
+
+**Coverage:** 5 tests
+
+Critical tests for consensus safety:
+- `test_petta_is_registered_as_non_deterministic` - Verifies `SWIPL_EXECUTE_PETTA` in `non_deterministic_ops()`
+- `test_petta_replay_consistency` - Basic replay with cached output
+- `test_petta_replay_with_multiple_calls` - Multiple PeTTa calls in one contract
+- `test_petta_replay_error_consistency` - Error cases are replayed correctly
+- `test_petta_replay_uses_cached_output` - Verifies replay doesn't re-execute PeTTa
+
+**Run:** `PETTA_PATH=/path/to/PeTTa cargo test --package rholang --test swipl_petta_replay_spec`
+
+## Running All Tests
+
+### With PeTTa Installed
+```bash
+# Set PeTTa path
+export PETTA_PATH=/path/to/PeTTa
+
+# Run all PeTTa tests
+cargo test --package rholang --test swipl_petta_execution_spec
+cargo test --package rholang --test swipl_petta_integration_spec  
+cargo test --package rholang --test swipl_petta_replay_spec
+
+# Run unit tests
+cargo test --package rholang --lib swi_prolog_service::tests
+```

--- a/rholang/tests/PETTA_TESTS_SUMMARY.md
+++ b/rholang/tests/PETTA_TESTS_SUMMARY.md
@@ -9,8 +9,8 @@ For the PeTTa tests to run, the following requirements must be met:
 
 1. **The PeTTa installation must be available**.
 
-   See [DEVELOPER.md](../../DEVELOPER.md) for details on how to initialize this git
-   submodule.
+   See the "MeTTa / PeTTa" prerequisites section in the top-level
+   [README.md](../../README.md#source-development) for details.
 
    The installation location must be specified in the `PETTA_PATH` environment
    variable. If this variable is not set, the relative path `./PeTTa` will be used,
@@ -19,8 +19,8 @@ For the PeTTa tests to run, the following requirements must be met:
 
 2. **`swipl` must be available in the `PATH`**.
 
-   See [DEVELOPER.md](../../DEVELOPER.md) for details on how to install this
-   program.
+   See the "MeTTa / PeTTa" prerequisites section in the top-level
+   [README.md](../../README.md#source-development) for how to install this program.
 
 If these are not available, the tests will be skipped by default. If this behaviour
 is not desirable (e.g: all tests must be run as part of CI), then the environment
@@ -102,3 +102,25 @@ cargo test --package rholang --test swipl_petta_replay_spec
 # Run unit tests
 cargo test --package rholang --lib swi_prolog_service::tests
 ```
+
+### With Docker (no local SWI-Prolog / PeTTa needed)
+
+The `petta-test` stage in [node/Dockerfile](../../node/Dockerfile) runs the whole
+suite inside a container that already provides the janus-capable SWI-Prolog and
+the pinned PeTTa. From the repository root:
+
+```bash
+# Build the test image once (reuses the node build cache)
+docker build --target petta-test -t f1r3fly-petta-test -f node/Dockerfile .
+
+# Run the full PeTTa test suite. The named volumes cache compiled crates and
+# artifacts, so repeated runs only re-run the tests, not a full rebuild.
+docker run --rm \
+  -v petta-cargo:/usr/local/cargo/registry \
+  -v petta-target:/build/target \
+  f1r3fly-petta-test
+```
+
+The container sets `PETTA_PATH` and `RUSTFLAGS` and invokes
+`rholang/tests/RUN_PETTA_TESTS.sh` for you; the run exits non-zero if any test
+fails.

--- a/rholang/tests/PETTA_TESTS_SUMMARY.md
+++ b/rholang/tests/PETTA_TESTS_SUMMARY.md
@@ -79,7 +79,7 @@ Same tests as above, but using the Rholang runtime.
 **Coverage:** 5 tests
 
 Critical tests for consensus safety:
-- `test_petta_is_registered_as_non_deterministic` - Verifies `SWIPL_EXECUTE_PETTA` in `non_deterministic_ops()`
+- `test_petta_is_registered_as_non_deterministic` - Verifies `PETTA_EXECUTE` in `non_deterministic_ops()`
 - `test_petta_replay_consistency` - Basic replay with cached output
 - `test_petta_replay_with_multiple_calls` - Multiple PeTTa calls in one contract
 - `test_petta_replay_error_consistency` - Error cases are replayed correctly

--- a/rholang/tests/RUN_PETTA_TESTS.sh
+++ b/rholang/tests/RUN_PETTA_TESTS.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Script to run all PeTTa-related tests
+# Usage: ./RUN_PETTA_TESTS.sh
+
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Check if PETTA_PATH is set, otherwise use default
+if [ -z "$PETTA_PATH" ]; then
+    PETTA_PATH="$REPO_ROOT/PeTTa"
+    echo -e "${YELLOW}PETTA_PATH not set, using default: $PETTA_PATH${NC}"
+fi
+
+# Check if PeTTa exists
+if [ ! -f "$PETTA_PATH/src/metta.pl" ]; then
+    echo -e "${YELLOW}Warning: PeTTa not found at $PETTA_PATH/src/metta.pl${NC}"
+    echo "Tests will skip PeTTa-dependent operations"
+    echo ""
+fi
+
+export PETTA_PATH
+
+echo -e "${BLUE}=== Running PeTTa Test Suite ===${NC}"
+echo ""
+
+# Run unit tests
+echo -e "${GREEN}[1/4] Running unit tests for value_to_par...${NC}"
+cargo test --package rholang --lib swi_prolog_service::tests
+echo ""
+
+# Run direct execution tests
+echo -e "${GREEN}[2/4] Running direct PeTTa execution tests...${NC}"
+cargo test --package rholang --test swipl_petta_execution_spec -- --nocapture
+echo ""
+
+# Run integration tests
+echo -e "${GREEN}[3/4] Running Rholang integration tests...${NC}"
+cargo test --package rholang --test swipl_petta_integration_spec -- --nocapture
+echo ""
+
+# Run replay tests
+echo -e "${GREEN}[4/4] Running replay tests (non-deterministic operations)...${NC}"
+cargo test --package rholang --test swipl_petta_replay_spec -- --nocapture
+echo ""
+
+echo -e "${BLUE}=== All PeTTa tests completed successfully! ===${NC}"

--- a/rholang/tests/swipl_petta_execution_spec.rs
+++ b/rholang/tests/swipl_petta_execution_spec.rs
@@ -1,0 +1,152 @@
+use prost::Message;
+use rholang::rust::interpreter::swi_prolog_service::petta_execute;
+use rholang::rust::interpreter::test_utils::utils::should_skip_petta_test;
+
+/// Tests for PeTTa execution service. This service is experimental.
+/// This API is not finalized. Specifically, the interface between Rholang and MeTTa
+/// is not complete. Here we test simple success and failure cases.
+///
+/// These tests require PeTTa to be installed. Set PETTA_PATH environment variable
+/// to point to the PeTTa installation directory.
+/// Example: PETTA_PATH=/path/to/PeTTa cargo test
+
+#[tokio::test]
+async fn test_petta_execute_simple_swap() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let metta_code = "(= (swap (Pair $x $y)) (Pair $y $x)) !(swap (Pair 1 3))";
+    let result = petta_execute(metta_code).await;
+
+    assert!(
+        result.is_ok(),
+        "PeTTa execution should succeed: {:?}",
+        result.err()
+    );
+    let par = result.unwrap();
+
+    // Verify we got a valid Par structure back
+    assert!(
+        !par.encode_to_vec().is_empty(),
+        "Par structure should not be empty"
+    );
+}
+
+#[tokio::test]
+async fn test_petta_execute_fibonacci() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let metta_code = r#"
+        (= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b))))
+        (= (fib $n) (fib-tr $n 0 1))
+        !(fib 10)
+    "#;
+    let result = petta_execute(metta_code).await;
+
+    assert!(
+        result.is_ok(),
+        "Fibonacci execution should succeed: {:?}",
+        result.err()
+    );
+    let par = result.unwrap();
+
+    // Verify we got a valid Par structure back (result should be 55)
+    assert!(
+        !par.encode_to_vec().is_empty(),
+        "Par structure should not be empty"
+    );
+}
+
+#[tokio::test]
+async fn test_petta_execute_simple_arithmetic() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let metta_code = "!(+ 1 2)";
+    let result = petta_execute(metta_code).await;
+
+    assert!(
+        result.is_ok(),
+        "Simple arithmetic should succeed: {:?}",
+        result.err()
+    );
+    let par = result.unwrap();
+    assert!(
+        !par.encode_to_vec().is_empty(),
+        "Par structure should not be empty"
+    );
+}
+
+#[tokio::test]
+async fn test_petta_execute_invalid_syntax() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    // This should fail due to invalid MeTTa syntax
+    let metta_code = "(= incomplete";
+    let result = petta_execute(metta_code).await;
+
+    // We expect this to either error or return an error result
+    // The exact behavior depends on PeTTa's error handling
+    if result.is_err() {
+        println!("Got expected error: {:?}", result.err());
+    } else {
+        println!(
+            "PeTTa handled invalid syntax without error: {:?}",
+            result.ok()
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_petta_execute_empty_code() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let metta_code = "";
+    let result = petta_execute(metta_code).await;
+
+    // Empty code might succeed or fail depending on PeTTa behavior
+    println!("Empty code result: {:?}", result);
+}
+
+#[tokio::test]
+async fn test_petta_execute_timeout_large_fibonacci() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    // Fibonacci of a very large number should timeout (10 second limit)
+    // fib(10000000) will take much longer than 10 seconds
+    let metta_code = r#"
+        (= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b))))
+        (= (fib $n) (fib-tr $n 0 1))
+        !(fib 10000000)
+    "#;
+
+    let result = petta_execute(metta_code).await;
+
+    // Should fail with a timeout error
+    assert!(
+        result.is_err(),
+        "Large fibonacci computation should timeout after 10 seconds"
+    );
+
+    let err = result.unwrap_err();
+    let err_msg = format!("{:?}", err);
+
+    println!("Timeout error (expected): {}", err_msg);
+
+    // Error should mention timeout
+    assert!(
+        err_msg.contains("timed out") || err_msg.contains("timeout"),
+        "Error should be a timeout error, got: {}",
+        err_msg
+    );
+}

--- a/rholang/tests/swipl_petta_execution_spec.rs
+++ b/rholang/tests/swipl_petta_execution_spec.rs
@@ -1,4 +1,5 @@
 use prost::Message;
+use rholang::rust::interpreter::rho_type::{RhoList, RhoMap, RhoNumber, RhoString};
 use rholang::rust::interpreter::swi_prolog_service::petta_execute;
 use rholang::rust::interpreter::test_utils::utils::should_skip_petta_test;
 
@@ -26,7 +27,23 @@ async fn test_petta_execute_simple_swap() {
     );
     let par = result.unwrap();
 
-    // Verify we got a valid Par structure back
+    let expected_map = RhoMap::create_par(
+        vec![(
+            RhoString::create_par("results".into()),
+            RhoList::create_par(vec![RhoList::create_par(vec![
+                RhoString::create_par("Pair".into()),
+                RhoNumber::create_par(3),
+                RhoNumber::create_par(1),
+            ])]),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    assert_eq!(
+        par, expected_map,
+        "Result should be {{\"results\": [\"(Pair 3 1)\"]}}"
+    );
     assert!(
         !par.encode_to_vec().is_empty(),
         "Par structure should not be empty"
@@ -53,7 +70,19 @@ async fn test_petta_execute_fibonacci() {
     );
     let par = result.unwrap();
 
-    // Verify we got a valid Par structure back (result should be 55)
+    let expected_map = RhoMap::create_par(
+        vec![(
+            RhoString::create_par("results".into()),
+            RhoList::create_par(vec![RhoNumber::create_par(55)]),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    assert_eq!(
+        par, expected_map,
+        "fib(10) should return {{\"results\": [55]}}"
+    );
     assert!(
         !par.encode_to_vec().is_empty(),
         "Par structure should not be empty"
@@ -75,6 +104,20 @@ async fn test_petta_execute_simple_arithmetic() {
         result.err()
     );
     let par = result.unwrap();
+
+    let expected_map = RhoMap::create_par(
+        vec![(
+            RhoString::create_par("results".into()),
+            RhoList::create_par(vec![RhoNumber::create_par(3)]),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    assert_eq!(
+        par, expected_map,
+        "1 + 2 should return {{\"results\": [3]}}"
+    );
     assert!(
         !par.encode_to_vec().is_empty(),
         "Par structure should not be empty"
@@ -87,20 +130,14 @@ async fn test_petta_execute_invalid_syntax() {
         return;
     }
 
-    // This should fail due to invalid MeTTa syntax
     let metta_code = "(= incomplete";
     let result = petta_execute(metta_code).await;
 
-    // We expect this to either error or return an error result
-    // The exact behavior depends on PeTTa's error handling
-    if result.is_err() {
-        println!("Got expected error: {:?}", result.err());
-    } else {
-        println!(
-            "PeTTa handled invalid syntax without error: {:?}",
-            result.ok()
-        );
-    }
+    assert!(
+        result.is_err(),
+        "Invalid MeTTa syntax should fail: got {:?}",
+        result.ok()
+    );
 }
 
 #[tokio::test]

--- a/rholang/tests/swipl_petta_integration_spec.rs
+++ b/rholang/tests/swipl_petta_integration_spec.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::interpreter::EvaluateResult;
+use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
+use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
+use rholang::rust::interpreter::test_utils::utils::should_skip_petta_test;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+async fn evaluate_petta_term(term: &str) -> EvaluateResult {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (runtime, _, _): (
+        RhoRuntimeImpl,
+        RhoRuntimeImpl,
+        Arc<
+            Box<
+                dyn HistoryRepository<Par, BindPattern, ListParWithRandom, TaggedContinuation>
+                    + Send
+                    + Sync
+                    + 'static,
+            >,
+        >,
+    ) = create_runtimes_with_services(store, false, &mut Vec::new(), ExternalServices::noop())
+        .await;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "test".to_string());
+
+    runtime
+        .evaluate(term, initial_phlo, HashMap::new(), rand)
+        .await
+        .expect("Evaluation failed")
+}
+
+#[tokio::test]
+async fn test_petta_rholang_integration_swap() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), stdout(`rho:io:stdout`), retCh in {
+            executePetta!("(= (swap (Pair $x $y)) (Pair $y $x)) !(swap (Pair 1 3))", *retCh) |
+            for(@result <- retCh) {
+                stdout!(result)
+            }
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "PeTTa swap should execute without errors: {:?}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn test_petta_rholang_integration_fibonacci() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("(= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b)))) (= (fib $n) (fib-tr $n 0 1)) !(fib 10)", *retCh)
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "PeTTa fibonacci should execute without errors: {:?}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn test_petta_rholang_integration_arithmetic() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("!(+ 1 2)", *retCh) |
+            for(@result <- retCh) {
+                retCh!(result)
+            }
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "PeTTa arithmetic should execute without errors: {:?}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn test_petta_rholang_multiple_calls() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), ret1, ret2 in {
+            executePetta!("!(+ 1 2)", *ret1) |
+            executePetta!("!(* 3 4)", *ret2) |
+            for(@r1 <- ret1; @r2 <- ret2) {
+                ret1!(r1) | ret2!(r2)
+            }
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    assert!(
+        result.errors.is_empty(),
+        "Multiple PeTTa calls should execute without errors: {:?}",
+        result.errors
+    );
+}
+
+#[tokio::test]
+async fn test_petta_rholang_error_handling() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    // Test with invalid MeTTa syntax
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("(= incomplete", *retCh)
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    // Should produce an error due to invalid syntax
+    assert!(
+        !result.errors.is_empty(),
+        "Invalid MeTTa syntax should produce errors"
+    );
+}
+
+#[tokio::test]
+async fn test_petta_rholang_timeout_large_computation() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    // Test that timeout is enforced through the full Rholang runtime
+    // This fibonacci computation should timeout after 10 seconds
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("(= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b)))) (= (fib $n) (fib-tr $n 0 1)) !(fib 10000000)", *retCh)
+        }
+    "#;
+
+    let result = evaluate_petta_term(term).await;
+
+    // Should have errors due to timeout
+    assert!(
+        !result.errors.is_empty(),
+        "Large fibonacci computation should timeout and produce errors: {:?}",
+        result.errors
+    );
+
+    // Check that at least one error mentions timeout
+    let has_timeout_error = result.errors.iter().any(|err| {
+        let err_str = format!("{:?}", err);
+        err_str.contains("timed out") || err_str.contains("timeout")
+    });
+
+    assert!(
+        has_timeout_error,
+        "At least one error should mention timeout, errors: {:?}",
+        result.errors
+    );
+}

--- a/rholang/tests/swipl_petta_integration_spec.rs
+++ b/rholang/tests/swipl_petta_integration_spec.rs
@@ -17,6 +17,7 @@ async fn evaluate_petta_term(term: &str) -> EvaluateResult {
     let mut kvm = InMemoryStoreManager::new();
     let store = kvm.r_space_stores().await.unwrap();
 
+    #[allow(clippy::type_complexity)]
     let (runtime, _, _): (
         RhoRuntimeImpl,
         RhoRuntimeImpl,

--- a/rholang/tests/swipl_petta_replay_spec.rs
+++ b/rholang/tests/swipl_petta_replay_spec.rs
@@ -1,0 +1,282 @@
+use std::collections::HashMap;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::rho_runtime::RhoRuntime;
+use rholang::rust::interpreter::system_processes::{non_deterministic_ops, BodyRefs};
+use rholang::rust::interpreter::test_utils::resources::create_runtimes;
+use rholang::rust::interpreter::test_utils::utils::should_skip_petta_test;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+#[test]
+fn test_petta_is_registered_as_non_deterministic() {
+    let non_det_ops = non_deterministic_ops();
+
+    assert!(
+        non_det_ops.contains(&BodyRefs::SWIPL_EXECUTE_PETTA),
+        "SWIPL_EXECUTE_PETTA should be marked as non-deterministic"
+    );
+}
+
+/// This test demonstrates that PeTTa execution can be replayed successfully.
+/// We verify that:
+/// 1. PeTTa is registered as non-deterministic (see above)
+/// 2. Event log captures the PeTTa execution output
+/// 3. Replay runtime can be rigged with the event log
+/// 4. Replay execution completes without errors using cached output
+#[tokio::test]
+async fn test_petta_replay_consistency() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (mut runtime, mut replay_runtime, _) = create_runtimes(store, false, &mut Vec::new()).await;
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("!(+ 1 2)", *retCh) |
+            for(@_ <- retCh) { Nil }
+        }
+    "#;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "replay test".to_string());
+
+    // 1. Execute in play mode
+    let play_checkpoint = runtime.create_soft_checkpoint().await;
+    let play_result = runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
+        .await
+        .expect("Play evaluation failed");
+
+    assert!(
+        play_result.errors.is_empty(),
+        "Play should succeed: {:?}",
+        play_result.errors
+    );
+
+    // 2. Capture event log from play execution
+    let event_log = runtime.take_event_log().await;
+
+    // Verify event log contains data (non-deterministic operation was captured)
+    assert!(
+        !event_log.is_empty(),
+        "Event log should contain captured PeTTa execution"
+    );
+
+    // 3. Rig replay runtime with event log
+    replay_runtime
+        .rig(event_log)
+        .await
+        .expect("Rig failed - this means PeTTa is not properly registered as non-deterministic");
+
+    // 4. Execute same term in replay mode
+    let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
+    let replay_result = replay_runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
+        .await
+        .expect("Replay evaluation failed");
+
+    assert!(
+        replay_result.errors.is_empty(),
+        "Replay should succeed using cached output: {:?}",
+        replay_result.errors
+    );
+
+    println!("Play cost: {:?}", play_result.cost);
+    println!("Replay cost: {:?}", replay_result.cost);
+    println!("Replay successfully used cached PeTTa output");
+
+    // Cleanup checkpoints
+    runtime.revert_to_soft_checkpoint(play_checkpoint).await;
+    replay_runtime
+        .revert_to_soft_checkpoint(replay_checkpoint)
+        .await;
+}
+
+#[tokio::test]
+async fn test_petta_replay_with_multiple_calls() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (mut runtime, mut replay_runtime, _) = create_runtimes(store, false, &mut Vec::new()).await;
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), ret1, ret2 in {
+            executePetta!("!(+ 1 2)", *ret1) |
+            executePetta!("!(* 3 4)", *ret2) |
+            for(@_ <- ret1; @_ <- ret2) { Nil }
+        }
+    "#;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "replay test".to_string());
+
+    let play_checkpoint = runtime.create_soft_checkpoint().await;
+    let play_result = runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
+        .await
+        .expect("Play evaluation failed");
+
+    assert!(
+        play_result.errors.is_empty(),
+        "Play should succeed: {:?}",
+        play_result.errors
+    );
+
+    let event_log = runtime.take_event_log().await;
+    assert!(
+        !event_log.is_empty(),
+        "Event log should capture multiple PeTTa calls"
+    );
+
+    replay_runtime.rig(event_log).await.expect("Rig failed");
+
+    let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
+    let replay_result = replay_runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
+        .await
+        .expect("Replay evaluation failed");
+
+    assert!(
+        replay_result.errors.is_empty(),
+        "Replay should succeed: {:?}",
+        replay_result.errors
+    );
+
+    println!("Multiple PeTTa calls - Play cost: {:?}", play_result.cost);
+    println!(
+        "Multiple PeTTa calls - Replay cost: {:?}",
+        replay_result.cost
+    );
+    println!("Replay successfully used cached output for multiple calls");
+
+    runtime.revert_to_soft_checkpoint(play_checkpoint).await;
+    replay_runtime
+        .revert_to_soft_checkpoint(replay_checkpoint)
+        .await;
+}
+
+#[tokio::test]
+async fn test_petta_replay_error_consistency() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (mut runtime, mut replay_runtime, _) = create_runtimes(store, false, &mut Vec::new()).await;
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("(= incomplete", *retCh)
+        }
+    "#;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "replay error test".to_string());
+
+    let play_checkpoint = runtime.create_soft_checkpoint().await;
+    let play_result = runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
+        .await
+        .expect("Play evaluation completed");
+
+    assert!(
+        !play_result.errors.is_empty(),
+        "Play should have errors for invalid MeTTa code"
+    );
+
+    let event_log = runtime.take_event_log().await;
+    assert!(!event_log.is_empty(), "Event log should capture error case");
+
+    replay_runtime
+        .rig(event_log)
+        .await
+        .expect("Rig should work even with errors");
+
+    let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
+    let replay_result = replay_runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
+        .await
+        .expect("Replay evaluation completed");
+
+    println!(
+        "Error case - Play cost: {:?}, errors: {}",
+        play_result.cost,
+        play_result.errors.len()
+    );
+    println!(
+        "Error case - Replay cost: {:?}, errors: {}",
+        replay_result.cost,
+        replay_result.errors.len()
+    );
+    println!("Replay successfully handled error case using cached output");
+
+    runtime.revert_to_soft_checkpoint(play_checkpoint).await;
+    replay_runtime
+        .revert_to_soft_checkpoint(replay_checkpoint)
+        .await;
+}
+
+/// This test verifies that PeTTa replay uses cached output instead of re-executing.
+#[tokio::test]
+async fn test_petta_replay_uses_cached_output() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (mut runtime, mut replay_runtime, _) = create_runtimes(store, false, &mut Vec::new()).await;
+
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("!(+ 1 2)", *retCh) |
+            for(@_ <- retCh) { Nil }
+        }
+    "#;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "replay cache test".to_string());
+
+    let play_checkpoint = runtime.create_soft_checkpoint().await;
+    let play_result = runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
+        .await
+        .expect("Play evaluation failed");
+
+    let event_log = runtime.take_event_log().await;
+
+    assert!(
+        !event_log.is_empty(),
+        "Event log should contain PeTTa execution data"
+    );
+
+    replay_runtime.rig(event_log).await.expect("Rig failed");
+
+    let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
+    let replay_result = replay_runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
+        .await
+        .expect("Replay evaluation failed");
+
+    println!("Cached output test - Play cost: {:?}", play_result.cost);
+    println!("Cached output test - Replay cost: {:?}", replay_result.cost);
+    println!("Replay successfully retrieved and used cached PeTTa output from event log");
+
+    runtime.revert_to_soft_checkpoint(play_checkpoint).await;
+    replay_runtime
+        .revert_to_soft_checkpoint(replay_checkpoint)
+        .await;
+}

--- a/rholang/tests/swipl_petta_replay_spec.rs
+++ b/rholang/tests/swipl_petta_replay_spec.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 
 use crypto::rust::hash::blake2b512_random::Blake2b512Random;
 use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::errors::InterpreterError;
 use rholang::rust::interpreter::rho_runtime::RhoRuntime;
 use rholang::rust::interpreter::system_processes::{non_deterministic_ops, BodyRefs};
 use rholang::rust::interpreter::test_utils::resources::create_runtimes;
 use rholang::rust::interpreter::test_utils::utils::should_skip_petta_test;
 use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
 use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+use rspace_plus_plus::rspace::trace::event::{Event, IOEvent};
 
 #[test]
 fn test_petta_is_registered_as_non_deterministic() {
@@ -166,16 +168,22 @@ async fn test_petta_replay_with_multiple_calls() {
 }
 
 /// This test verifies that failed PeTTa executions are properly recorded in the event log
-/// and can be replayed without re-invoking swipl. The test specifically ensures:
+/// and produce a deterministic replay error without re-invoking swipl. The test specifically
+/// ensures:
 ///
 /// 1. Play execution fails with invalid MeTTa syntax
-/// 2. The failure is captured in the event log (NonDeterministicProcessFailure)
-/// 3. Replay runtime can be rigged with the failed execution
-/// 4. Replay reproduces the same error without invoking swipl (using cached failure)
-/// 5. Error consistency: play and replay produce the same error
+/// 2. The failure is recorded in the event log as a `Produce` with `failed == true` and
+///    `output_value` empty (the original cause is NOT stored — only the boolean flag)
+/// 3. Replay runtime can be rigged with the event log containing the failed execution
+/// 4. Replay raises `InterpreterError::CanNotReplayFailedNonDeterministicProcess` (a
+///    deterministic error) — this is raised by `continue_produce_process` BEFORE dispatch,
+///    so the system process handler and swipl/PeTTa are NEVER re-invoked
+/// 5. Replay error does NOT contain `SwiplError` / `"incomplete"` / `NonDeterministicProcessFailure`,
+///    proving swipl was not re-invoked to re-derive those messages
 ///
-/// This is critical for consensus safety - validators must agree on failures as well as
-/// successes, and replay must not diverge by attempting to re-execute failed operations.
+/// This is critical for consensus safety: validators must agree on failures as well as successes.
+/// The CanNotReplay short-circuit ensures all replaying validators produce the same error regardless
+/// of the original non-deterministic failure cause, preventing divergence.
 #[tokio::test]
 async fn test_petta_replay_error_consistency() {
     if should_skip_petta_test() {
@@ -209,20 +217,32 @@ async fn test_petta_replay_error_consistency() {
     );
 
     // Verify the error is a NonDeterministicProcessFailure (correct error type for failed non-det ops)
-    let play_error_msg = format!("{:?}", play_result.errors);
     assert!(
-        play_error_msg.contains("NonDeterministicProcessFailure")
-            || play_error_msg.contains("SwiplError")
-            || play_error_msg.contains("incomplete"),
-        "Error should indicate MeTTa syntax failure, got: {}",
-        play_error_msg
+        play_result
+            .errors
+            .iter()
+            .any(|e| matches!(e, InterpreterError::NonDeterministicProcessFailure { .. })),
+        "Play should contain NonDeterministicProcessFailure, got: {:?}",
+        play_result.errors
     );
 
-    // Step 2: Capture event log - should contain the failed execution
+    // Step 2: Capture event log - should contain a failed produce
     let event_log = runtime.take_event_log().await;
+    let has_failed_produce = event_log.iter().any(|event| match event {
+        Event::Comm(comm) => comm
+            .produces
+            .iter()
+            .any(|p| p.failed && p.output_value.is_empty()),
+        Event::IoEvent(IOEvent::Produce(p)) => p.failed && p.output_value.is_empty(),
+        Event::IoEvent(IOEvent::Consume(_)) => false,
+    });
     assert!(
-        !event_log.is_empty(),
-        "Event log should capture failed execution for replay"
+        has_failed_produce,
+        "Event log should contain a Produce with failed==true and empty output_value. \
+         This means the runtime correctly recorded the failed non-det produce, and during \
+         replay continue_produce_process will short-circuit with \
+         CanNotReplayFailedNonDeterministicProcess. Event log: {:?}",
+        event_log
     );
 
     // Step 3: Rig replay runtime with the event log containing the failure
@@ -231,36 +251,53 @@ async fn test_petta_replay_error_consistency() {
         .await
         .expect("Rig should work with failed non-det operations");
 
-    // Step 4: Execute in replay mode - should reproduce the same error without invoking swipl
+    // Step 4: Execute in replay mode - should short-circuit with CanNotReplayFailedNonDeterministicProcess
     let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
     let replay_result = replay_runtime
         .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
         .await
         .expect("Replay evaluation completed (with errors)");
 
-    // Step 5: Verify error consistency between play and replay
+    // Step 5: Verify replay raises CanNotReplayFailedNonDeterministicProcess
+    assert_eq!(
+        replay_result.errors.len(),
+        1,
+        "Replay should produce exactly one error"
+    );
     assert!(
-        !replay_result.errors.is_empty(),
-        "Replay should reproduce the same error"
+        matches!(
+            replay_result.errors[0],
+            InterpreterError::CanNotReplayFailedNonDeterministicProcess
+        ),
+        "Replay should produce CanNotReplayFailedNonDeterministicProcess, got: {:?}",
+        replay_result.errors[0]
     );
 
-    let replay_error_msg = format!("{:?}", replay_result.errors);
+    // Prove swipl was NOT re-invoked during replay: the replay error should NOT contain
+    // SwiplError, "incomplete", or NonDeterministicProcessFailure (which swipl would produce).
+    let replay_has_swipl_output = replay_result.errors.iter().any(|e| match e {
+        InterpreterError::NonDeterministicProcessFailure { cause, .. }
+        | InterpreterError::ProduceFailureWithOutput { cause, .. } => {
+            matches!(cause.as_ref(), InterpreterError::SwiplError(_))
+        }
+        InterpreterError::SwiplError(_) => true,
+        _ => false,
+    });
     assert!(
-        replay_error_msg.contains("NonDeterministicProcessFailure")
-            || replay_error_msg.contains("SwiplError")
-            || replay_error_msg.contains("incomplete"),
-        "Replay error should match play error type, got: {}",
-        replay_error_msg
+        !replay_has_swipl_output,
+        "Replay error should NOT contain SwiplError — swipl was not re-invoked. Got: {:?}",
+        replay_result.errors
     );
 
     println!(
-        "✓ Play execution failed as expected with {} error(s)",
+        "Play execution failed as expected with {} error(s)",
         play_result.errors.len()
     );
-    println!("✓ Event log captured failed execution");
+    println!("✓ Event log contains a Produce with failed==true and empty output_value");
     println!("✓ Replay runtime rigged successfully with failed execution");
     println!(
-        "✓ Replay reproduced the same error ({} error(s)) without re-invoking swipl",
+        "Replay deterministically raised CanNotReplayFailedNonDeterministicProcess ({} errors) \
+         — swipl was NOT re-invoked",
         replay_result.errors.len()
     );
     println!("✓ Failed PeTTa executions are replay-safe");
@@ -328,21 +365,38 @@ async fn test_petta_replay_timeout_error() {
     let replay_result = replay_runtime
         .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
         .await
-        .expect("Replay evaluation completed (with timeout)");
+        .expect("Replay evaluation completed (with CanNotReplayFailedNonDeterministicProcess)");
 
     assert!(
         !replay_result.errors.is_empty(),
-        "Replay should reproduce timeout error"
+        "Replay should produce a CanNotReplayFailedNonDeterministicProcess error"
     );
 
-    let replay_error_msg = format!("{:?}", replay_result.errors);
+    // Replay must raise CanNotReplayFailedNonDeterministicProcess (short-circuits before dispatch)
     assert!(
-        replay_error_msg.contains("timed out") || replay_error_msg.contains("timeout"),
-        "Replay error should match play timeout, got: {}",
-        replay_error_msg
+        replay_result.errors.iter().any(|e| {
+            matches!(
+                e,
+                InterpreterError::CanNotReplayFailedNonDeterministicProcess
+            )
+        }),
+        "Replay should produce CanNotReplayFailedNonDeterministicProcess, got: {:?}",
+        replay_result.errors
     );
 
-    println!("✓ Timeout error properly recorded and replayed");
+    // Prove swipl was NOT re-invoked during replay: assert no timeout/timed out/SwiplError
+    let replay_has_swipl_output = replay_result.errors.iter().any(|e| {
+        matches!(e, InterpreterError::SwiplError(_))
+            || matches!(e, InterpreterError::NonDeterministicProcessFailure { .. })
+    });
+    assert!(
+        !replay_has_swipl_output,
+        "Replay should NOT contain SwiplError or NonDeterministicProcessFailure \
+         — swipl was not re-invoked. Got: {:?}",
+        replay_result.errors
+    );
+
+    println!("✓ Timeout failure properly recorded; replay deterministically raised CanNotReplayFailedNonDeterministicProcess");
 
     runtime.revert_to_soft_checkpoint(play_checkpoint).await;
     replay_runtime

--- a/rholang/tests/swipl_petta_replay_spec.rs
+++ b/rholang/tests/swipl_petta_replay_spec.rs
@@ -165,6 +165,17 @@ async fn test_petta_replay_with_multiple_calls() {
         .await;
 }
 
+/// This test verifies that failed PeTTa executions are properly recorded in the event log
+/// and can be replayed without re-invoking swipl. The test specifically ensures:
+///
+/// 1. Play execution fails with invalid MeTTa syntax
+/// 2. The failure is captured in the event log (NonDeterministicProcessFailure)
+/// 3. Replay runtime can be rigged with the failed execution
+/// 4. Replay reproduces the same error without invoking swipl (using cached failure)
+/// 5. Error consistency: play and replay produce the same error
+///
+/// This is critical for consensus safety - validators must agree on failures as well as
+/// successes, and replay must not diverge by attempting to re-execute failed operations.
 #[tokio::test]
 async fn test_petta_replay_error_consistency() {
     if should_skip_petta_test() {
@@ -185,42 +196,153 @@ async fn test_petta_replay_error_consistency() {
     let rand = Blake2b512Random::create_from_bytes(&[]);
     let initial_phlo = Cost::create(i64::MAX, "replay error test".to_string());
 
+    // Step 1: Execute in play mode - should fail with syntax error
     let play_checkpoint = runtime.create_soft_checkpoint().await;
     let play_result = runtime
         .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
         .await
-        .expect("Play evaluation completed");
+        .expect("Play evaluation completed (with errors)");
 
     assert!(
         !play_result.errors.is_empty(),
         "Play should have errors for invalid MeTTa code"
     );
 
+    // Verify the error is a NonDeterministicProcessFailure (correct error type for failed non-det ops)
+    let play_error_msg = format!("{:?}", play_result.errors);
+    assert!(
+        play_error_msg.contains("NonDeterministicProcessFailure")
+            || play_error_msg.contains("SwiplError")
+            || play_error_msg.contains("incomplete"),
+        "Error should indicate MeTTa syntax failure, got: {}",
+        play_error_msg
+    );
+
+    // Step 2: Capture event log - should contain the failed execution
     let event_log = runtime.take_event_log().await;
-    assert!(!event_log.is_empty(), "Event log should capture error case");
+    assert!(
+        !event_log.is_empty(),
+        "Event log should capture failed execution for replay"
+    );
+
+    // Step 3: Rig replay runtime with the event log containing the failure
+    replay_runtime
+        .rig(event_log)
+        .await
+        .expect("Rig should work with failed non-det operations");
+
+    // Step 4: Execute in replay mode - should reproduce the same error without invoking swipl
+    let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
+    let replay_result = replay_runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
+        .await
+        .expect("Replay evaluation completed (with errors)");
+
+    // Step 5: Verify error consistency between play and replay
+    assert!(
+        !replay_result.errors.is_empty(),
+        "Replay should reproduce the same error"
+    );
+
+    let replay_error_msg = format!("{:?}", replay_result.errors);
+    assert!(
+        replay_error_msg.contains("NonDeterministicProcessFailure")
+            || replay_error_msg.contains("SwiplError")
+            || replay_error_msg.contains("incomplete"),
+        "Replay error should match play error type, got: {}",
+        replay_error_msg
+    );
+
+    println!(
+        "✓ Play execution failed as expected with {} error(s)",
+        play_result.errors.len()
+    );
+    println!("✓ Event log captured failed execution");
+    println!("✓ Replay runtime rigged successfully with failed execution");
+    println!(
+        "✓ Replay reproduced the same error ({} error(s)) without re-invoking swipl",
+        replay_result.errors.len()
+    );
+    println!("✓ Failed PeTTa executions are replay-safe");
+
+    runtime.revert_to_soft_checkpoint(play_checkpoint).await;
+    replay_runtime
+        .revert_to_soft_checkpoint(replay_checkpoint)
+        .await;
+}
+
+/// This test verifies that PeTTa timeout failures are properly recorded and replayed.
+/// Timeout errors are a specific type of NonDeterministicProcessFailure that should
+/// also be replay-safe.
+#[tokio::test]
+async fn test_petta_replay_timeout_error() {
+    if should_skip_petta_test() {
+        return;
+    }
+
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+
+    let (mut runtime, mut replay_runtime, _) = create_runtimes(store, false, &mut Vec::new()).await;
+
+    // Large fibonacci that will timeout (>10 seconds)
+    let term = r#"
+        new executePetta(`rho:petta:execute`), retCh in {
+            executePetta!("(= (fib-tr $n $a $b) (if (== $n 0) $a (fib-tr (- $n 1) $b (+ $a $b)))) (= (fib $n) (fib-tr $n 0 1)) !(fib 10000000)", *retCh)
+        }
+    "#;
+
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let initial_phlo = Cost::create(i64::MAX, "timeout replay test".to_string());
+
+    let play_checkpoint = runtime.create_soft_checkpoint().await;
+    let play_result = runtime
+        .evaluate(term, initial_phlo.clone(), HashMap::new(), rand.clone())
+        .await
+        .expect("Play evaluation completed (with timeout)");
+
+    assert!(
+        !play_result.errors.is_empty(),
+        "Play should timeout with large fibonacci"
+    );
+
+    let play_error_msg = format!("{:?}", play_result.errors);
+    assert!(
+        play_error_msg.contains("timed out") || play_error_msg.contains("timeout"),
+        "Error should indicate timeout, got: {}",
+        play_error_msg
+    );
+
+    let event_log = runtime.take_event_log().await;
+    assert!(
+        !event_log.is_empty(),
+        "Event log should capture timeout failure"
+    );
 
     replay_runtime
         .rig(event_log)
         .await
-        .expect("Rig should work even with errors");
+        .expect("Rig should work with timeout errors");
 
     let replay_checkpoint = replay_runtime.create_soft_checkpoint().await;
     let replay_result = replay_runtime
         .evaluate(term, initial_phlo.clone(), HashMap::new(), rand)
         .await
-        .expect("Replay evaluation completed");
+        .expect("Replay evaluation completed (with timeout)");
 
-    println!(
-        "Error case - Play cost: {:?}, errors: {}",
-        play_result.cost,
-        play_result.errors.len()
+    assert!(
+        !replay_result.errors.is_empty(),
+        "Replay should reproduce timeout error"
     );
-    println!(
-        "Error case - Replay cost: {:?}, errors: {}",
-        replay_result.cost,
-        replay_result.errors.len()
+
+    let replay_error_msg = format!("{:?}", replay_result.errors);
+    assert!(
+        replay_error_msg.contains("timed out") || replay_error_msg.contains("timeout"),
+        "Replay error should match play timeout, got: {}",
+        replay_error_msg
     );
-    println!("Replay successfully handled error case using cached output");
+
+    println!("✓ Timeout error properly recorded and replayed");
 
     runtime.revert_to_soft_checkpoint(play_checkpoint).await;
     replay_runtime

--- a/rholang/tests/swipl_petta_replay_spec.rs
+++ b/rholang/tests/swipl_petta_replay_spec.rs
@@ -17,7 +17,7 @@ fn test_petta_is_registered_as_non_deterministic() {
 
     assert!(
         non_det_ops.contains(&BodyRefs::SWIPL_EXECUTE_PETTA),
-        "SWIPL_EXECUTE_PETTA should be marked as non-deterministic"
+        "PETTA_EXECUTE should be marked as non-deterministic"
     );
 }
 


### PR DESCRIPTION
Add PeTTa (Prolog-based MeTTa) integration for executing MeTTa smart contracts from Rholang via the rho:petta:execute system contract URN.