### PR TITLE
ci: cut OCI VM usage 20→4 per run; fix pre-push hook race check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -51,12 +51,16 @@ if [ -n "${CI:-}" ] || [ -n "${GITLAB_CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; 
     exit 0
 fi
 
+# Remote name is the hook's first argument (falls back to origin only if
+# git ever invokes the hook without args).
+remote_name="${1:-origin}"
+zero="0000000000000000000000000000000000000000"
+
 # Check if there are actually new commits to push
 has_new_commits=0
 push_info=""
 while IFS=' ' read -r local_ref local_oid remote_ref remote_oid; do
     push_info+="$local_ref $local_oid $remote_ref $remote_oid"$'\n'
-    zero="0000000000000000000000000000000000000000"
     if [ "$local_oid" != "$remote_oid" ] && [ "$local_oid" != "$zero" ]; then
         has_new_commits=1
     fi
@@ -66,11 +70,27 @@ if [ -z "$push_info" ] || [ "$has_new_commits" -eq 0 ]; then
     exit 0
 fi
 
+# True when every ref being pushed already sits at its local OID on the
+# remote (racing push landed first). Keyed off the stdin refspecs, never
+# HEAD: HEAD may be detached or on a different branch than the refs being
+# pushed, and a ref that is absent on the remote (new branch) must count
+# as needing a push.
+refs_already_on_remote() {
+    local local_ref local_oid remote_ref remote_oid actual_oid
+    while IFS=' ' read -r local_ref local_oid remote_ref remote_oid; do
+        [ -z "$local_ref" ] && continue
+        [ "$local_oid" = "$zero" ] && continue
+        actual_oid=$(git ls-remote "$remote_name" "$remote_ref" 2>/dev/null | awk '{print $1}') || actual_oid=""
+        if [ "$actual_oid" != "$local_oid" ]; then
+            return 1
+        fi
+    done <<< "$push_info"
+    return 0
+}
+
 # Double-check against the actual remote to catch racing pushes
-local_head=$(git rev-parse HEAD)
-remote_head=$(git ls-remote origin "$(git symbolic-ref HEAD)" 2>/dev/null | awk '{print $1}') || remote_head=""
-if [ -n "$remote_head" ] && [ "$local_head" = "$remote_head" ]; then
-    git fetch origin 2>/dev/null || true
+if refs_already_on_remote; then
+    git fetch "$remote_name" 2>/dev/null || true
     echo -e "${CYAN}Already up to date with remote. Nothing to push.${NC}"
     exit 1
 fi
@@ -232,9 +252,8 @@ echo ""
 
 if [[ $FAILED -eq 0 ]]; then
     # Re-check remote after tests for race condition
-    post_remote=$(git ls-remote origin "$(git symbolic-ref HEAD)" 2>/dev/null | awk '{print $1}') || post_remote=""
-    if [ -n "$post_remote" ] && [ "$local_head" = "$post_remote" ]; then
-        git fetch origin 2>/dev/null || true
+    if refs_already_on_remote; then
+        git fetch "$remote_name" 2>/dev/null || true
         echo -e "${GREEN}All checks passed!${NC}"
         echo -e "${CYAN}Remote already up to date (pushed by prior attempt). Nothing to push.${NC}"
         exit 1

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -200,7 +200,7 @@ jobs:
           chmod 600 ~/.oci/config
           oci iam region list >/dev/null && echo "OCI auth OK"
 
-      - name: Launch 10 amd64 + 10 arm64 ephemeral runners
+      - name: Launch 2 amd64 + 2 arm64 ephemeral runners
         shell: bash -ex {0}
         env:
           # The default GITHUB_TOKEN can't mint runner registration tokens even
@@ -215,12 +215,14 @@ jobs:
           cd system-integration/ci/oci-runners
           # Launch in parallel; each script exits as soon as the OCI launch
           # API call returns (the VM continues booting in the background and
-          # registers itself via cloud-init). 10 amd64 + 10 arm64 feeds the
-          # 20-job dual-provider matrix (docker × {amd64,arm64} × 5 slots +
-          # subprocess × {amd64,arm64} × 5 slots).
+          # registers itself via cloud-init). 2 amd64 + 2 arm64 feeds the
+          # 4-job dual-provider matrix ({docker,subprocess} × {amd64,arm64}).
+          # Kept to one VM per matrix job: OCI daily instance-creation quota
+          # is shared tenancy-wide, and the previous 20-VM layout (5 identical
+          # slots per arch×provider) exhausted it under normal PR traffic.
           pids=()
-          for _ in $(seq 1 10); do ./launch-runner.sh amd64 & pids+=($!); done
-          for _ in $(seq 1 10); do ./launch-runner.sh arm64 & pids+=($!); done
+          for _ in $(seq 1 2); do ./launch-runner.sh amd64 & pids+=($!); done
+          for _ in $(seq 1 2); do ./launch-runner.sh arm64 & pids+=($!); done
           failed=0
           for pid in "${pids[@]}"; do
             if ! wait "$pid"; then
@@ -231,7 +233,7 @@ jobs:
             echo "At least one OCI runner launch failed."
             exit 1
           fi
-          echo "All 20 ephemeral runner VMs submitted."
+          echo "All 4 ephemeral runner VMs submitted."
 
       - name: Remove OCI credentials
         if: always()
@@ -243,10 +245,14 @@ jobs:
   # Integration tests run on ephemeral OCI runners — one fresh VM per matrix
   # job, self-terminating after the job completes. The matrix runs the same
   # test suite against TWO node-spawn backends (docker provider, subprocess
-  # provider) on each arch — 20 jobs total. Each arch's 10 jobs share its 10
-  # ephemeral runners (provider is a pytest flag, not a runner concern).
+  # provider) on each arch — 4 jobs total, one ephemeral runner each
+  # (provider is a pytest flag, not a runner concern). The former layout ran
+  # 5 identical slots per arch×provider (20 VMs) — pure repetition carried
+  # over from legacy rust/staging, dropped to conserve OCI daily quota.
+  # Job names must keep the "arch-provider" form: the per-arch aggregators
+  # in ci.yml / ci-fork-pr.yml match on contains("Integration Tests (amd64-").
   integration_tests:
-    name: Integration Tests (${{ matrix.arch }}-${{ matrix.provider }}-${{ matrix.slot }})
+    name: Integration Tests (${{ matrix.arch }}-${{ matrix.provider }})
     needs: [build_docker_image, launch_ephemeral_runners]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -256,77 +262,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── amd64 × docker × 5 ───────────────────────────────────────────────
           - {
               arch: amd64,
               provider: docker,
-              slot: 1,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: docker,
-              slot: 2,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: docker,
-              slot: 3,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: docker,
-              slot: 4,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: docker,
-              slot: 5,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          # ── amd64 × subprocess × 5 ───────────────────────────────────────────
-          - {
-              arch: amd64,
-              provider: subprocess,
-              slot: 1,
               runner:
                 [
                   self-hosted,
@@ -339,7 +277,6 @@ jobs:
           - {
               arch: amd64,
               provider: subprocess,
-              slot: 2,
               runner:
                 [
                   self-hosted,
@@ -350,115 +287,8 @@ jobs:
                 ],
             }
           - {
-              arch: amd64,
-              provider: subprocess,
-              slot: 3,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: subprocess,
-              slot: 4,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: amd64,
-              provider: subprocess,
-              slot: 5,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  x64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          # ── arm64 × docker × 5 ───────────────────────────────────────────────
-          - {
               arch: arm64,
               provider: docker,
-              slot: 1,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: docker,
-              slot: 2,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: docker,
-              slot: 3,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: docker,
-              slot: 4,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: docker,
-              slot: 5,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          # ── arm64 × subprocess × 5 ───────────────────────────────────────────
-          - {
-              arch: arm64,
-              provider: subprocess,
-              slot: 1,
               runner:
                 [
                   self-hosted,
@@ -471,46 +301,6 @@ jobs:
           - {
               arch: arm64,
               provider: subprocess,
-              slot: 2,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: subprocess,
-              slot: 3,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: subprocess,
-              slot: 4,
-              runner:
-                [
-                  self-hosted,
-                  linux,
-                  arm64,
-                  f1r3fly-rust-ci-ephemeral,
-                  oracle-cloud,
-                ],
-            }
-          - {
-              arch: arm64,
-              provider: subprocess,
-              slot: 5,
               runner:
                 [
                   self-hosted,
@@ -605,7 +395,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: integration-logs-${{ matrix.arch }}-${{ matrix.provider }}-slot${{ matrix.slot }}-run${{ github.run_id }}-attempt${{ github.run_attempt }}
+          name: integration-logs-${{ matrix.arch }}-${{ matrix.provider }}-run${{ github.run_id }}-attempt${{ github.run_attempt }}
           path: system-integration/integration-tests/
           retention-days: 7
 

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -429,6 +429,14 @@ jobs:
           zcat /tmp/rust-node-docker.tar.gz | docker image load
           docker tag ${{ env.DOCKER_IMAGE_NAME }}:amd64 ${{ env.DOCKER_IMAGE_NAME }}
 
+      - name: Reserve node host ports
+        shell: bash -ex {0}
+        # 40400-40455 sit inside the kernel ephemeral range (32768-60999); a
+        # transient outbound connection can grab one as its source port and
+        # fail the bind with "address already in use". Reserving them excludes
+        # them from ephemeral allocation.
+        run: sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
+
       - name: Start standalone node
         shell: bash -ex {0}
         run: docker compose -f docker/standalone.yml up -d
@@ -514,6 +522,12 @@ jobs:
         run: |
           zcat /tmp/rust-node-docker.tar.gz | docker image load
           docker tag ${{ env.DOCKER_IMAGE_NAME }}:amd64 ${{ env.DOCKER_IMAGE_NAME }}
+
+      - name: Reserve node host ports
+        shell: bash -ex {0}
+        # Same ephemeral-port hazard as the standalone smoke; observed as
+        # rnode.validator2 failing to bind 0.0.0.0:40420 (run 28917696069).
+        run: sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
 
       - name: Start shard
         shell: bash -ex {0}
@@ -609,6 +623,12 @@ jobs:
       - name: Setup standalone data
         shell: bash -ex {0}
         run: just setup-standalone
+
+      - name: Reserve node host ports
+        shell: bash -ex {0}
+        # Same ephemeral-port hazard as the docker smokes: the node binary
+        # binds 40400-40405 directly on the host.
+        run: sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
 
       - name: Start standalone node
         shell: bash -ex {0}

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -171,7 +171,9 @@ jobs:
         run: |
           # This runner later holds OCI_* secrets, so the installer must not be
           # fetched from a movable ref. Fails closed on any checksum mismatch.
-          curl -fsSL "$OCI_CLI_INSTALLER_URL" -o /tmp/oci-install.sh
+          # Retries cover transient raw.githubusercontent.com 429s, which curl
+          # treats as retryable; the pinned checksum still gates what runs.
+          curl -fsSL --retry 5 --retry-delay 10 "$OCI_CLI_INSTALLER_URL" -o /tmp/oci-install.sh
           echo "$OCI_CLI_INSTALLER_SHA256  /tmp/oci-install.sh" | sha256sum -c -
           bash /tmp/oci-install.sh \
             --accept-all-defaults --install-dir /opt/oci-cli --exec-dir /usr/local/bin

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -52,7 +52,7 @@ jobs:
 
   # Per-arch aggregators. The branch ruleset requires status checks named
   # exactly `Integration Tests (amd64)` / `(arm64)`. These collapse the reusable
-  # pipeline's 10 per-arch matrix slots into one ruleset gate per arch. They use
+  # pipeline's per-arch matrix jobs into one ruleset gate per arch. They use
   # `contains(...)` (not `startswith`) because reusable-workflow job names are
   # prefixed with the caller job id ("Heavy Pipeline / Integration Tests (...)").
   integration_tests_amd64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 
 # Concurrency: PRs run in parallel (one group per ref) for fast feedback; pushes
 # (dev/master/staging/trying/tags) share a single group so merge and release runs
-# serialize rather than piling up independent 20-VM OCI matrices. Nothing is
+# serialize rather than piling up independent 4-VM OCI matrices. Nothing is
 # cancelled mid-flight — a re-push queues behind its own in-flight run, so release
 # jobs and long integration runs always reach completion.
 concurrency:
@@ -229,7 +229,7 @@ jobs:
 
   # Per-arch aggregators. The branch ruleset requires status checks named
   # exactly `Integration Tests (amd64)` / `(arm64)`. These collapse the reusable
-  # pipeline's 10 per-arch matrix slots into one ruleset gate per arch. They use
+  # pipeline's per-arch matrix jobs into one ruleset gate per arch. They use
   # `contains(...)` (not `startswith`) because reusable-workflow job names are
   # prefixed with the caller job id ("Heavy Pipeline / Integration Tests (...)").
   # Internal-only: fork PRs get this check from ci-fork-pr.yml instead, so this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,17 @@ jobs:
           # unauthenticated/bot requests. A 403 response from these
           # endpoints still proves the URL is well-formed and the
           # resource exists; a real broken link would 404. The 429
-          # allowance for rate-limited fetches is unchanged.
+          # allowance for rate-limited fetches is unchanged. 503 is
+          # accepted because it is transient by definition (seen from
+          # rust-fuzz.github.io during a GitHub Pages blip); a genuinely
+          # dead link returns 404/410, not 503.
           args: >-
             --no-progress
             --exclude-loopback
             --exclude 'https://www\.gutenberg\.org/ebooks/132'
             --max-retries 2
             --retry-wait-time 5
-            --accept 200..=299,403,429
+            --accept 200..=299,403,429,503
             './**/*.md'
           fail: true
 


### PR DESCRIPTION
## What

Two related CI-infrastructure fixes:

1. **Cut the integration matrix from 20 to 4 OCI VMs per run** (`5d6cadb5`)
   The 5 "slots" per arch×provider were identical repetitions — the pytest
   invocation never referenced `matrix.slot` (it only appeared in the artifact
   name), carried over verbatim from legacy rust/staging. Every internal run
   launched 20 ephemeral OCI VMs, and normal PR traffic exhausted the tenancy's
   daily instance-creation quota (`LimitExceeded` in Launch Ephemeral Runners,
   e.g. run 28914712980, which blocked PR #101).
   The matrix is now {docker,subprocess} × {amd64,arm64} = 4 jobs, one VM each —
   an 80% cut in daily quota consumption. Job names keep the `arch-provider`
   form so the per-arch ruleset aggregators' `contains()` matching is unaffected.

2. **Fix the pre-push hook's 'already up to date' race check** (`ee5f40fa`)
   Both race checks compared HEAD against `origin` via `git symbolic-ref`, so the
   hook wrongly aborted pushes of any ref other than the checked-out branch (e.g.
   a new branch pushed while on staging), broke in detached HEAD, and always
   consulted origin even when pushing to another remote. The checks now iterate
   the refspecs git supplies on stdin and compare each local OID against the
   actual target remote (hook arg $1); a ref absent on the remote counts as
   needing a push.

## Verification

- All three workflow files parse as valid YAML
- Aggregator `contains("Integration Tests (amd64-")` matching verified against new job names
- `bash -n` passes on the hook; executable bit preserved