### PR TITLE
chore: re-pin rholang-parser to master HEAD after #95 merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5066,7 +5066,7 @@ dependencies = [
 [[package]]
 name = "rholang-parser"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=0202e79#0202e79f24e060456f6f885dc1fd77a89f9ad1a1"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
 dependencies = [
  "bitvec",
  "nonempty-collections",
@@ -5081,7 +5081,7 @@ dependencies = [
 [[package]]
 name = "rholang-tree-sitter"
 version = "0.1.2"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=0202e79#0202e79f24e060456f6f885dc1fd77a89f9ad1a1"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5090,7 +5090,7 @@ dependencies = [
 [[package]]
 name = "rholang-tree-sitter-proc-macro"
 version = "0.1.2"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=0202e79#0202e79f24e060456f6f885dc1fd77a89f9ad1a1"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
 dependencies = [
  "anyhow",
  "quote",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,7 +45,7 @@ tonic = { workspace = true }
 prost = { workspace = true }
 tonic-prost = { workspace = true }
 colored = "3.0"
-rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "0202e79" }
+rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "527af8a" }
 rustyline = "13.0"
 rpassword = "7.4"
 tracing = { workspace = true }

--- a/rholang/Cargo.toml
+++ b/rholang/Cargo.toml
@@ -43,7 +43,7 @@ indexmap = "2.8.0"
 rayon = "1.10.0"
 tempfile = "3.19.1"
 clap = { version = "4.5", features = ["derive"] }
-rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "0202e79" }
+rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "527af8a" }
 validated = "1.0.0"
 smallvec = { version = "1.15.1", features = [
 	"union",

--- a/rspace++/Cargo.toml
+++ b/rspace++/Cargo.toml
@@ -42,7 +42,7 @@ rstest = "0.19.0"
 proptest-derive = "0.5.1"
 counter = "0.5.7"
 multiset = "0.0.5"
-rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", package = "rholang-parser", rev = "0202e79" }
+rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", package = "rholang-parser", rev = "527af8a" }
 validated = "1.0.0"
 metrics = "0.23"
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
## Summary

Re-pins `rholang-parser` from the branch-head SHA `0202e79` to the merge commit `527af8a` on upstream `rholang-rs` master.

## Why

[PR #91](https://github.com/F1R3FLY-io/f1r3node-rust/pull/91) (merged) pinned to `0202e79` as a stopgap — that's the head of [rholang-rs#95](https://github.com/F1R3FLY-io/rholang-rs/pull/95)'s branch (`pr/un-reserve-agent-keywords`), which fixed a keyword-reservation regression introduced by rholang-rs#94. The original PR-3 commit message noted the pin should be re-bumped once #95 merged.

#95 has since merged at master commit `527af8a`. Re-pinning to that commit means:
- The dependency points at a canonical upstream master ref instead of a branch-head SHA.
- Upstream is free to delete the `pr/un-reserve-agent-keywords` branch without breaking our build.

## Effective change

Lockfile-only — the SHA being pulled (`527af8a`) is a merge commit whose tree is the same as `0202e79`. This is metadata cleanup, not a code change.

## Test plan

- [x] `cargo build -p rholang` — clean
- [x] `cargo test -p rholang --test sugar_regression` — 10 pass (the regression tests added in PR #91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
