### PR TITLE
ci: skip duplicate heavy runs on promotion PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,10 +221,22 @@ jobs:
   # receive secrets normally and need no approval gate (gated: false). Fork PRs
   # cannot get secrets on a `pull_request` event, so they skip this job and are
   # served by ci-fork-pr.yml (pull_request_target, maintainer-gated) instead.
+  #
+  # Promotion PRs (head is a push-covered branch: dev/staging/master/trying)
+  # also skip: the push run on the identical commit already runs the identical
+  # pipeline, so the PR-event copy would only double OCI VM creations against
+  # the tenancy's daily limit. Required checks are commit-scoped — the push
+  # run's aggregator results land on the same SHA and gate the PR; the
+  # PR-side aggregators skip alongside (skipped = passing, same semantics the
+  # fork path relies on) and finish long before the push run's real results,
+  # so the real results are the latest and win.
   pipeline:
     name: Heavy Pipeline
     needs: lint
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork == false
+    if: >-
+      github.event_name == 'push'
+      || (github.event.pull_request.head.repo.fork == false
+      && !contains(fromJSON('["dev", "staging", "master", "trying"]'), github.event.pull_request.head.ref))
     uses: ./.github/workflows/_integration-pipeline.yml
     with:
       gated: false
@@ -237,10 +249,15 @@ jobs:
   # prefixed with the caller job id ("Heavy Pipeline / Integration Tests (...)").
   # Internal-only: fork PRs get this check from ci-fork-pr.yml instead, so this
   # one skips for them (a skipped required check is treated as passing).
+  # Promotion PRs skip too, mirroring the pipeline job's dedupe condition.
   integration_tests_amd64:
     name: Integration Tests (amd64)
     needs: pipeline
-    if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false)
+    if: >-
+      always()
+      && (github.event_name == 'push'
+      || (github.event.pull_request.head.repo.fork == false
+      && !contains(fromJSON('["dev", "staging", "master", "trying"]'), github.event.pull_request.head.ref)))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -269,7 +286,11 @@ jobs:
   integration_tests_arm64:
     name: Integration Tests (arm64)
     needs: pipeline
-    if: always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork == false)
+    if: >-
+      always()
+      && (github.event_name == 'push'
+      || (github.event.pull_request.head.repo.fork == false
+      && !contains(fromJSON('["dev", "staging", "master", "trying"]'), github.event.pull_request.head.ref)))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
Promotion PRs (staging->dev, dev->master) have a head that is itself a push-covered branch, so every promotion commit ran the heavy pipeline twice: once for the push, once for the pull_request event on the same SHA. Each copy launches 4 OCI VMs against the tenancy's daily creation limit, and the duplicate lost the quota race on dev@08d9d3c1 (run 28957033445) while the push run on the identical commit was green.

The pipeline job and both per-arch aggregators now skip pull_request events whose head ref is dev/staging/master/trying. Required checks are commit-scoped: the push run's aggregators land on the same SHA and gate the PR; the PR-side aggregators skip (skipped = passing, the semantics the fork path already relies on) and complete before the push run's real results, so the real results win as latest.

- Promotion PRs (staging→dev, dev→master) have push-covered head branches, so every promotion commit ran the heavy pipeline twice on the same SHA — doubling OCI VM creations against the daily throttle
- Observed concretely on dev@08d9d3c1: push run green, PR #1's duplicate run lost the quota race
- Push-run checks are commit-scoped and gate the PR; PR-side aggregators skip (same skipped-equals-passing semantics the fork path uses) and finish before the push run's real results, so the real results win
- Caveat for future maintainers: if a required check is ever added that only runs on pull_request events, this skip condition needs revisiting