### PR TITLE
ci: pass aggregator gates on skipped pipeline, harden OCI auth step

### DIFF
--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2082717906d633870d6812c2a3d126fced12e088  # pinned system-integration main
+          ref: a50eeb198c6e542504af8db92389de5c02500422  # pinned system-integration main
           path: system-integration
           persist-credentials: false
 
@@ -165,7 +165,7 @@ jobs:
           oci --version
 
       - name: Configure OCI auth from secrets
-        shell: bash -ex {0}
+        shell: bash -e {0}   # no -x: never trace the multi-line private key
         env:
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: F1R3FLY-io/system-integration
-          ref: 2082717906d633870d6812c2a3d126fced12e088  # pinned system-integration main
+          ref: a50eeb198c6e542504af8db92389de5c02500422  # pinned system-integration main
           path: system-integration
           persist-credentials: false
 

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -69,7 +69,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi
@@ -98,7 +98,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi
@@ -260,7 +260,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash -e {0}
         run: |
-          if [ "${{ needs.pipeline.result }}" != "success" ]; then
+          if [ "${{ needs.pipeline.result }}" = "failure" ] || [ "${{ needs.pipeline.result }}" = "cancelled" ]; then
             echo "Heavy Pipeline did not succeed (result: ${{ needs.pipeline.result }}); failing gate."
             exit 1
           fi


### PR DESCRIPTION
## Problem

The v0.4.17 release-bump push to `master` ([run 29047861724](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/29047861724)) failed CI: `chore(release)` pushes intentionally skip the Heavy Pipeline (the tag push handles publishing), but the `Integration Tests (amd64)/(arm64)` aggregator gates run with `if: always()` and treated `skipped` as failure. Every future release push would paint master red.

## Fix

Cherry-pick of 37d9ec4e from `dev` (PR #88), which already fixed this there on Jun 26 — **minus its prerelease policy change** (master keeps the PATCH-based release-type derivation, per the PR #109 decision):

- `ci.yml` / `ci-fork-pr.yml`: gates fail only on `failure`/`cancelled`; `skipped` passes through
- `_integration-pipeline.yml`: OCI auth step runs without `-x` (never trace the private key); system-integration pin bumped to `a50eeb19` (runner watchdog)

## Safety notes

- Not fail-open in practice: on PRs, `setup`/`Lint` always run and Lint is a required check on master and dev, so any skipped-pipeline path leaves a red required check; fork PRs are gated by `ci-fork-pr.yml`'s maintainer approval instead.
- Merge simulation vs dev is clean: the guard hunks are content-identical to dev's, and PR #109's newer `SYSTEM_INTEGRATION_REF` pin (06f2020c) supersedes `a50eeb19` without conflict once #109 lands.