### PR TITLE
feat(fileio): NormalizerEnv injection bundle for the FS-agent bootstrap

### DIFF
--- a/rholang/src/rust/interpreter/io/injections.rs
+++ b/rholang/src/rust/interpreter/io/injections.rs
@@ -1,0 +1,277 @@
+//! `NormalizerEnv` bundles for the File I/O native primitives.
+//!
+//! The `rho:io:fs:native:1.0.0/*` URNs are filtered out of the
+//! runtime's shared `urn_map` (see
+//! `rho_runtime::is_internal_urn`), so user code can't bind them
+//! via `new x(URN)`. The genesis-time FS-agent deploy still
+//! needs a way to obtain the fixed-channel `Par` for each
+//! primitive so its Rholang can dispatch to the handlers. The
+//! per-deploy `NormalizerEnv` (a `HashMap<String, Par>` accepted
+//! by `Compiler::source_to_adt_with_normalizer_env` /
+//! `RhoRuntime::evaluate_with_env_and_phlo`) is that channel.
+//!
+//! During compilation the env is copied into every `new` node's
+//! `injections` `BTreeMap`. At `eval_new` time (`reduce.rs`),
+//! URNs that miss `urn_map` fall through to `new.injections` --
+//! meaning the fileio native URNs, which are absent from the
+//! former, are resolved from the latter. See
+//! `implementation-plan.md` §"Bootstrap path for the FS agent"
+//! for the full design.
+//!
+//! Injection values are the bare `GPrivate` `Par`s
+//! `FixedChannels::native_*()` returns. They are NOT
+//! bundle-wrapped: `eval_new`'s injection path
+//! (`reduce.rs:1297-1325`) accepts only `GUnforgeable` or
+//! `Expression` Pars and errors on `Bundle`. Bare unforgeable is
+//! the right authority level for the FS-agent, which owns the
+//! channel and never leaks the name; user code has no path to
+//! obtain the private name because the URN isn't in `urn_map`.
+
+use std::collections::HashMap;
+
+use models::rhoapi::Par;
+
+use crate::rust::interpreter::system_processes::FixedChannels;
+
+/// Return the `NormalizerEnv` bundle for the File I/O native
+/// primitives: the seventeen `rho:io:fs:native:1.0.0/*` URNs
+/// registered in `std_system_processes()`, each mapped to its
+/// fixed-channel `Par` (a `GUnforgeable::GPrivate` under the
+/// hood).
+///
+/// The FS-agent's genesis deploy passes this map (merged with
+/// whatever other genesis bindings it needs) to
+/// `Compiler::source_to_adt_with_normalizer_env` so its
+/// `new nOpen(`rho:io:fs:native:1.0.0/open`), ...` binding
+/// resolves at compile-into-`injections` time and at runtime via
+/// `eval_new`'s injection fallback.
+///
+/// Consumers must NOT publish this map on any user-reachable
+/// surface. Handing the map to user Rholang would immediately
+/// grant that Rholang unauthenticated arbitrary-host-FS
+/// authority.
+pub fn fileio_native_urns() -> HashMap<String, Par> {
+    let mut m = HashMap::with_capacity(17);
+    m.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/close".to_string(),
+        FixedChannels::native_close(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/read".to_string(),
+        FixedChannels::native_read(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/write".to_string(),
+        FixedChannels::native_write(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/seek".to_string(),
+        FixedChannels::native_seek(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/tell".to_string(),
+        FixedChannels::native_tell(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/size".to_string(),
+        FixedChannels::native_size(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/truncate".to_string(),
+        FixedChannels::native_truncate(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/flush".to_string(),
+        FixedChannels::native_flush(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/stat".to_string(),
+        FixedChannels::native_stat(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/entries".to_string(),
+        FixedChannels::native_entries(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/exists".to_string(),
+        FixedChannels::native_exists(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/rename".to_string(),
+        FixedChannels::native_rename(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/copyFile".to_string(),
+        FixedChannels::native_copy_file(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/removeFile".to_string(),
+        FixedChannels::native_remove_file(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/removeDir".to_string(),
+        FixedChannels::native_remove_dir(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/chmod".to_string(),
+        FixedChannels::native_chmod(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/quarantine".to_string(),
+        FixedChannels::native_quarantine(),
+    );
+    m.insert(
+        "rho:io:fs:native:1.0.0/chown".to_string(),
+        FixedChannels::native_chown(),
+    );
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use models::rhoapi::expr::ExprInstance;
+    use models::rhoapi::g_unforgeable::UnfInstance;
+
+    use super::*;
+    use crate::rust::interpreter::compiler::compiler::Compiler;
+
+    /// The bundle keys are the URN strings we register in
+    /// `std_system_processes()`. Any drift (e.g. renaming an
+    /// endpoint) needs a matching update here or the bundle
+    /// misses the URN and eval_new errors with "No value set for
+    /// {urn}" at runtime.
+    #[test]
+    fn bundle_covers_every_fileio_native_urn() {
+        let bundle = fileio_native_urns();
+        let expected: &[&str] = &[
+            "rho:io:fs:native:1.0.0/open",
+            "rho:io:fs:native:1.0.0/close",
+            "rho:io:fs:native:1.0.0/read",
+            "rho:io:fs:native:1.0.0/write",
+            "rho:io:fs:native:1.0.0/seek",
+            "rho:io:fs:native:1.0.0/tell",
+            "rho:io:fs:native:1.0.0/size",
+            "rho:io:fs:native:1.0.0/truncate",
+            "rho:io:fs:native:1.0.0/flush",
+            "rho:io:fs:native:1.0.0/stat",
+            "rho:io:fs:native:1.0.0/entries",
+            "rho:io:fs:native:1.0.0/exists",
+            "rho:io:fs:native:1.0.0/rename",
+            "rho:io:fs:native:1.0.0/copyFile",
+            "rho:io:fs:native:1.0.0/removeFile",
+            "rho:io:fs:native:1.0.0/removeDir",
+            "rho:io:fs:native:1.0.0/chmod",
+            "rho:io:fs:native:1.0.0/quarantine",
+            "rho:io:fs:native:1.0.0/chown",
+        ];
+        for urn in expected {
+            assert!(bundle.contains_key(*urn), "bundle missing {urn}");
+        }
+        assert_eq!(
+            bundle.len(),
+            expected.len(),
+            "bundle has {} entries, expected {}",
+            bundle.len(),
+            expected.len()
+        );
+    }
+
+    /// Each value is a Par carrying a single `GPrivate`
+    /// unforgeable, i.e. what `byte_name(N)` produces. That
+    /// shape is what `eval_new`'s injection path
+    /// (`reduce.rs:1297-1325`) recognizes via
+    /// `RhoUnforgeable::unapply`; any other shape (Bundle, list,
+    /// literal) would land in `Err("invalid injection")` at
+    /// runtime.
+    #[test]
+    fn every_value_is_a_bare_gprivate_unforgeable() {
+        let bundle = fileio_native_urns();
+        for (urn, par) in &bundle {
+            assert_eq!(
+                par.exprs.len(),
+                0,
+                "{urn}: injection Par should have no exprs"
+            );
+            assert_eq!(
+                par.unforgeables.len(),
+                1,
+                "{urn}: injection Par should have exactly one unforgeable"
+            );
+            let unf = &par.unforgeables[0];
+            assert!(
+                matches!(unf.unf_instance, Some(UnfInstance::GPrivateBody(_))),
+                "{urn}: injection unforgeable should be GPrivate, got {:?}",
+                unf.unf_instance
+            );
+        }
+    }
+
+    /// End-to-end plumbing check: compile a fragment that binds
+    /// one fileio URN with the bundle in the normalizer env, and
+    /// assert the resulting `New` node's `injections` BTreeMap
+    /// carries the URN mapped to the same fixed-channel Par we
+    /// injected. This is the exact hop the FS-agent's genesis
+    /// deploy will rely on at boot.
+    #[test]
+    fn injections_land_in_the_new_node_after_compilation() {
+        use models::rhoapi::New;
+
+        let bundle = fileio_native_urns();
+        let expected_par = bundle
+            .get("rho:io:fs:native:1.0.0/open")
+            .cloned()
+            .expect("bundle has open");
+
+        let src = "new nOpen(`rho:io:fs:native:1.0.0/open`) in { Nil }";
+        let par = Compiler::source_to_adt_with_normalizer_env(src, bundle)
+            .expect("compile with fileio injections");
+
+        // The compiled Par should have one `New` (or contain it
+        // nested; for this shape it's at the top level).
+        assert_eq!(
+            par.news.len(),
+            1,
+            "expected exactly one New at the top level"
+        );
+        let new_node: &New = &par.news[0];
+        let injected = new_node
+            .injections
+            .get("rho:io:fs:native:1.0.0/open")
+            .expect("injections should carry the fileio URN");
+        assert_eq!(
+            injected, &expected_par,
+            "injected Par should match the bundle's fixed-channel Par"
+        );
+    }
+
+    /// Negative twin of the above: compile the same fragment
+    /// with an empty env; the URN still ends up in the New's
+    /// `uri` list (compilation doesn't validate URN existence),
+    /// but the `injections` map has no entry for it. At runtime
+    /// this would produce `"No value set for {urn}"` from
+    /// `eval_new` -- documented here so a future caller who
+    /// forgets to pass the bundle understands the failure mode.
+    #[test]
+    fn empty_env_omits_the_url_from_injections() {
+        let src = "new nOpen(`rho:io:fs:native:1.0.0/open`) in { Nil }";
+        let par = Compiler::source_to_adt_with_normalizer_env(src, HashMap::new())
+            .expect("compile with empty env");
+        assert_eq!(par.news.len(), 1);
+        let new_node = &par.news[0];
+        assert!(new_node
+            .uri
+            .contains(&"rho:io:fs:native:1.0.0/open".to_string()));
+        assert!(
+            !new_node
+                .injections
+                .contains_key("rho:io:fs:native:1.0.0/open"),
+            "empty env should not populate injections"
+        );
+        // Silence unused-import warning under this test-arm-only path.
+        let _ = ExprInstance::GBool(true);
+    }
+}

--- a/rholang/src/rust/interpreter/io/injections.rs
+++ b/rholang/src/rust/interpreter/io/injections.rs
@@ -26,32 +26,40 @@
 //! the right authority level for the FS-agent, which owns the
 //! channel and never leaks the name; user code has no path to
 //! obtain the private name because the URN isn't in `urn_map`.
+//!
+//! # Visibility discipline
+//!
+//! `fileio_native_urns()` is `pub(crate)` on purpose: callers
+//! outside `rholang` must not obtain the raw bundle, since
+//! merging it into any user-reachable env would grant
+//! unauthenticated arbitrary-host-FS authority. The one
+//! legitimate consumer (the FS-agent's genesis deploy) goes
+//! through [`compile_fileio_genesis_source`], which merges the
+//! bundle in-crate and returns only the compiled `Par`. A
+//! downstream crate accidentally reaching for
+//! `injections::fileio_native_urns()` will then be a compile
+//! error, not a code-review invariant.
 
 use std::collections::HashMap;
 
 use models::rhoapi::Par;
 
+use crate::rust::interpreter::compiler::compiler::Compiler;
+use crate::rust::interpreter::errors::InterpreterError;
 use crate::rust::interpreter::system_processes::FixedChannels;
 
 /// Return the `NormalizerEnv` bundle for the File I/O native
-/// primitives: the seventeen `rho:io:fs:native:1.0.0/*` URNs
+/// primitives: the nineteen `rho:io:fs:native:1.0.0/*` URNs
 /// registered in `std_system_processes()`, each mapped to its
 /// fixed-channel `Par` (a `GUnforgeable::GPrivate` under the
 /// hood).
 ///
-/// The FS-agent's genesis deploy passes this map (merged with
-/// whatever other genesis bindings it needs) to
-/// `Compiler::source_to_adt_with_normalizer_env` so its
-/// `new nOpen(`rho:io:fs:native:1.0.0/open`), ...` binding
-/// resolves at compile-into-`injections` time and at runtime via
-/// `eval_new`'s injection fallback.
-///
-/// Consumers must NOT publish this map on any user-reachable
-/// surface. Handing the map to user Rholang would immediately
-/// grant that Rholang unauthenticated arbitrary-host-FS
-/// authority.
-pub fn fileio_native_urns() -> HashMap<String, Par> {
-    let mut m = HashMap::with_capacity(17);
+/// Kept `pub(crate)` -- external callers must go through
+/// [`compile_fileio_genesis_source`] so the raw bundle never
+/// crosses the crate boundary. See the module docstring's
+/// "Visibility discipline" section.
+pub(crate) fn fileio_native_urns() -> HashMap<String, Par> {
+    let mut m = HashMap::with_capacity(19);
     m.insert(
         "rho:io:fs:native:1.0.0/open".to_string(),
         FixedChannels::native_open(),
@@ -129,6 +137,37 @@ pub fn fileio_native_urns() -> HashMap<String, Par> {
         FixedChannels::native_chown(),
     );
     m
+}
+
+/// Compile the FS-agent's genesis Rholang source with the
+/// fileio-native URN bundle spliced into the normalizer env.
+/// The raw bundle is never returned; callers only see the
+/// compiled `Par`, which carries the fixed-channel `Par`s inside
+/// each `New` node's `injections` map where `eval_new` can
+/// resolve them but nothing else can name them.
+///
+/// `extra_env` lets the caller add its own bindings (e.g. the
+/// per-deploy `deployId`/`deployerId` pair from
+/// `normalizer_env_from_deploy`). Collisions with the fileio
+/// namespace are rejected -- the fileio URNs are a fixed
+/// vocabulary, so a caller attempting to shadow one is a
+/// programming error, not a legitimate override.
+pub fn compile_fileio_genesis_source(
+    source: &str,
+    extra_env: HashMap<String, Par>,
+) -> Result<Par, InterpreterError> {
+    let fileio_env = fileio_native_urns();
+    for k in extra_env.keys() {
+        if fileio_env.contains_key(k) {
+            return Err(InterpreterError::BugFoundError(format!(
+                "compile_fileio_genesis_source: extra_env shadows a fileio native URN ({})",
+                k
+            )));
+        }
+    }
+    let mut env = fileio_env;
+    env.extend(extra_env);
+    Compiler::source_to_adt_with_normalizer_env(source, env)
 }
 
 #[cfg(test)]
@@ -273,5 +312,66 @@ mod tests {
         );
         // Silence unused-import warning under this test-arm-only path.
         let _ = ExprInstance::GBool(true);
+    }
+
+    /// Wrapper happy-path: `compile_fileio_genesis_source` with
+    /// no extra env produces a Par whose top-level `New` carries
+    /// the fileio URN in `injections`.
+    #[test]
+    fn wrapper_compiles_fileio_source_and_injects_bundle() {
+        let src = "new nOpen(`rho:io:fs:native:1.0.0/open`) in { Nil }";
+        let par = compile_fileio_genesis_source(src, HashMap::new())
+            .expect("wrapper should compile with default fileio env");
+        assert_eq!(par.news.len(), 1);
+        let expected = FixedChannels::native_open();
+        let injected = par.news[0]
+            .injections
+            .get("rho:io:fs:native:1.0.0/open")
+            .expect("wrapper must inject fileio URN");
+        assert_eq!(injected, &expected);
+    }
+
+    /// Wrapper rejects any `extra_env` key that shadows a fileio
+    /// URN. Prevents a caller from swapping the FS-agent's channel
+    /// out from under itself (either accidentally or maliciously).
+    #[test]
+    fn wrapper_rejects_extra_env_shadowing_a_fileio_urn() {
+        let src = "new nOpen(`rho:io:fs:native:1.0.0/open`) in { Nil }";
+        let mut extra = HashMap::new();
+        extra.insert("rho:io:fs:native:1.0.0/open".to_string(), Par::default());
+        let err =
+            compile_fileio_genesis_source(src, extra).expect_err("collision should be rejected");
+        assert!(
+            format!("{:?}", err).contains("shadows a fileio native URN"),
+            "unexpected error: {:?}",
+            err
+        );
+    }
+
+    /// Wrapper merges caller-supplied env alongside the fileio
+    /// bundle: a non-colliding extra binding lands in the compiled
+    /// New's injections just like the fileio URNs.
+    #[test]
+    fn wrapper_preserves_non_colliding_extra_env() {
+        use models::rhoapi::g_unforgeable::UnfInstance;
+        use models::rhoapi::{GPrivate, GUnforgeable};
+
+        let extra_par = Par::default().with_unforgeables(vec![GUnforgeable {
+            unf_instance: Some(UnfInstance::GPrivateBody(GPrivate { id: vec![0xEE; 64] })),
+        }]);
+        let mut extra = HashMap::new();
+        extra.insert("rho:test:injection:custom".to_string(), extra_par.clone());
+
+        let src = r#"new nOpen(`rho:io:fs:native:1.0.0/open`),
+                          custom(`rho:test:injection:custom`) in { Nil }"#;
+        let par = compile_fileio_genesis_source(src, extra)
+            .expect("wrapper should compile with mixed env");
+        assert_eq!(par.news.len(), 1);
+        let injections = &par.news[0].injections;
+        assert!(injections.contains_key("rho:io:fs:native:1.0.0/open"));
+        assert_eq!(
+            injections.get("rho:test:injection:custom"),
+            Some(&extra_par)
+        );
     }
 }

--- a/rholang/src/rust/interpreter/io/mod.rs
+++ b/rholang/src/rust/interpreter/io/mod.rs
@@ -11,6 +11,7 @@
 //! per the FIP.
 
 pub mod handle_table;
+pub mod injections;
 pub mod mode;
 #[cfg(unix)]
 pub mod nss;

--- a/rholang/src/rust/interpreter/reduce.rs
+++ b/rholang/src/rust/interpreter/reduce.rs
@@ -1292,8 +1292,17 @@ impl DebruijnInterpreter {
 
             let add_urn = |new_env: &mut Env<Par>, urn: String| {
                 if !self.urn_map.contains_key(&urn) {
-                    // TODO: Injections (from normalizer) are not used currently, see [[NormalizerEnv]].
-                    // If `urn` can't be found in `urnMap`, it must be referencing an injection - OLD
+                    // URN missed the shared urn_map; fall through to
+                    // this deploy's per-New injections. Injections
+                    // are populated by the normalizer from the
+                    // `NormalizerEnv: HashMap<String, Par>` argument
+                    // to `Compiler::source_to_adt_with_normalizer_env`
+                    // (or equivalently `RhoRuntime::evaluate_with_env`).
+                    // The File I/O FS-agent's genesis deploy uses this
+                    // path to bind the `rho:io:fs:native:1.0.0/*` URNs
+                    // (which are deliberately hidden from `urn_map`)
+                    // to their fixed-channel Pars -- see
+                    // `crate::rust::interpreter::io::injections`.
                     match new.injections.get(&urn) {
                         Some(p) => {
                             if let Some(gunf) = RhoUnforgeable::unapply(p) {

--- a/rholang/tests/injection_runtime_spec.rs
+++ b/rholang/tests/injection_runtime_spec.rs
@@ -1,0 +1,138 @@
+//! Runtime-level negative tests for the `eval_new` injection path.
+//!
+//! The unit tests in `interpreter::io::injections` prove the
+//! compile-time shape: that the fileio bundle is copied into the
+//! `New` node's `injections` `BTreeMap`, and that an empty env
+//! leaves that map empty. The two tests below close the loop at
+//! the *runtime* end -- driving a real `RhoRuntimeImpl` through
+//! `evaluate_with_env` and confirming that:
+//!
+//! 1. A user-written `new x(`rho:io:fs:native:1.0.0/open`) in { ... }`
+//!    compiled with an empty env fails at `eval_new` with "No value
+//!    set for {urn}", because the URN is filtered out of `urn_map`
+//!    by `rho_runtime::is_internal_urn` and nothing populates
+//!    `new.injections` for it. This is the property the FS-agent's
+//!    ocap story leans on -- verified end-to-end here rather than
+//!    inferred from reading the filter + `reduce.rs`.
+//!
+//! 2. A `Bundle`-wrapped `Par` supplied via the injection env is
+//!    rejected at `eval_new` with "invalid injection". The
+//!    injection path (`reduce.rs:1297-1325`) only accepts
+//!    `GUnforgeable` or `Expression` shapes; anything else lands
+//!    in the fallback error branch. This is why
+//!    `fileio_native_urns()` must return bare `GPrivate` Pars, not
+//!    bundle-wrapped ones -- documented in the module docstring
+//!    but only implied by code inspection until now.
+
+use std::sync::Arc;
+
+use models::rhoapi::{BindPattern, Bundle, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::errors::InterpreterError;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::matcher::r#match::Matcher;
+use rholang::rust::interpreter::rho_runtime::{create_rho_runtime, RhoRuntime, RhoRuntimeImpl};
+use rspace_plus_plus::rspace::rspace::RSpace;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+const OPEN_URN: &str = "rho:io:fs:native:1.0.0/open";
+const OPEN_SRC: &str = "new nOpen(`rho:io:fs:native:1.0.0/open`) in { Nil }";
+
+async fn mk_runtime() -> RhoRuntimeImpl {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+    let space: RSpace<Par, BindPattern, ListParWithRandom, TaggedContinuation> =
+        RSpace::create(store, Arc::new(Box::new(Matcher))).unwrap();
+    create_rho_runtime(
+        space,
+        Arc::new(std::collections::HashMap::new()),
+        true,
+        &mut Vec::new(),
+        ExternalServices::noop(),
+    )
+    .await
+}
+
+fn error_text(errors: &[InterpreterError]) -> String {
+    errors
+        .iter()
+        .map(|e| format!("{:?}", e))
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// Compile succeeds (compilation doesn't validate URN existence),
+/// but at `eval_new` time the URN misses `urn_map` (filtered by
+/// `is_internal_urn`) *and* the empty env means `new.injections`
+/// has no fallback, so we get "No value set for
+/// rho:io:fs:native:1.0.0/open".
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn user_deploy_cannot_bind_hidden_fileio_urn_with_empty_env() {
+    let mut runtime = mk_runtime().await;
+    let outcome = runtime
+        .evaluate_with_env(OPEN_SRC, std::collections::HashMap::new())
+        .await;
+
+    match outcome {
+        Ok(eval_result) => {
+            assert!(
+                !eval_result.errors.is_empty(),
+                "expected eval to fail; got no errors"
+            );
+            let combined = error_text(&eval_result.errors);
+            assert!(
+                combined.contains(OPEN_URN) && combined.to_lowercase().contains("no value set"),
+                "expected 'No value set for {OPEN_URN}' in errors, got: {combined}"
+            );
+        }
+        Err(err) => {
+            let msg = format!("{:?}", err);
+            assert!(
+                msg.contains(OPEN_URN) && msg.to_lowercase().contains("no value set"),
+                "expected 'No value set for {OPEN_URN}' in top-level err, got: {msg}"
+            );
+        }
+    }
+}
+
+/// The injection path only accepts `GUnforgeable` or `Expression`
+/// Pars. A `Bundle` wrapper -- even one containing the correct
+/// fixed-channel Par -- is rejected. This test proves the
+/// docstring warning in `io/injections.rs` is enforced by the
+/// runtime, not just by code review.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bundle_wrapped_injection_is_rejected_at_runtime() {
+    use rholang::rust::interpreter::system_processes::FixedChannels;
+
+    let bundle_par = Par::default().with_bundles(vec![Bundle {
+        body: Some(FixedChannels::native_open()),
+        write_flag: true,
+        read_flag: false,
+    }]);
+    let mut env = std::collections::HashMap::new();
+    env.insert(OPEN_URN.to_string(), bundle_par);
+
+    let mut runtime = mk_runtime().await;
+    let outcome = runtime.evaluate_with_env(OPEN_SRC, env).await;
+
+    match outcome {
+        Ok(eval_result) => {
+            assert!(
+                !eval_result.errors.is_empty(),
+                "expected eval to fail on bundle injection; got no errors"
+            );
+            let combined = error_text(&eval_result.errors);
+            assert!(
+                combined.contains("invalid injection"),
+                "expected 'invalid injection' in errors, got: {combined}"
+            );
+        }
+        Err(err) => {
+            let msg = format!("{:?}", err);
+            assert!(
+                msg.contains("invalid injection"),
+                "expected 'invalid injection' in top-level err, got: {msg}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds `crate::interpreter::io::injections::fileio_native_urns()`, the `HashMap<String, Par>` that the FS-agent's genesis deploy will pass to `Compiler::source_to_adt_with_normalizer_env` to obtain the fixed-channel `Par`s for the 19 `rho:io:fs:native:1.0.0/*` URNs.

Why a bundle instead of extending `urn_map`: the fileio native URNs are deliberately hidden from the shared `urn_map` (see `rho_runtime::is_internal_urn`) so user code cannot bind them via `new x(URN)`. `NormalizerEnv` is the supported way to bind hidden URNs on a per-deploy basis — the env is copied into each `new` node's `injections` `BTreeMap` at normalization time, and `eval_new` falls back to injections when a URN misses `urn_map`.

Values are bare `GPrivate` unforgeables (what `FixedChannels::native_*()` returns) — **not** `Bundle`-wrapped. `eval_new`'s injection path (`reduce.rs:1297-1325`) only accepts `GUnforgeable` or `Expression` Pars; bare is the right authority level for the FS-agent, which owns the channel and never leaks the name.

## Changes

- `rholang/src/rust/interpreter/io/injections.rs` (new) — `fileio_native_urns()` returning 19 URN → `Par` bindings + 4 unit tests.
- `rholang/src/rust/interpreter/io/mod.rs` — `pub mod injections;`.
- `rholang/src/rust/interpreter/reduce.rs` — replaces the stale "Injections (from normalizer) are not used currently" TODO with an accurate comment explaining the injection path and the fileio use case.

## Tests

Four new tests in `io::injections`:

- **`bundle_covers_every_fileio_native_urn`** — asserts all 19 expected URNs are present and no extras. Drift-detection: if someone renames or drops a URN in `std_system_processes()` without updating the bundle, this fires before the FS-agent hits `"No value set for {urn}"` at runtime.
- **`every_value_is_a_bare_gprivate_unforgeable`** — each `Par` must have zero exprs, exactly one unforgeable, and that unforgeable must be `GPrivate`. Catches accidental `Bundle` wrapping or `Expression` shapes that `eval_new`'s injection path rejects.
- **`injections_land_in_the_new_node_after_compilation`** — end-to-end plumbing: compiles a fragment binding one fileio URN with the bundle in the env, asserts the resulting `New`'s `injections` `BTreeMap` carries the URN mapped to the same fixed-channel `Par` we injected. This is the exact hop the FS-agent's genesis deploy will rely on at boot.
- **`empty_env_omits_the_url_from_injections`** — negative twin: compiling with an empty env leaves the URN in the `New`'s `uri` list but nothing in `injections`, which at runtime produces `"No value set for {urn}"`. Documented here so a future caller who forgets to pass the bundle understands the failure mode.

## Test plan

- [x] `cargo build -p rholang` clean
- [x] `cargo test -p rholang --lib io::` — 34 pass (30 prior + 4 new)
- [x] `empty_state_hash_should_be_the_same_as_hard_coded_cached_value` passes (no genesis-contract changes)
- [x] `cargo fmt -p rholang` clean
- [x] Pre-push hook (workspace fmt/clippy/deny + full test matrix) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786910903&installation_id=145946300&pr_number=132&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F132&signature=fe91407815383b7cae3c0cd732723f3c51aa54dd51c22e0aefdc385c25fcbf9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->