### PR TITLE
docs: restore git interaction policy with per-commit consent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,19 @@ Three crates have `build.rs` for protobuf code generation:
 - `rust-toolchain.toml` — nightly channel pin
 - `Cross.toml` — cross-compilation for amd64/arm64
 
+## Git Interaction
+
+- Do not run `git add`, `git commit`, or `git push` unless explicitly requested
+- Commit consent is per-commit: never create a commit — including merge
+  commits and plumbing equivalents (`commit-tree`/`update-ref`) — without an
+  unambiguous per-commit request; consent does not carry over from a plan or
+  an earlier commit
+- "Resolve the merge conflicts" authorizes conflict resolution only: resolve,
+  verify the build, report, and stop before the merge commit
+- `git stash pop|drop|clear|branch` are blocked (destructive); other stash
+  writes require user confirmation; `stash list`/`show` are fine
+- See `CLAUDE.md` § "Git Interaction Policy" for the full rules
+
 ## Subagent Usage
 
 - Only use a subagent if the user has explicitly told you to do so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Three crates have `build.rs` for protobuf code generation:
   and fully-autonomous (YOLO/worktree) modes; in interactive sessions it is
   overridden by the consent rules above.
 
-**Full Documentation**: [Git Interaction Policy](../../SA/top-level-gitlab-profile/docs/common/git-interaction-policy.md) (workspace checkout) — use the GitLab copy when working single-repo.
+**Full Documentation**: [Git Interaction Policy](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/git-interaction-policy.md) (canonical; also available at `../../SA/top-level-gitlab-profile/docs/common/git-interaction-policy.md` in a multi-repo workspace checkout).
 
 ### Commit Messages
 - Use `[agent]` prefix in agentic mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,31 @@ Three crates have `build.rs` for protobuf code generation:
 
 ## Git and Version Control
 
+### Git Interaction Policy (agents)
+- Use `/quick-commit` for git add/commit operations
+- Use `/recursive-push` for git push operations
+- Do not run `git add`, `git commit`, or `git push` directly unless explicitly requested
+- **Commit consent is per-commit**: never create a commit — including merge
+  commits and plumbing equivalents (`git commit-tree`, `git update-ref`) —
+  without the user invoking `/quick-commit` or giving an unambiguous
+  per-commit "yes". Consent does not carry over from a plan, an earlier
+  commit, or a previous merge in the same session.
+- **Merge conflicts**: a request to "resolve the merge conflicts" authorizes
+  conflict resolution only — resolve the files, verify the build, report,
+  then STOP before the merge commit. The user running `git merge` in their
+  own terminal is not a request for the agent to act.
+- `git mv` is permitted but requires user confirmation
+- `git stash`:
+  - `git stash list`, `git stash show` are permitted (read-only)
+  - `git stash`, `git stash push|save|apply` require user confirmation
+  - `git stash pop|drop|clear|branch` are blocked (destructive; can silently lose uncommitted work)
+- **Exception:** In agentic mode (`claude-agentic`), all restrictions are lifted
+- The workspace stigmergic guidance to "commit frequently" applies to humans
+  and fully-autonomous (YOLO/worktree) modes; in interactive sessions it is
+  overridden by the consent rules above.
+
+**Full Documentation**: [Git Interaction Policy](../../SA/top-level-gitlab-profile/docs/common/git-interaction-policy.md) (workspace checkout) — use the GitLab copy when working single-repo.
+
 ### Commit Messages
 - Use `[agent]` prefix in agentic mode
 - Do NOT include Claude Code attribution footer or emoji


### PR DESCRIPTION
Restores the canonical workspace Git Interaction policy that this repo's CLAUDE.md lost to drift, and extends it with two rules the canonical policy lacked.

## Changes

**CLAUDE.md** — new "Git Interaction Policy (agents)" section:
- `/quick-commit` / `/recursive-push` funnel; no direct `git add`/`commit`/`push` unless explicitly requested
- **Per-commit consent**: merge commits and plumbing (`commit-tree`/`update-ref`) included; consent never carries over from a plan, an earlier commit, or a previous merge
- **Merge-conflict scope**: "resolve the merge conflicts" authorizes resolution only — resolve, verify, report, then stop before the merge commit; a user-run `git merge` is not a request for an agent to act
- Tiered `git stash` policy (list/show OK; mutations need confirmation; pop/drop/clear/branch blocked)
- Notes the stigmergic "commit frequently" guidance is overridden by consent rules in interactive sessions

**AGENTS.md** — concise synced Git Interaction section, per the workspace CLAUDE.md/AGENTS.md sync requirement.

Matching upstream additions landed in `top-level-gitlab-profile` (CLAUDE.md, AGENTS.md, `docs/common/git-interaction-policy.md`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786648912&installation_id=145946300&pr_number=121&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F121&signature=bad0297abb0f48e46cf0dcb823012972d6f4bd531d49799ba3836fe8106ffb28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->