### PR TITLE
fix(casper,node): complete PR #114 port — finalization scope, byte-bounded admission, DAG-width backpressure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,33 @@ Three crates have `build.rs` for protobuf code generation:
 - `rust-toolchain.toml` — nightly channel pin
 - `Cross.toml` — cross-compilation for amd64/arm64
 
+### Recommended Claude Code local settings
+Add to `.claude/settings.local.json` (personal, not committed) when working
+in this repo with Claude Code:
+
+```json
+{
+  "fileCheckpointingEnabled": false,
+  "env": {
+    "BASH_DEFAULT_TIMEOUT_MS": "1200000",
+    "BASH_MAX_TIMEOUT_MS": "1800000"
+  }
+}
+```
+
+- `fileCheckpointingEnabled: false` — Claude Code's checkpointing/rewind
+  feature runs `git stash` + `git reset --hard` against the workspace repo
+  around tool events, taking real `.git/index.lock` locks that collide with
+  concurrent git commands ("Unable to create index.lock"; see
+  anthropics/claude-code#68315). Disabling it trades away `/rewind` file
+  restore in this repo.
+- Bash timeouts raised to 20/30 min — the pre-push hook runs the full
+  release test suite for all 11 crates (~9 min, longer on cold caches),
+  which exceeds the default 10-minute window and gets a `git push` killed
+  mid-gate when run through Claude Code.
+
+Both settings take effect at the next session start.
+
 ## Network Ports
 | Port | Service |
 |------|---------|

--- a/casper/src/rust/api/block_api.rs
+++ b/casper/src/rust/api/block_api.rs
@@ -73,6 +73,9 @@ fn recoverable_propose_failure_message(status: &ProposeStatus) -> Option<String>
         ProposeStatus::Failure(ProposeFailure::NoNewDeploys) => {
             Some("No new deploys to propose.".to_string())
         }
+        ProposeStatus::Failure(ProposeFailure::RecoveryDeferred) => {
+            Some("Rejected deploy recovery deferred to selected leader.".to_string())
+        }
         ProposeStatus::Failure(ProposeFailure::CheckConstraintsFailure(
             CheckProposeConstraintsFailure::NotEnoughNewBlocks,
         )) => Some("No new blocks from peers yet; synchronize with network first.".to_string()),

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -25,6 +25,7 @@ use models::rust::casper::protocol::casper_message::{
 };
 use models::rust::validator::Validator;
 use prost::bytes::Bytes;
+use prost::Message;
 use rholang::rust::interpreter::system_processes::BlockData;
 use rspace_plus_plus::rspace::errors::HistoryError;
 use tracing;
@@ -62,6 +63,9 @@ pub struct PreparedUserDeploys {
     pub selected_in_scope_recovery_count: usize,
     pub selected_in_scope_recovery_sigs: HashSet<Bytes>,
     pub already_in_scope_count: usize,
+    pub selected_user_deploy_bytes: usize,
+    pub deferred_user_deploy_bytes: usize,
+    pub byte_cap_hit: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,6 +124,16 @@ struct FreshAdmissionFallback {
     backpressure: bool,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DeploySelection {
+    deploys: HashSet<Signed<DeployData>>,
+    strategy: &'static str,
+    selected_bytes: usize,
+    deferred_bytes: usize,
+    count_capped: bool,
+    byte_capped: bool,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct FinalityLagStats {
     dag_tip: i64,
@@ -136,6 +150,8 @@ struct FinalityLagStats {
 /// already in place.
 const DEPLOY_SELECTION_RESERVE_TAIL_ENABLED: bool = true;
 const ORDINARY_DEPLOY_PROPOSAL_CAP: usize = 128;
+const USER_DEPLOY_BYTE_PROPOSAL_BUDGET: usize = 2 * 1024 * 1024;
+const USER_DEPLOY_BACKPRESSURE_BYTE_PROPOSAL_BUDGET: usize = 512 * 1024;
 const RETRY_DEPLOY_REPROPOSAL_CAP: usize = 32;
 const NON_LEADER_FALLBACK_ORDINARY_DEPLOY_CAP: usize = 8;
 const NON_LEADER_FALLBACK_MIN_ORDINARY_DEPLOY_CAP: usize = 4;
@@ -167,40 +183,80 @@ fn ordered_user_deploys(deploys: &HashSet<Signed<DeployData>>) -> Vec<Signed<Dep
     ordered
 }
 
+#[cfg(test)]
 fn select_recovered_deploys_for_block(
     deploys: &HashSet<Signed<DeployData>>,
     _block_number: i64,
     cap: usize,
-) -> HashSet<Signed<DeployData>> {
-    let ordered = ordered_user_deploys(deploys);
-    if ordered.is_empty() || cap == 0 {
-        return HashSet::new();
-    }
-    ordered.into_iter().take(cap).collect()
+) -> DeploySelection {
+    select_deploys_for_block(deploys, cap, false, USER_DEPLOY_BYTE_PROPOSAL_BUDGET)
 }
 
-fn select_ordinary_deploys_for_block(
+fn deploy_encoded_len(deploy: &Signed<DeployData>) -> usize {
+    DeployData::to_proto(deploy.clone()).encoded_len()
+}
+
+fn select_deploys_for_block(
     deploys: &HashSet<Signed<DeployData>>,
     cap: usize,
     reserve_tail: bool,
-) -> (HashSet<Signed<DeployData>>, &'static str) {
+    byte_budget: usize,
+) -> DeploySelection {
+    let total_bytes: usize = deploys.iter().map(deploy_encoded_len).sum();
     let ordered = ordered_user_deploys(deploys);
-    if ordered.is_empty() || cap == 0 {
-        return (HashSet::new(), "none");
+    if ordered.is_empty() || cap == 0 || byte_budget == 0 {
+        return DeploySelection {
+            deploys: HashSet::new(),
+            strategy: "none",
+            selected_bytes: 0,
+            deferred_bytes: total_bytes,
+            count_capped: !ordered.is_empty(),
+            byte_capped: byte_budget == 0 && !ordered.is_empty(),
+        };
     }
-    if ordered.len() <= cap {
-        return (ordered.into_iter().collect(), "uncapped");
-    }
-    if reserve_tail && DEPLOY_SELECTION_RESERVE_TAIL_ENABLED && cap > 1 {
+    let count_capped = ordered.len() > cap;
+    let (candidates, strategy): (Vec<Signed<DeployData>>, &'static str) = if ordered.len() <= cap {
+        (ordered, "uncapped")
+    } else if reserve_tail && DEPLOY_SELECTION_RESERVE_TAIL_ENABLED && cap > 1 {
         let oldest_take = cap.saturating_sub(1);
-        let mut picked: HashSet<Signed<DeployData>> =
+        let mut candidates: Vec<Signed<DeployData>> =
             ordered.iter().take(oldest_take).cloned().collect();
-        if let Some(newest) = ordered.iter().last().cloned() {
-            picked.insert(newest);
-        }
-        (picked, "oldest-plus-newest")
+        candidates.extend(ordered.iter().last().cloned());
+        (candidates, "oldest-plus-newest")
     } else {
         (ordered.into_iter().take(cap).collect(), "oldest-only")
+    };
+    let mut selected = HashSet::new();
+    let mut selected_bytes = 0usize;
+    let mut byte_capped = false;
+    for deploy in candidates {
+        let deploy_bytes = deploy_encoded_len(&deploy);
+        let next_bytes = selected_bytes.saturating_add(deploy_bytes);
+        if next_bytes <= byte_budget || selected.is_empty() {
+            selected_bytes = next_bytes;
+            selected.insert(deploy);
+        } else {
+            byte_capped = true;
+        }
+    }
+    if selected_bytes > byte_budget {
+        byte_capped = true;
+    }
+    DeploySelection {
+        deploys: selected,
+        strategy,
+        selected_bytes,
+        deferred_bytes: total_bytes.saturating_sub(selected_bytes),
+        count_capped,
+        byte_capped,
+    }
+}
+
+fn user_deploy_byte_budget(admission_policy: DeployAdmissionPolicy) -> usize {
+    if admission_policy.backpressure {
+        USER_DEPLOY_BACKPRESSURE_BYTE_PROPOSAL_BUDGET
+    } else {
+        USER_DEPLOY_BYTE_PROPOSAL_BUDGET
     }
 }
 
@@ -627,46 +683,68 @@ async fn prepare_user_deploys_with_policy(
         HashSet::new()
     };
     let retry_candidate_count = retry_candidates.len();
-    let selected_retries = select_recovered_deploys_for_block(
+    let total_byte_budget = user_deploy_byte_budget(admission_policy);
+    let mut remaining_byte_budget = total_byte_budget;
+    let retry_selection = select_deploys_for_block(
         &retry_candidates,
-        block_number,
         RETRY_DEPLOY_REPROPOSAL_CAP,
+        false,
+        remaining_byte_budget,
     );
-    let retry_capped = retry_candidate_count > selected_retries.len();
+    remaining_byte_budget = remaining_byte_budget.saturating_sub(retry_selection.selected_bytes);
+    let retry_capped = retry_selection.count_capped || retry_selection.byte_capped;
     if retry_capped {
-        let deferred_retries = retry_candidate_count.saturating_sub(selected_retries.len());
+        let deferred_retries = retry_candidate_count.saturating_sub(retry_selection.deploys.len());
         tracing::info!(
             target: "f1r3fly.casper.recovery",
-            "Retry deploy selection capped for block #{}: selected={}, deferred={}, cap={}",
+            "Retry deploy selection capped for block #{}: selected={}, deferred={}, cap={}, selected_bytes={}, deferred_bytes={}, byte_budget={}",
             block_number,
-            selected_retries.len(),
+            retry_selection.deploys.len(),
             deferred_retries,
-            RETRY_DEPLOY_REPROPOSAL_CAP
+            RETRY_DEPLOY_REPROPOSAL_CAP,
+            retry_selection.selected_bytes,
+            retry_selection.deferred_bytes,
+            total_byte_budget
         );
     }
-    let (selected_ordinary, ordinary_selection_strategy) = select_ordinary_deploys_for_block(
+    let ordinary_selection = select_deploys_for_block(
         &ordinary_candidates,
         ordinary_cap,
         admission_policy.reserve_tail,
+        remaining_byte_budget,
     );
-    let ordinary_capped = ordinary_candidates.len() > selected_ordinary.len();
-    let (selected_in_scope_recovery, in_scope_recovery_selection_strategy) =
-        select_ordinary_deploys_for_block(
-            &in_scope_recovery_candidates,
-            in_scope_recovery_cap,
-            false,
-        );
+    remaining_byte_budget = remaining_byte_budget.saturating_sub(ordinary_selection.selected_bytes);
+    let ordinary_capped = ordinary_selection.count_capped || ordinary_selection.byte_capped;
+    let in_scope_recovery_selection = select_deploys_for_block(
+        &in_scope_recovery_candidates,
+        in_scope_recovery_cap,
+        false,
+        remaining_byte_budget,
+    );
     let in_scope_recovery_capped =
-        in_scope_recovery_candidates.len() > selected_in_scope_recovery.len();
+        in_scope_recovery_selection.count_capped || in_scope_recovery_selection.byte_capped;
+    let selected_in_scope_recovery = in_scope_recovery_selection.deploys;
     let selected_in_scope_recovery_sigs: HashSet<Bytes> = selected_in_scope_recovery
         .iter()
         .map(|deploy| deploy.sig.clone())
         .collect();
-    let selected: HashSet<Signed<DeployData>> = selected_retries
+    let selected: HashSet<Signed<DeployData>> = retry_selection
+        .deploys
         .into_iter()
-        .chain(selected_ordinary.into_iter())
+        .chain(ordinary_selection.deploys.into_iter())
         .chain(selected_in_scope_recovery.into_iter())
         .collect();
+    let selected_user_deploy_bytes = retry_selection
+        .selected_bytes
+        .saturating_add(ordinary_selection.selected_bytes)
+        .saturating_add(in_scope_recovery_selection.selected_bytes);
+    let deferred_user_deploy_bytes = retry_selection
+        .deferred_bytes
+        .saturating_add(ordinary_selection.deferred_bytes)
+        .saturating_add(in_scope_recovery_selection.deferred_bytes);
+    let byte_cap_hit = retry_selection.byte_capped
+        || ordinary_selection.byte_capped
+        || in_scope_recovery_selection.byte_capped;
     let selected_retry_count = selected
         .iter()
         .filter(|deploy| is_retry_candidate(deploy))
@@ -691,23 +769,43 @@ async fn prepare_user_deploys_with_policy(
     let cap_hit = retry_capped || ordinary_capped || in_scope_recovery_capped;
     if ordinary_capped {
         tracing::info!(
-            "Ordinary deploy selection capped for block #{}: selected={}, deferred={}, cap={}, strategy={}",
+            "Ordinary deploy selection capped for block #{}: selected={}, deferred={}, cap={}, strategy={}, selected_bytes={}, deferred_bytes={}, remaining_byte_budget={}",
             block_number,
             selected_ordinary_count,
             ordinary_candidates.len().saturating_sub(selected_ordinary_count),
             ordinary_cap,
-            ordinary_selection_strategy
+            ordinary_selection.strategy,
+            ordinary_selection.selected_bytes,
+            ordinary_selection.deferred_bytes,
+            total_byte_budget.saturating_sub(retry_selection.selected_bytes)
         );
     }
     if !selected_in_scope_recovery_sigs.is_empty() || in_scope_recovery_capped {
         tracing::info!(
             target: "f1r3fly.casper.recovery",
-            "In-scope deploy recovery selection for block #{}: selected={}, deferred={}, cap={}, strategy={}",
+            "In-scope deploy recovery selection for block #{}: selected={}, deferred={}, cap={}, strategy={}, selected_bytes={}, deferred_bytes={}, remaining_byte_budget={}",
             block_number,
             selected_in_scope_recovery_count,
             in_scope_recovery_candidates.len().saturating_sub(selected_in_scope_recovery_count),
             in_scope_recovery_cap,
-            in_scope_recovery_selection_strategy
+            in_scope_recovery_selection.strategy,
+            in_scope_recovery_selection.selected_bytes,
+            in_scope_recovery_selection.deferred_bytes,
+            total_byte_budget
+                .saturating_sub(retry_selection.selected_bytes)
+                .saturating_sub(ordinary_selection.selected_bytes)
+        );
+    }
+    if byte_cap_hit {
+        tracing::info!(
+            target: "f1r3fly.casper.recovery",
+            "Deploy selection byte budget capped block #{}: selected_bytes={}, deferred_bytes={}, byte_budget={}, selected={}, deferred={}",
+            block_number,
+            selected_user_deploy_bytes,
+            deferred_user_deploy_bytes,
+            total_byte_budget,
+            selected.len(),
+            deferred
         );
     }
 
@@ -862,9 +960,12 @@ async fn prepare_user_deploys_with_policy(
             cap_hit,
             ordinary_cap,
             in_scope_recovery_cap,
-            ordinary_strategy = ordinary_selection_strategy,
-            in_scope_recovery_strategy = in_scope_recovery_selection_strategy,
+            ordinary_strategy = ordinary_selection.strategy,
+            in_scope_recovery_strategy = in_scope_recovery_selection.strategy,
             deferred,
+            selected_user_deploy_bytes,
+            deferred_user_deploy_bytes,
+            byte_cap_hit,
             chosen = ?chosen,
             "merge.step: final deploy set chosen for block"
         );
@@ -879,6 +980,9 @@ async fn prepare_user_deploys_with_policy(
         selected_in_scope_recovery_count,
         selected_in_scope_recovery_sigs,
         already_in_scope_count,
+        selected_user_deploy_bytes,
+        deferred_user_deploy_bytes,
+        byte_cap_hit,
     })
 }
 
@@ -2096,7 +2200,9 @@ fn record_deploy_admission_metrics(
         BLOCK_CREATOR_DEPLOY_ADMISSION_ALREADY_IN_SCOPE_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_BACKPRESSURE_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_BLOCK_TIME_STALE_METRIC,
+        BLOCK_CREATOR_DEPLOY_ADMISSION_BYTE_CAP_HIT_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_DAG_TIP_METRIC,
+        BLOCK_CREATOR_DEPLOY_ADMISSION_DEFERRED_USER_BYTES_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_FALLBACK_CAP_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_FALLBACK_ENABLED_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_FRESH_LOCAL_METRIC,
@@ -2110,8 +2216,10 @@ fn record_deploy_admission_metrics(
         BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_IN_SCOPE_RECOVERY_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_ORDINARY_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_RETRY_METRIC,
+        BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_USER_BYTES_METRIC,
         BLOCK_CREATOR_DEPLOY_ADMISSION_SIGNATURE_STALE_METRIC,
-        BLOCK_CREATOR_DEPLOY_ADMISSION_STRANDED_IN_SCOPE_METRIC, CASPER_METRICS_SOURCE,
+        BLOCK_CREATOR_DEPLOY_ADMISSION_STRANDED_IN_SCOPE_METRIC,
+        BLOCK_CREATOR_DEPLOY_ADMISSION_USER_BYTE_BUDGET_METRIC, CASPER_METRICS_SOURCE,
     };
     let (progress_new_sigs, progress_recycled_sigs) = inclusion_progress
         .latest_deploy
@@ -2163,6 +2271,26 @@ fn record_deploy_admission_metrics(
         "source" => CASPER_METRICS_SOURCE
     )
     .set(prepared.selected_in_scope_recovery_count as f64);
+    metrics::gauge!(
+        BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_USER_BYTES_METRIC,
+        "source" => CASPER_METRICS_SOURCE
+    )
+    .set(prepared.selected_user_deploy_bytes as f64);
+    metrics::gauge!(
+        BLOCK_CREATOR_DEPLOY_ADMISSION_DEFERRED_USER_BYTES_METRIC,
+        "source" => CASPER_METRICS_SOURCE
+    )
+    .set(prepared.deferred_user_deploy_bytes as f64);
+    metrics::gauge!(
+        BLOCK_CREATOR_DEPLOY_ADMISSION_USER_BYTE_BUDGET_METRIC,
+        "source" => CASPER_METRICS_SOURCE
+    )
+    .set(user_deploy_byte_budget(admission_policy) as f64);
+    metrics::gauge!(
+        BLOCK_CREATOR_DEPLOY_ADMISSION_BYTE_CAP_HIT_METRIC,
+        "source" => CASPER_METRICS_SOURCE
+    )
+    .set(metric_bool(prepared.byte_cap_hit));
     metrics::gauge!(
         BLOCK_CREATOR_DEPLOY_ADMISSION_FALLBACK_ENABLED_METRIC,
         "source" => CASPER_METRICS_SOURCE
@@ -2257,8 +2385,9 @@ pub async fn create(
     use crate::rust::metrics_constants::{
         BLOCK_CREATOR_COMPUTE_DEPLOYS_CHECKPOINT_TIME_METRIC,
         BLOCK_CREATOR_COMPUTE_PARENTS_POST_STATE_TIME_METRIC,
-        BLOCK_CREATOR_PACKAGE_BLOCK_TIME_METRIC, BLOCK_CREATOR_PREPARE_USER_DEPLOYS_TIME_METRIC,
-        BLOCK_CREATOR_TOTAL_TIME_METRIC, CASPER_METRICS_SOURCE,
+        BLOCK_CREATOR_PACKAGE_BLOCK_TIME_METRIC, BLOCK_CREATOR_PACKED_BLOCK_BYTES_METRIC,
+        BLOCK_CREATOR_PREPARE_USER_DEPLOYS_TIME_METRIC, BLOCK_CREATOR_TOTAL_TIME_METRIC,
+        CASPER_METRICS_SOURCE,
     };
     let create_started = std::time::Instant::now();
     // Capture current time once to ensure consistency between deploy filtering and block timestamp.
@@ -2983,6 +3112,9 @@ pub async fn create(
     let sign_started = std::time::Instant::now();
     let signed_block = validator_identity.sign_block(&unsigned_block);
     let sign_ms = sign_started.elapsed().as_millis();
+    let signed_block_bytes = signed_block.to_proto().encoded_len();
+    metrics::gauge!(BLOCK_CREATOR_PACKED_BLOCK_BYTES_METRIC, "source" => CASPER_METRICS_SOURCE)
+        .set(signed_block_bytes as f64);
 
     let selected_user_deploys_for_buffer_drain: Vec<Signed<DeployData>> = ordered_user_deploys
         .iter()
@@ -3011,9 +3143,10 @@ pub async fn create(
 
     tracing::debug!(
         target: "f1r3fly.block_creator.timing",
-        "Block creator timing: package_ms={}, sign_ms={}, total_create_block_ms={}",
+        "Block creator timing: package_ms={}, sign_ms={}, packed_block_bytes={}, total_create_block_ms={}",
         package_ms,
         sign_ms,
+        signed_block_bytes,
         total_create_block_ms
     );
     metrics::histogram!(
@@ -4890,6 +5023,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ordinary_storage_selection_uses_byte_budget_for_large_stored_event_batches() {
+        let mut kvm = InMemoryStoreManager::new();
+        let deploy_storage = Arc::new(parking_lot::Mutex::new(
+            KeyValueDeployStorage::new(&mut kvm)
+                .await
+                .expect("deploy storage"),
+        ));
+        let rejected_deploy_buffer = Arc::new(Mutex::new(
+            KeyValueRejectedDeployBuffer::new(&mut kvm)
+                .await
+                .expect("rejected deploy buffer"),
+        ));
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let mut snapshot =
+            crate::rust::casper::test_helpers::TestCasperWithSnapshot::create_empty_snapshot();
+        snapshot
+            .on_chain_state
+            .shard_conf
+            .max_user_deploys_per_block = 128;
+        snapshot.on_chain_state.shard_conf.deploy_lifespan = 500;
+        let payload = "x".repeat(USER_DEPLOY_BYTE_PROPOSAL_BUDGET / 8);
+        let deploys: Vec<_> = (1..=40)
+            .map(|id| {
+                construct_deploy::source_deploy(
+                    format!("@\"{}{}\"!(Nil)", payload, id),
+                    1_000 + id as i64,
+                    None,
+                    None,
+                    None,
+                    Some(id as i64),
+                    Some("test".to_string()),
+                )
+                .expect("deploy")
+            })
+            .collect();
+
+        deploy_storage
+            .lock()
+            .add(deploys)
+            .expect("seed deploy storage");
+
+        let prepared = prepare_user_deploys_with_policy(
+            &snapshot,
+            300,
+            10_000,
+            deploy_storage,
+            rejected_deploy_buffer,
+            &block_store,
+            false,
+            DeployAdmissionPolicy {
+                allow_ordinary: true,
+                ordinary_cap: ORDINARY_DEPLOY_PROPOSAL_CAP,
+                allow_in_scope_recovery: false,
+                in_scope_recovery_cap: 0,
+                reserve_tail: false,
+                fallback: false,
+                backpressure: false,
+            },
+        )
+        .await
+        .expect("prepare deploys");
+
+        assert!(!prepared.deploys.is_empty());
+        assert!(prepared.deploys.len() < ORDINARY_DEPLOY_PROPOSAL_CAP);
+        assert!(prepared.byte_cap_hit);
+        assert!(prepared.cap_hit);
+        assert!(prepared.selected_user_deploy_bytes <= USER_DEPLOY_BYTE_PROPOSAL_BUDGET);
+        assert!(prepared.deferred_user_deploy_bytes > 0);
+    }
+
+    #[tokio::test]
     async fn fallback_ordinary_selection_uses_bounded_oldest_first_cap() {
         let mut kvm = InMemoryStoreManager::new();
         let deploy_storage = Arc::new(parking_lot::Mutex::new(
@@ -5573,8 +5779,36 @@ mod tests {
         let selected_a = select_recovered_deploys_for_block(&deploys, 10, 4);
         let selected_b = select_recovered_deploys_for_block(&deploys, 11, 4);
 
-        assert_eq!(selected_a.len(), 4);
-        assert_eq!(selected_a, selected_b);
+        assert_eq!(selected_a.deploys.len(), 4);
+        assert_eq!(selected_a.deploys, selected_b.deploys);
+    }
+
+    #[test]
+    fn byte_budget_still_selects_one_oversize_deploy() {
+        let deploy = construct_deploy::source_deploy(
+            format!(
+                "@\"{}\"!(Nil)",
+                "x".repeat(USER_DEPLOY_BYTE_PROPOSAL_BUDGET + 1)
+            ),
+            1_000,
+            None,
+            None,
+            None,
+            Some(1),
+            Some("test".to_string()),
+        )
+        .expect("deploy");
+        let deploys = HashSet::from([deploy]);
+        let selected = select_deploys_for_block(
+            &deploys,
+            ORDINARY_DEPLOY_PROPOSAL_CAP,
+            false,
+            USER_DEPLOY_BYTE_PROPOSAL_BUDGET,
+        );
+
+        assert_eq!(selected.deploys.len(), 1);
+        assert!(selected.selected_bytes > USER_DEPLOY_BYTE_PROPOSAL_BUDGET);
+        assert!(selected.byte_capped);
     }
 
     #[tokio::test]

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -5,9 +5,7 @@
 //
 // See casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
 
-#[cfg(test)]
-use std::collections::HashMap;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
@@ -193,7 +191,7 @@ fn select_recovered_deploys_for_block(
 }
 
 fn deploy_encoded_len(deploy: &Signed<DeployData>) -> usize {
-    DeployData::to_proto(deploy.clone()).encoded_len()
+    DeployData::to_proto_ref(deploy).encoded_len()
 }
 
 fn select_deploys_for_block(
@@ -202,7 +200,13 @@ fn select_deploys_for_block(
     reserve_tail: bool,
     byte_budget: usize,
 ) -> DeploySelection {
-    let total_bytes: usize = deploys.iter().map(deploy_encoded_len).sum();
+    // One proto encoding per deploy per selection call: sizes are computed
+    // here and reused for both the total and the budget loop below.
+    let sizes: HashMap<Bytes, usize> = deploys
+        .iter()
+        .map(|d| (d.sig.clone(), deploy_encoded_len(d)))
+        .collect();
+    let total_bytes: usize = sizes.values().sum();
     let ordered = ordered_user_deploys(deploys);
     if ordered.is_empty() || cap == 0 || byte_budget == 0 {
         return DeploySelection {
@@ -210,7 +214,7 @@ fn select_deploys_for_block(
             strategy: "none",
             selected_bytes: 0,
             deferred_bytes: total_bytes,
-            count_capped: !ordered.is_empty(),
+            count_capped: cap == 0 && !ordered.is_empty(),
             byte_capped: byte_budget == 0 && !ordered.is_empty(),
         };
     }
@@ -229,8 +233,14 @@ fn select_deploys_for_block(
     let mut selected = HashSet::new();
     let mut selected_bytes = 0usize;
     let mut byte_capped = false;
+    // Skip-and-continue is starvation-free, not just best-effort packing: a
+    // budget-skipped deploy keeps its position in the (valid_after, timestamp,
+    // sig) order while everything ahead of it gets selected, included, and
+    // removed from storage — new deploys always sort behind it — so it
+    // strictly advances to the front, where the `selected.is_empty()`
+    // carve-out admits it alone even when it alone exceeds the budget.
     for deploy in candidates {
-        let deploy_bytes = deploy_encoded_len(&deploy);
+        let deploy_bytes = sizes.get(&deploy.sig).copied().unwrap_or_default();
         let next_bytes = selected_bytes.saturating_add(deploy_bytes);
         if next_bytes <= byte_budget || selected.is_empty() {
             selected_bytes = next_bytes;
@@ -1949,6 +1959,22 @@ fn in_scope_local_deploy_stats(
     })
 }
 
+/// Admission-time recoverability check: does the rejected-deploy buffer hold
+/// at least one deploy worth re-proposing from THIS proposer's perspective?
+///
+/// Deliberately NOT the same filter as
+/// `snapshot::local_rejected_buffer_has_recoverable_deploys` — that twin runs
+/// inside `compute_snapshot`, before the snapshot's `deploys_in_scope` /
+/// `rejected_in_scope` sets exist, so it can only approximate with the
+/// block-number window. This copy runs after snapshot completion and refines
+/// with the scope sets (clean-in-scope deploys excluded; rejected-in-scope
+/// deploys keep recovery eligibility past the window). Disagreements are
+/// benign by construction: the snapshot copy only drives the parent-narrowing
+/// heuristic, never admission. Do NOT "harmonize" the filters.
+///
+/// Cost: O(1) when the buffer is empty (the common steady state); otherwise
+/// one canonical-won scan bounded below by `scan_floor` (never deeper than
+/// the deploy-lifespan window).
 fn rejected_buffer_has_recoverable_deploys(
     casper_snapshot: &CasperSnapshot,
     block_number: i64,
@@ -1956,10 +1982,15 @@ fn rejected_buffer_has_recoverable_deploys(
     rejected_deploy_buffer: &Arc<Mutex<KeyValueRejectedDeployBuffer>>,
     block_store: &KeyValueBlockStore,
 ) -> Result<bool, CasperError> {
-    let buffered_deploys = rejected_deploy_buffer
-        .lock()
-        .map_err(|e| CasperError::LockError(e.to_string()))?
-        .read_all()?;
+    let buffered_deploys = {
+        let buffer_guard = rejected_deploy_buffer
+            .lock()
+            .map_err(|e| CasperError::LockError(e.to_string()))?;
+        if !buffer_guard.non_empty()? {
+            return Ok(false);
+        }
+        buffer_guard.read_all()?
+    };
     if buffered_deploys.is_empty() {
         return Ok(false);
     }

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -322,6 +322,35 @@ async fn prepare_user_deploys_with_policy(
         } else {
             HashSet::new()
         };
+    let parent_hashes: Vec<BlockHash> = casper_snapshot
+        .parents
+        .iter()
+        .map(|p| p.block_hash.clone())
+        .collect();
+    let earliest_block_number =
+        block_number - casper_snapshot.on_chain_state.shard_conf.deploy_lifespan;
+    let expired_buffered: Vec<Signed<DeployData>> = buffered_deploys
+        .iter()
+        .filter(|deploy| deploy.data.is_expired_at(current_time_millis))
+        .cloned()
+        .collect();
+    if !expired_buffered.is_empty() {
+        tracing::info!(
+            target: "f1r3fly.casper.recovery",
+            "Removing {} expired rejected-buffer deploy(s) from storage and rejected-deploy buffer",
+            expired_buffered.len()
+        );
+        deploy_storage_guard.remove(expired_buffered.clone())?;
+        rejected_deploy_buffer
+            .lock()
+            .map_err(|e| CasperError::LockError(e.to_string()))?
+            .remove(expired_buffered.clone())?;
+        let expired_sigs: HashSet<Bytes> = expired_buffered
+            .into_iter()
+            .map(|deploy| deploy.sig)
+            .collect();
+        buffered_deploys.retain(|deploy| !expired_sigs.contains(&deploy.sig));
+    }
     let mut buffered_sigs: HashSet<Bytes> =
         buffered_deploys.iter().map(|d| d.sig.clone()).collect();
 
@@ -341,13 +370,6 @@ async fn prepare_user_deploys_with_policy(
         );
     }
 
-    let parent_hashes: Vec<BlockHash> = casper_snapshot
-        .parents
-        .iter()
-        .map(|p| p.block_hash.clone())
-        .collect();
-    let earliest_block_number =
-        block_number - casper_snapshot.on_chain_state.shard_conf.deploy_lifespan;
     let buffer_scan_floor = buffered_deploys
         .iter()
         .map(|d| d.data.valid_after_block_number)
@@ -1823,6 +1845,56 @@ fn in_scope_local_deploy_stats(
     })
 }
 
+fn rejected_buffer_has_recoverable_deploys(
+    casper_snapshot: &CasperSnapshot,
+    block_number: i64,
+    current_time_millis: i64,
+    rejected_deploy_buffer: &Arc<Mutex<KeyValueRejectedDeployBuffer>>,
+    block_store: &KeyValueBlockStore,
+) -> Result<bool, CasperError> {
+    let buffered_deploys = rejected_deploy_buffer
+        .lock()
+        .map_err(|e| CasperError::LockError(e.to_string()))?
+        .read_all()?;
+    if buffered_deploys.is_empty() {
+        return Ok(false);
+    }
+    let parent_hashes: Vec<BlockHash> = casper_snapshot
+        .parents
+        .iter()
+        .map(|p| p.block_hash.clone())
+        .collect();
+    let earliest_block_number =
+        block_number - casper_snapshot.on_chain_state.shard_conf.deploy_lifespan;
+    let candidates: Vec<_> = buffered_deploys
+        .iter()
+        .filter(|deploy| {
+            let rejected_in_scope = casper_snapshot.rejected_in_scope.contains(&deploy.sig);
+            let clean_in_scope =
+                casper_snapshot.deploys_in_scope.contains(&deploy.sig) && !rejected_in_scope;
+            !clean_in_scope
+                && not_future_deploy(block_number, &deploy.data)
+                && !deploy.data.is_expired_at(current_time_millis)
+                && (rejected_in_scope || not_expired_deploy(earliest_block_number, &deploy.data))
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Ok(false);
+    }
+    let scan_floor = candidates
+        .iter()
+        .map(|d| d.data.valid_after_block_number)
+        .min()
+        .map(|h| h.min(earliest_block_number))
+        .unwrap_or(earliest_block_number);
+    let canonical_won =
+        interpreter_util::canonical_won_sigs(block_store, &parent_hashes, scan_floor)?;
+
+    Ok(candidates
+        .iter()
+        .any(|deploy| !canonical_won.contains(&deploy.sig)))
+}
+
 fn should_skip_empty_recovery_heartbeat(
     suppress_empty_recovery_block_by_non_leader: bool,
     user_work_in_flight: bool,
@@ -2344,14 +2416,13 @@ pub async fn create(
             in_scope_local_stats,
             finality_lag_stats,
         );
-        let rejected_buffer_non_empty = {
-            let buffer_guard = rejected_deploy_buffer
-                .lock()
-                .map_err(|e| CasperError::LockError(e.to_string()))?;
-            buffer_guard
-                .non_empty()
-                .map_err(CasperError::KvStoreError)?
-        };
+        let rejected_buffer_non_empty = rejected_buffer_has_recoverable_deploys(
+            casper_snapshot,
+            next_block_num,
+            now_millis,
+            &rejected_deploy_buffer,
+            block_store,
+        )?;
         let admission_policy = ordinary_admission_policy(
             casper_snapshot,
             rejected_buffer_non_empty,
@@ -2641,7 +2712,7 @@ pub async fn create(
                 target: "f1r3fly.casper.recovery",
                 "Skipping empty recovery-context block creation: rejected deploy recovery is deferred to validator-set leader"
             );
-            return Ok(BlockCreatorResult::NoNewDeploys);
+            return Ok(BlockCreatorResult::RecoveryDeferred);
         }
         if !allow_empty_blocks {
             tracing::info!(
@@ -4607,6 +4678,156 @@ mod tests {
             .deploys
             .iter()
             .any(|deploy| deploy.sig == buffered.sig));
+    }
+
+    #[tokio::test]
+    async fn rejected_buffer_backlog_requires_selectable_deploy() {
+        let mut kvm = InMemoryStoreManager::new();
+        let rejected_deploy_buffer = Arc::new(Mutex::new(
+            KeyValueRejectedDeployBuffer::new(&mut kvm)
+                .await
+                .expect("rejected deploy buffer"),
+        ));
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let mut snapshot =
+            crate::rust::casper::test_helpers::TestCasperWithSnapshot::create_empty_snapshot();
+        snapshot.on_chain_state.shard_conf.deploy_lifespan = 50;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_millis() as i64;
+        let mut expired = construct_deploy::source_deploy_now(
+            "@expired-buffer!(0)".to_string(),
+            None,
+            Some(10),
+            Some("test".to_string()),
+        )
+        .expect("expired deploy");
+        expired.data.expiration_timestamp = Some(now - 1);
+        let old = construct_deploy::source_deploy_now(
+            "@old-buffer!(0)".to_string(),
+            None,
+            Some(-40),
+            Some("test".to_string()),
+        )
+        .expect("old deploy");
+        let future = construct_deploy::source_deploy_now(
+            "@future-buffer!(0)".to_string(),
+            None,
+            Some(20),
+            Some("test".to_string()),
+        )
+        .expect("future deploy");
+        rejected_deploy_buffer
+            .lock()
+            .expect("rejected buffer lock")
+            .add(vec![expired, old, future])
+            .expect("seed rejected buffer");
+
+        assert!(!rejected_buffer_has_recoverable_deploys(
+            &snapshot,
+            20,
+            now,
+            &rejected_deploy_buffer,
+            &block_store
+        )
+        .expect("check unselectable buffer"));
+
+        let fresh = construct_deploy::source_deploy_now(
+            "@fresh-buffer!(0)".to_string(),
+            None,
+            Some(19),
+            Some("test".to_string()),
+        )
+        .expect("fresh deploy");
+        rejected_deploy_buffer
+            .lock()
+            .expect("rejected buffer lock")
+            .add(vec![fresh])
+            .expect("seed fresh buffer");
+
+        assert!(rejected_buffer_has_recoverable_deploys(
+            &snapshot,
+            20,
+            now,
+            &rejected_deploy_buffer,
+            &block_store
+        )
+        .expect("check selectable buffer"));
+    }
+
+    #[tokio::test]
+    async fn prepare_user_deploys_purges_expired_rejected_buffer_entries() {
+        let mut kvm = InMemoryStoreManager::new();
+        let deploy_storage = Arc::new(parking_lot::Mutex::new(
+            KeyValueDeployStorage::new(&mut kvm)
+                .await
+                .expect("deploy storage"),
+        ));
+        let rejected_deploy_buffer = Arc::new(Mutex::new(
+            KeyValueRejectedDeployBuffer::new(&mut kvm)
+                .await
+                .expect("rejected deploy buffer"),
+        ));
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let mut snapshot =
+            crate::rust::casper::test_helpers::TestCasperWithSnapshot::create_empty_snapshot();
+        snapshot
+            .on_chain_state
+            .shard_conf
+            .max_user_deploys_per_block = 10;
+        snapshot.on_chain_state.shard_conf.deploy_lifespan = 50;
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_millis() as i64;
+        let mut expired = construct_deploy::source_deploy_now(
+            "@expired-purge!(0)".to_string(),
+            None,
+            Some(10),
+            Some("test".to_string()),
+        )
+        .expect("expired deploy");
+        expired.data.expiration_timestamp = Some(now - 1);
+        deploy_storage
+            .lock()
+            .add(vec![expired.clone()])
+            .expect("seed deploy storage");
+        rejected_deploy_buffer
+            .lock()
+            .expect("rejected buffer lock")
+            .add(vec![expired.clone()])
+            .expect("seed rejected buffer");
+
+        let prepared = prepare_user_deploys(
+            &snapshot,
+            20,
+            now,
+            deploy_storage.clone(),
+            rejected_deploy_buffer.clone(),
+            &block_store,
+            true,
+            true,
+        )
+        .await
+        .expect("prepare deploys");
+
+        assert!(prepared.deploys.is_empty());
+        assert!(!deploy_storage
+            .lock()
+            .read_all()
+            .expect("read storage")
+            .iter()
+            .any(|deploy| deploy.sig == expired.sig));
+        assert!(!rejected_deploy_buffer
+            .lock()
+            .expect("rejected buffer lock")
+            .contains_sig(&expired.sig)
+            .expect("buffer contains"));
     }
 
     #[tokio::test]

--- a/casper/src/rust/blocks/proposer/propose_result.rs
+++ b/casper/src/rust/blocks/proposer/propose_result.rs
@@ -34,6 +34,7 @@ pub struct ProposeSuccess {
 #[derive(Debug, Clone)]
 pub enum ProposeFailure {
     NoNewDeploys,
+    RecoveryDeferred,
     InternalDeployError,
     BugError,
     CheckConstraintsFailure(CheckProposeConstraintsFailure),
@@ -58,6 +59,7 @@ pub enum CheckProposeConstraintsFailure {
 #[derive(Debug, Clone)]
 pub enum BlockCreatorResult {
     NoNewDeploys,
+    RecoveryDeferred,
     /// The created block together with the pre- and post-state hashes that were computed
     /// during `compute_deploys_checkpoint`. Carrying these hashes avoids re-running the
     /// expensive checkpoint replay during self-validation.
@@ -137,10 +139,19 @@ impl ProposeResult {
             ProposeStatus::Failure(ProposeFailure::NoNewDeploys)
         )
     }
+
+    pub fn is_recovery_deferred(&self) -> bool {
+        matches!(
+            self.propose_status,
+            ProposeStatus::Failure(ProposeFailure::RecoveryDeferred)
+        )
+    }
 }
 
 impl BlockCreatorResult {
     pub fn no_new_deploys() -> Self { BlockCreatorResult::NoNewDeploys }
+
+    pub fn recovery_deferred() -> Self { BlockCreatorResult::RecoveryDeferred }
 
     pub fn created(b: BlockMessage, pre_state_hash: Bytes, post_state_hash: Bytes) -> Self {
         BlockCreatorResult::Created(b, pre_state_hash, post_state_hash)
@@ -153,6 +164,7 @@ impl fmt::Display for ProposeStatus {
             ProposeStatus::Success(r) => write!(f, "Propose succeed: {:?}", r.result),
             ProposeStatus::Failure(failure) => match failure {
                 ProposeFailure::NoNewDeploys => write!(f, "Proposal failed: NoNewDeploys. No unprocessed deploys in pool. If you just deployed, the deploy may have already been included by the auto-proposer."),
+                ProposeFailure::RecoveryDeferred => write!(f, "Proposal deferred: rejected deploy recovery is waiting for the selected leader"),
                 ProposeFailure::InternalDeployError => {
                     write!(f, "Proposal failed: internal deploy error")
                 }

--- a/casper/src/rust/blocks/proposer/proposer.rs
+++ b/casper/src/rust/blocks/proposer/proposer.rs
@@ -214,6 +214,10 @@ where
                     BlockCreatorResult::NoNewDeploys => {
                         Ok((ProposeResult::failure(ProposeFailure::NoNewDeploys), None))
                     }
+                    BlockCreatorResult::RecoveryDeferred => Ok((
+                        ProposeResult::failure(ProposeFailure::RecoveryDeferred),
+                        None,
+                    )),
                     BlockCreatorResult::Created(block, pre_state_hash, post_state_hash) => {
                         // Publish BlockCreated event immediately after block is created (before validation)
                         self.propose_effect_handler.publish_block_created(&block)?;

--- a/casper/src/rust/casper_conf.rs
+++ b/casper/src/rust/casper_conf.rs
@@ -382,6 +382,12 @@ pub struct HeartbeatAdvancedConf {
         default = "default_deploy_recovery_max_lag"
     )]
     pub deploy_recovery_max_lag: i64,
+    #[serde(
+        rename = "empty-frontier-max-unfinalized-blocks",
+        deserialize_with = "de_non_negative_i64",
+        default = "default_empty_frontier_max_unfinalized_blocks"
+    )]
+    pub empty_frontier_max_unfinalized_blocks: i64,
 }
 
 impl Default for HeartbeatAdvancedConf {
@@ -390,6 +396,7 @@ impl Default for HeartbeatAdvancedConf {
             frontier_chase_max_lag: default_frontier_chase_max_lag(),
             pending_deploy_max_lag: default_pending_deploy_max_lag(),
             deploy_recovery_max_lag: default_deploy_recovery_max_lag(),
+            empty_frontier_max_unfinalized_blocks: default_empty_frontier_max_unfinalized_blocks(),
         }
     }
 }
@@ -399,6 +406,8 @@ fn default_frontier_chase_max_lag() -> i64 { 0 }
 fn default_pending_deploy_max_lag() -> i64 { 20 }
 
 fn default_deploy_recovery_max_lag() -> i64 { 64 }
+
+fn default_empty_frontier_max_unfinalized_blocks() -> i64 { 64 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FinalizerConf {

--- a/casper/src/rust/engine/multi_parent_casper/snapshot.rs
+++ b/casper/src/rust/engine/multi_parent_casper/snapshot.rs
@@ -188,6 +188,12 @@ fn prefer_deploy_support_main_parent(
     Ok(reordered)
 }
 
+/// Collapse the parent set to a single deploy-free parent that DAG-covers
+/// every other candidate. No tip content is lost: covering means every other
+/// parent is already in the candidate's ancestry, so their effects are in its
+/// post-state and "merging" them would be the degenerate ancestor-merge case.
+/// Sibling tips that do not cover each other are always kept (`covers_all`
+/// fails), so genuine multi-parent merges are unaffected.
 fn prune_dag_covered_parents(
     dag: &KeyValueDagRepresentation,
     parents: Vec<BlockMessage>,
@@ -251,6 +257,18 @@ fn candidate_scope_has_rejected_deploys(
     Ok(false)
 }
 
+/// Snapshot-time approximation of buffer recoverability, used only to decide
+/// whether `compute_snapshot` enters a recovery context (which narrows parent
+/// selection). Runs BEFORE the snapshot's `deploys_in_scope` /
+/// `rejected_in_scope` sets exist, so it can only filter by the block-number
+/// window and wall-clock expiry — it is deliberately coarser than its
+/// admission-time twin, `block_creator::rejected_buffer_has_recoverable_deploys`,
+/// which refines the same tail (canonical-won exclusion) with the completed
+/// snapshot's scope sets. Disagreements are benign: true-here/false-there
+/// costs one narrowed-parent propose that then declines recovery;
+/// false-here/true-there skips the narrowing heuristic while recovery still
+/// admits at block creation. Do NOT "harmonize" the filters — this one cannot
+/// use fields that do not exist yet.
 fn local_rejected_buffer_has_recoverable_deploys(
     block_store: &KeyValueBlockStore,
     rejected_deploy_buffer: &Arc<Mutex<KeyValueRejectedDeployBuffer>>,
@@ -263,6 +281,9 @@ fn local_rejected_buffer_has_recoverable_deploys(
         let buffer_guard = rejected_deploy_buffer
             .lock()
             .map_err(|err| CasperError::LockError(err.to_string()))?;
+        if !buffer_guard.non_empty().map_err(CasperError::from)? {
+            return Ok(false);
+        }
         buffer_guard.read_all().map_err(CasperError::from)?
     };
     if buffered_deploys.is_empty() {

--- a/casper/src/rust/engine/multi_parent_casper/snapshot.rs
+++ b/casper/src/rust/engine/multi_parent_casper/snapshot.rs
@@ -7,15 +7,18 @@
 //! module while the trait method is a one-line delegate in `traits.rs`.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
 
 use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
+use block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer;
 use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use comm::rust::transport::transport_layer::TransportLayer;
+use crypto::rust::signatures::signed::Signed;
 use models::rust::block_hash::BlockHash;
 use models::rust::block_metadata::BlockMetadata;
 use models::rust::casper::pretty_printer::PrettyPrinter;
-use models::rust::casper::protocol::casper_message::{BlockMessage, Justification};
+use models::rust::casper::protocol::casper_message::{BlockMessage, DeployData, Justification};
 use models::rust::validator::Validator;
 use prost::bytes::Bytes;
 use shared::rust::dag::dag_ops;
@@ -29,6 +32,7 @@ use crate::rust::metrics_constants::{
     DEPLOYS_IN_SCOPE_SIG_BYTES_ESTIMATE_METRIC, DEPLOYS_IN_SCOPE_SIZE_METRIC,
 };
 use crate::rust::util::proto_util;
+use crate::rust::util::rholang::interpreter_util;
 
 /// C15 / Smell-1: byte-size estimate for a secp256k1 compact-encoded
 /// deploy signature. ~64 bytes signature + 1 byte prefix. Used to
@@ -212,6 +216,50 @@ fn candidate_scope_has_rejected_deploys(
     Ok(false)
 }
 
+fn local_rejected_buffer_has_recoverable_deploys(
+    block_store: &KeyValueBlockStore,
+    rejected_deploy_buffer: &Arc<Mutex<KeyValueRejectedDeployBuffer>>,
+    parent_hashes: &[BlockHash],
+    current_block_number: i64,
+    current_time_millis: i64,
+    deploy_lifespan: i64,
+) -> Result<bool, CasperError> {
+    let buffered_deploys: HashSet<Signed<DeployData>> = {
+        let buffer_guard = rejected_deploy_buffer
+            .lock()
+            .map_err(|err| CasperError::LockError(err.to_string()))?;
+        buffer_guard.read_all().map_err(CasperError::from)?
+    };
+    if buffered_deploys.is_empty() {
+        return Ok(false);
+    }
+
+    let earliest_block_number = current_block_number - deploy_lifespan;
+    let candidates: Vec<_> = buffered_deploys
+        .iter()
+        .filter(|deploy| {
+            deploy.data.valid_after_block_number < current_block_number
+                && deploy.data.valid_after_block_number > earliest_block_number
+                && !deploy.data.is_expired_at(current_time_millis)
+        })
+        .collect();
+    if candidates.is_empty() {
+        return Ok(false);
+    }
+    let scan_floor = candidates
+        .iter()
+        .map(|deploy| deploy.data.valid_after_block_number)
+        .min()
+        .map(|height| height.min(earliest_block_number))
+        .unwrap_or(earliest_block_number);
+    let canonical_won =
+        interpreter_util::canonical_won_sigs(block_store, parent_hashes, scan_floor)?;
+
+    Ok(candidates
+        .iter()
+        .any(|deploy| !canonical_won.contains(&deploy.sig)))
+}
+
 fn deploy_scope_cache_key_matches(
     cached_generation: u64,
     cached_lfb: &BlockHash,
@@ -336,14 +384,15 @@ pub(crate) async fn compute_snapshot<T: TransportLayer + Send + Sync>(
         &dag.last_finalized_block(),
     )?;
 
-    let rejected_deploys_in_candidate_scope = if sorted_parents_list.is_empty() {
-        false
+    let (rejected_deploys_in_candidate_scope, recovery_backlog) = if sorted_parents_list.is_empty()
+    {
+        (false, false)
     } else {
         let sorted_parent_hashes: Vec<BlockHash> = sorted_parents_list
             .iter()
             .map(|block| block.block_hash.clone())
             .collect();
-        let sorted_parent_metas = dag.lookups_unsafe(sorted_parent_hashes)?;
+        let sorted_parent_metas = dag.lookups_unsafe(sorted_parent_hashes.clone())?;
         let candidate_block_number = proto_util::max_block_number_metadata(&sorted_parent_metas)
             .checked_add(1)
             .ok_or_else(|| {
@@ -351,21 +400,32 @@ pub(crate) async fn compute_snapshot<T: TransportLayer + Send + Sync>(
                     "candidate max_block_num overflow while checking recovery context".to_string(),
                 )
             })?;
-        candidate_scope_has_rejected_deploys(
+        let rejected_deploys_in_candidate_scope = candidate_scope_has_rejected_deploys(
             &dag,
             &this.block_store,
             sorted_parent_metas,
             candidate_block_number,
             this.casper_shard_conf.deploy_lifespan,
-        )?
-    };
-
-    let recovery_backlog = {
-        let buffer_guard = this
-            .rejected_deploy_buffer
-            .lock()
-            .map_err(|err| CasperError::LockError(err.to_string()))?;
-        buffer_guard.non_empty().map_err(CasperError::from)?
+        )?;
+        let now_u128 = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(CasperError::from)?
+            .as_millis();
+        let now_millis = i64::try_from(now_u128).map_err(|_| {
+            CasperError::RuntimeError(format!(
+                "Current timestamp millis {} exceeds i64::MAX",
+                now_u128
+            ))
+        })?;
+        let recovery_backlog = local_rejected_buffer_has_recoverable_deploys(
+            &this.block_store,
+            &this.rejected_deploy_buffer,
+            &sorted_parent_hashes,
+            candidate_block_number,
+            now_millis,
+            this.casper_shard_conf.deploy_lifespan,
+        )?;
+        (rejected_deploys_in_candidate_scope, recovery_backlog)
     };
     let recovery_context = recovery_backlog || rejected_deploys_in_candidate_scope;
 
@@ -727,9 +787,13 @@ pub(crate) async fn get_on_chain_state<T: TransportLayer + Send + Sync>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::SystemTime;
+
     use block_storage::rust::dag::block_dag_key_value_storage::{
         BlockDagKeyValueStorage, InsertMode,
     };
+    use block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer;
     use block_storage::rust::key_value_block_store::KeyValueBlockStore;
     use models::rust::block_implicits;
     use models::rust::casper::protocol::casper_message::{ProcessedDeploy, RejectedDeploy};
@@ -737,7 +801,7 @@ mod tests {
 
     use super::{
         candidate_scope_has_rejected_deploys, deploy_scope_cache_key_matches,
-        prefer_deploy_support_main_parent,
+        local_rejected_buffer_has_recoverable_deploys, prefer_deploy_support_main_parent,
     };
 
     #[test]
@@ -770,6 +834,141 @@ mod tests {
             &lfb,
             &[parent_b, parent_a]
         ));
+    }
+
+    #[tokio::test]
+    async fn local_rejected_backlog_requires_selectable_deploy() {
+        let mut kvm = InMemoryStoreManager::new();
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let rejected_deploy_buffer = Arc::new(Mutex::new(
+            KeyValueRejectedDeployBuffer::new(&mut kvm)
+                .await
+                .expect("rejected deploy buffer"),
+        ));
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_millis() as i64;
+        let mut expired = crate::rust::util::construct_deploy::source_deploy_now(
+            "@expired!(0)".to_string(),
+            None,
+            Some(10),
+            Some("test".to_string()),
+        )
+        .expect("expired deploy");
+        expired.data.expiration_timestamp = Some(now - 1);
+        let old = crate::rust::util::construct_deploy::source_deploy_now(
+            "@old!(0)".to_string(),
+            None,
+            Some(-40),
+            Some("test".to_string()),
+        )
+        .expect("old deploy");
+        let future = crate::rust::util::construct_deploy::source_deploy_now(
+            "@future!(0)".to_string(),
+            None,
+            Some(20),
+            Some("test".to_string()),
+        )
+        .expect("future deploy");
+        rejected_deploy_buffer
+            .lock()
+            .expect("buffer lock")
+            .add(vec![expired, old, future])
+            .expect("seed buffer");
+
+        assert!(!local_rejected_buffer_has_recoverable_deploys(
+            &block_store,
+            &rejected_deploy_buffer,
+            &[],
+            20,
+            now,
+            50
+        )
+        .expect("check unselectable backlog"));
+
+        let fresh = crate::rust::util::construct_deploy::source_deploy_now(
+            "@fresh!(0)".to_string(),
+            None,
+            Some(19),
+            Some("test".to_string()),
+        )
+        .expect("fresh deploy");
+        rejected_deploy_buffer
+            .lock()
+            .expect("buffer lock")
+            .add(vec![fresh])
+            .expect("seed fresh");
+
+        assert!(local_rejected_buffer_has_recoverable_deploys(
+            &block_store,
+            &rejected_deploy_buffer,
+            &[],
+            20,
+            now,
+            50
+        )
+        .expect("check selectable backlog"));
+    }
+
+    #[tokio::test]
+    async fn local_rejected_backlog_ignores_canonical_wins() {
+        let mut kvm = InMemoryStoreManager::new();
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let rejected_deploy_buffer = Arc::new(Mutex::new(
+            KeyValueRejectedDeployBuffer::new(&mut kvm)
+                .await
+                .expect("rejected deploy buffer"),
+        ));
+        let canonical = crate::rust::util::construct_deploy::source_deploy_now(
+            "@canonical!(0)".to_string(),
+            None,
+            Some(10),
+            Some("test".to_string()),
+        )
+        .expect("canonical deploy");
+        let parent = block_implicits::get_random_block(
+            Some(19),
+            Some(19),
+            None,
+            None,
+            None,
+            None,
+            Some(19),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(vec![ProcessedDeploy::empty(canonical.clone())]),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        block_store
+            .put_block_message(&parent)
+            .expect("store parent");
+        rejected_deploy_buffer
+            .lock()
+            .expect("buffer lock")
+            .add(vec![canonical])
+            .expect("seed buffer");
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_millis() as i64;
+
+        assert!(!local_rejected_buffer_has_recoverable_deploys(
+            &block_store,
+            &rejected_deploy_buffer,
+            std::slice::from_ref(&parent.block_hash),
+            20,
+            now,
+            50
+        )
+        .expect("check canonical backlog"));
     }
 
     #[tokio::test]

--- a/casper/src/rust/engine/multi_parent_casper/snapshot.rs
+++ b/casper/src/rust/engine/multi_parent_casper/snapshot.rs
@@ -188,6 +188,41 @@ fn prefer_deploy_support_main_parent(
     Ok(reordered)
 }
 
+fn prune_dag_covered_parents(
+    dag: &KeyValueDagRepresentation,
+    parents: Vec<BlockMessage>,
+) -> Result<Vec<BlockMessage>, CasperError> {
+    if parents.len() <= 1 {
+        return Ok(parents);
+    }
+
+    for (idx, candidate) in parents.iter().enumerate() {
+        if !candidate.body.deploys.is_empty() {
+            continue;
+        }
+        let mut covers_all = true;
+        for (other_idx, other) in parents.iter().enumerate() {
+            if idx == other_idx {
+                continue;
+            }
+            if !dag.is_dag_ancestor(&other.block_hash, &candidate.block_hash)? {
+                covers_all = false;
+                break;
+            }
+        }
+        if covers_all {
+            tracing::info!(
+                target: "f1r3fly.casper.parent_selection",
+                original_parents = parents.len(),
+                pruned_parents = 1,
+                "Parent selection collapsed to DAG-covering parent"
+            );
+            return Ok(vec![candidate.clone()]);
+        }
+    }
+    Ok(parents)
+}
+
 fn candidate_scope_has_rejected_deploys(
     dag: &KeyValueDagRepresentation,
     block_store: &KeyValueBlockStore,
@@ -446,10 +481,11 @@ pub(crate) async fn compute_snapshot<T: TransportLayer + Send + Sync>(
     };
 
     let unfiltered_parents_count = unfiltered_parents.len();
+    let compacted_parents = prune_dag_covered_parents(&dag, unfiltered_parents)?;
 
     // C15 / Smell-3: shared wire-convention constant — see
     // `crate::rust::casper::UNLIMITED_PARENTS`.
-    let mut parents_after_count_limit = unfiltered_parents;
+    let mut parents_after_count_limit = compacted_parents;
     if this.casper_shard_conf.max_number_of_parents != crate::rust::casper::UNLIMITED_PARENTS {
         parents_after_count_limit.truncate(this.casper_shard_conf.max_number_of_parents as usize);
     }
@@ -802,6 +838,7 @@ mod tests {
     use super::{
         candidate_scope_has_rejected_deploys, deploy_scope_cache_key_matches,
         local_rejected_buffer_has_recoverable_deploys, prefer_deploy_support_main_parent,
+        prune_dag_covered_parents,
     };
 
     #[test]
@@ -834,6 +871,144 @@ mod tests {
             &lfb,
             &[parent_b, parent_a]
         ));
+    }
+
+    #[tokio::test]
+    async fn parent_selection_prunes_dag_covered_parents() {
+        let mut kvm = InMemoryStoreManager::new();
+        let dag_storage = BlockDagKeyValueStorage::new(&mut kvm)
+            .await
+            .expect("dag storage");
+
+        let genesis = block_implicits::get_random_block(
+            Some(0),
+            Some(0),
+            None,
+            None,
+            None,
+            None,
+            Some(0),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        let left = block_implicits::get_random_block(
+            Some(1),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Some(1),
+            Some(vec![genesis.block_hash.clone()]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        let right = block_implicits::get_random_block(
+            Some(1),
+            Some(2),
+            None,
+            None,
+            None,
+            None,
+            Some(1),
+            Some(vec![genesis.block_hash.clone()]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        let seal = block_implicits::get_random_block(
+            Some(2),
+            Some(3),
+            None,
+            None,
+            None,
+            None,
+            Some(2),
+            Some(vec![left.block_hash.clone(), right.block_hash.clone()]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        let left_child = block_implicits::get_random_block(
+            Some(3),
+            Some(4),
+            None,
+            None,
+            None,
+            None,
+            Some(3),
+            Some(vec![seal.block_hash.clone()]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+        let right_child = block_implicits::get_random_block(
+            Some(3),
+            Some(5),
+            None,
+            None,
+            None,
+            None,
+            Some(3),
+            Some(vec![seal.block_hash.clone()]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            None,
+            Some("test".to_string()),
+            None,
+        );
+
+        dag_storage
+            .insert(&genesis, InsertMode::Approved)
+            .expect("insert genesis");
+        for block in [&left, &right, &seal, &left_child, &right_child] {
+            dag_storage
+                .insert(block, InsertMode::Normal)
+                .expect("insert block");
+        }
+
+        let dag = dag_storage.get_representation().expect("dag");
+        let pruned =
+            prune_dag_covered_parents(&dag, vec![left.clone(), seal.clone(), right.clone()])
+                .expect("prune parents");
+        assert_eq!(pruned.len(), 1);
+        assert_eq!(pruned[0].block_hash, seal.block_hash);
+
+        let siblings = prune_dag_covered_parents(&dag, vec![left.clone(), right.clone()])
+            .expect("keep siblings");
+        assert_eq!(
+            siblings
+                .iter()
+                .map(|block| block.block_hash.clone())
+                .collect::<Vec<_>>(),
+            vec![left.block_hash, right.block_hash]
+        );
+
+        let diverged_from_seal =
+            prune_dag_covered_parents(&dag, vec![left_child.clone(), right_child.clone(), seal])
+                .expect("keep common anchor without single covering parent");
+        assert_eq!(diverged_from_seal.len(), 3);
+        assert_eq!(diverged_from_seal[0].block_hash, left_child.block_hash);
+        assert_eq!(diverged_from_seal[1].block_hash, right_child.block_hash);
     }
 
     #[tokio::test]

--- a/casper/src/rust/metrics_constants.rs
+++ b/casper/src/rust/metrics_constants.rs
@@ -193,6 +193,7 @@ pub const BLOCK_CREATOR_COMPUTE_PARENTS_POST_STATE_TIME_METRIC: &str =
 pub const BLOCK_CREATOR_COMPUTE_DEPLOYS_CHECKPOINT_TIME_METRIC: &str =
     "block-creator.compute-deploys-checkpoint.time";
 pub const BLOCK_CREATOR_PACKAGE_BLOCK_TIME_METRIC: &str = "block-creator.package-block.time";
+pub const BLOCK_CREATOR_PACKED_BLOCK_BYTES_METRIC: &str = "block-creator.packed-block.bytes";
 pub const BLOCK_CREATOR_TOTAL_TIME_METRIC: &str = "block-creator.total.time";
 pub const BLOCK_CREATOR_DEPLOY_ADMISSION_FRESH_LOCAL_METRIC: &str =
     "block-creator.deploy-admission.fresh-local";
@@ -212,6 +213,14 @@ pub const BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_RETRY_METRIC: &str =
     "block-creator.deploy-admission.selected-retry";
 pub const BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_IN_SCOPE_RECOVERY_METRIC: &str =
     "block-creator.deploy-admission.selected-in-scope-recovery";
+pub const BLOCK_CREATOR_DEPLOY_ADMISSION_SELECTED_USER_BYTES_METRIC: &str =
+    "block-creator.deploy-admission.selected-user-bytes";
+pub const BLOCK_CREATOR_DEPLOY_ADMISSION_DEFERRED_USER_BYTES_METRIC: &str =
+    "block-creator.deploy-admission.deferred-user-bytes";
+pub const BLOCK_CREATOR_DEPLOY_ADMISSION_USER_BYTE_BUDGET_METRIC: &str =
+    "block-creator.deploy-admission.user-byte-budget";
+pub const BLOCK_CREATOR_DEPLOY_ADMISSION_BYTE_CAP_HIT_METRIC: &str =
+    "block-creator.deploy-admission.byte-cap-hit";
 pub const BLOCK_CREATOR_DEPLOY_ADMISSION_FALLBACK_ENABLED_METRIC: &str =
     "block-creator.deploy-admission.fallback-enabled";
 pub const BLOCK_CREATOR_DEPLOY_ADMISSION_FALLBACK_CAP_METRIC: &str =

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -881,15 +881,16 @@ pub async fn compute_parents_post_state(
         // such system deploys are not mergeable, so take them from one of the parents.
         _ => {
             let cache_lookup_started = std::time::Instant::now();
-            // Fast path: if one parent is descendant of all others, its post-state already
-            // includes all effects from the remaining parents and we can skip DAG merge.
             for candidate in &parents {
+                if !candidate.body.deploys.is_empty() {
+                    continue;
+                }
                 let covers_all = parents
                     .iter()
                     .filter(|p| p.block_hash != candidate.block_hash)
                     .all(|p| {
                         s.dag
-                            .is_in_main_chain(&p.block_hash, &candidate.block_hash)
+                            .is_dag_ancestor(&p.block_hash, &candidate.block_hash)
                             .unwrap_or(false)
                     });
                 if covers_all {

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -881,10 +881,13 @@ pub async fn compute_parents_post_state(
         // such system deploys are not mergeable, so take them from one of the parents.
         _ => {
             let cache_lookup_started = std::time::Instant::now();
+            // A parent that DAG-covers every other parent already carries their
+            // effects in its post-state, deploys included — merging a block with
+            // its own ancestors is degenerate (the merger assumes siblings), so
+            // the covering parent short-circuits regardless of deploy content.
+            // (Port note: 6981b37a's empty-deploys guard is deliberately NOT
+            // taken — it re-exposed ancestor-merges on linear chains here.)
             for candidate in &parents {
-                if !candidate.body.deploys.is_empty() {
-                    continue;
-                }
                 let covers_all = parents
                     .iter()
                     .filter(|p| p.block_hash != candidate.block_hash)

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -64,6 +64,19 @@ pub fn canonical_rejected_sigs(
     canonical_disposition_sigs(block_store, parents, earliest_block_number, false)
 }
 
+fn block_in_floor_merge_scope(
+    dag: &KeyValueDagRepresentation,
+    hash: &BlockHash,
+    floor_hash: &BlockHash,
+    floor_block_number: i64,
+) -> Result<bool, CasperError> {
+    let meta = dag.lookup_unsafe(hash)?;
+    if meta.block_number > floor_block_number {
+        return Ok(true);
+    }
+    Ok(!dag.is_dag_ancestor(hash, floor_hash)?)
+}
+
 fn canonical_disposition_sigs(
     block_store: &KeyValueBlockStore,
     parents: &[BlockHash],
@@ -1034,14 +1047,8 @@ pub async fn compute_parents_post_state(
 
             let include_visible_ancestor =
                 |hash: &BlockHash, dag: &KeyValueDagRepresentation| -> bool {
-                    match dag.lookup(hash) {
-                        Ok(Some(meta)) => {
-                            meta.block_number >= floor_block_number
-                                || !dag.is_in_main_chain(hash, &floor_hash).unwrap_or(false)
-                        }
-                        Ok(None) => false,
-                        Err(_) => false,
-                    }
+                    block_in_floor_merge_scope(dag, hash, &floor_hash, floor_block_number)
+                        .unwrap_or(false)
                 };
             // Get all ancestors of all parents (including the parents themselves)
             // Use bounded traversal that stops once the floor's represented past is reached.
@@ -1065,9 +1072,7 @@ pub async fn compute_parents_post_state(
                 .collect();
             let flatten_visible_ms = flatten_visible_started.elapsed().as_millis();
 
-            // Scope visible_blocks to blocks not represented by the floor
-            // main chain. Height alone is insufficient because a below-floor
-            // co-parent branch can be finalized outside the floor's main-parent spine.
+            // Scope visible_blocks to blocks not represented by the floor.
             let pre_filter_count = visible_blocks.len();
             let pre_filter_blocks: Option<Vec<BlockHash>> = if tracing::enabled!(target: "f1r3fly.merge.step", tracing::Level::DEBUG)
             {
@@ -1075,12 +1080,9 @@ pub async fn compute_parents_post_state(
             } else {
                 None
             };
-            visible_blocks.retain(|bh| match s.dag.lookup_unsafe(bh) {
-                Ok(meta) => {
-                    meta.block_number >= floor_block_number
-                        || !s.dag.is_in_main_chain(bh, &floor_hash).unwrap_or(false)
-                }
-                Err(_) => true, // keep on lookup error (conservative)
+            visible_blocks.retain(|bh| {
+                block_in_floor_merge_scope(&s.dag, bh, &floor_hash, floor_block_number)
+                    .unwrap_or(true)
             });
             if tracing::enabled!(target: "f1r3fly.merge.step", tracing::Level::DEBUG) {
                 let dropped: Vec<String> = match &pre_filter_blocks {
@@ -1483,14 +1485,19 @@ mod backstop_tests {
         BlockDagKeyValueStorage, InsertMode,
     };
     use block_storage::rust::key_value_block_store::KeyValueBlockStore;
+    use crypto::rust::signatures::secp256k1::Secp256k1;
+    use crypto::rust::signatures::signatures_alg::SignaturesAlg;
+    use models::rust::block_hash::BlockHash;
     use models::rust::block_implicits;
-    use models::rust::casper::protocol::casper_message::{ProcessedDeploy, RejectedDeploy};
+    use models::rust::casper::protocol::casper_message::{
+        BlockMessage, ProcessedDeploy, RejectedDeploy,
+    };
     use prost::bytes::Bytes;
     use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
 
     use super::{
-        canonical_won_sigs, merge_scope_backstop_exceeded, rejected_sig_has_visible_non_source_win,
-        retain_pending_rejected_deploys_for_buffer,
+        block_in_floor_merge_scope, canonical_won_sigs, merge_scope_backstop_exceeded,
+        rejected_sig_has_visible_non_source_win, retain_pending_rejected_deploys_for_buffer,
         suppress_rejected_pairs_with_later_visible_rejection, visible_rejected_deploy_sigs,
         MAX_FLOOR_DISTANCE_BLOCKS,
     };
@@ -1518,6 +1525,111 @@ mod backstop_tests {
         let below = merge_scope_backstop_exceeded(MAX_FLOOR_DISTANCE_BLOCKS);
         let above = merge_scope_backstop_exceeded(MAX_FLOOR_DISTANCE_BLOCKS + 1);
         assert!(!below && above);
+    }
+
+    fn scope_test_block(
+        block_number: i64,
+        seq_num: i32,
+        sender: Bytes,
+        parents: Vec<BlockHash>,
+    ) -> BlockMessage {
+        block_implicits::get_random_block(
+            Some(block_number),
+            Some(seq_num),
+            None,
+            None,
+            Some(sender),
+            Some(1),
+            Some(0),
+            Some(parents),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some("root".to_string()),
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn floor_scope_drops_finalized_off_main_dag_ancestors() {
+        let mut kvm = InMemoryStoreManager::new();
+        let dag_storage = BlockDagKeyValueStorage::new(&mut kvm)
+            .await
+            .expect("dag storage");
+        let secp = Secp256k1;
+        let (_, v1_pk) = secp.new_key_pair();
+        let (_, v2_pk) = secp.new_key_pair();
+        let (_, v3_pk) = secp.new_key_pair();
+        let v1 = v1_pk.bytes;
+        let v2 = v2_pk.bytes;
+        let v3 = v3_pk.bytes;
+        let genesis = scope_test_block(0, 0, v1.clone(), Vec::new());
+        let main = scope_test_block(1, 1, v1.clone(), vec![genesis.block_hash.clone()]);
+        let off_main = scope_test_block(1, 1, v2.clone(), vec![genesis.block_hash.clone()]);
+        let floor = scope_test_block(2, 2, v1.clone(), vec![
+            main.block_hash.clone(),
+            off_main.block_hash.clone(),
+        ]);
+        let outside = scope_test_block(1, 1, v3.clone(), vec![genesis.block_hash.clone()]);
+        let outside_same_height =
+            scope_test_block(2, 2, v3.clone(), vec![outside.block_hash.clone()]);
+        let descendant = scope_test_block(3, 3, v1, vec![floor.block_hash.clone()]);
+
+        for (block, mode) in [
+            (&genesis, InsertMode::Approved),
+            (&main, InsertMode::Normal),
+            (&off_main, InsertMode::Normal),
+            (&floor, InsertMode::Normal),
+            (&outside, InsertMode::Normal),
+            (&outside_same_height, InsertMode::Normal),
+            (&descendant, InsertMode::Normal),
+        ] {
+            dag_storage.insert(block, mode).expect("insert block");
+        }
+        dag_storage
+            .record_directly_finalized(floor.block_hash.clone(), 1.0, |_| async { Ok(()) })
+            .await
+            .expect("record floor finalized");
+        let dag = dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let floor_block_number = dag
+            .lookup_unsafe(&floor.block_hash)
+            .expect("floor metadata")
+            .block_number;
+
+        assert!(dag.is_finalized(&off_main.block_hash));
+        assert!(!dag
+            .is_in_main_chain(&off_main.block_hash, &floor.block_hash)
+            .expect("main-chain query"));
+        assert!(dag
+            .is_dag_ancestor(&off_main.block_hash, &floor.block_hash)
+            .expect("dag ancestor query"));
+
+        let mut visible_blocks: HashSet<_> = [
+            genesis.block_hash.clone(),
+            main.block_hash.clone(),
+            off_main.block_hash.clone(),
+            floor.block_hash.clone(),
+            outside.block_hash.clone(),
+            outside_same_height.block_hash.clone(),
+            descendant.block_hash.clone(),
+        ]
+        .into_iter()
+        .collect();
+        visible_blocks.retain(|hash| {
+            block_in_floor_merge_scope(&dag, hash, &floor.block_hash, floor_block_number)
+                .expect("scope predicate")
+        });
+
+        assert!(!visible_blocks.contains(&genesis.block_hash));
+        assert!(!visible_blocks.contains(&main.block_hash));
+        assert!(!visible_blocks.contains(&off_main.block_hash));
+        assert!(!visible_blocks.contains(&floor.block_hash));
+        assert!(visible_blocks.contains(&outside.block_hash));
+        assert!(visible_blocks.contains(&outside_same_height.block_hash));
+        assert!(visible_blocks.contains(&descendant.block_hash));
     }
 
     #[tokio::test]

--- a/casper/tests/compute_parents_post_state_regression_spec.rs
+++ b/casper/tests/compute_parents_post_state_regression_spec.rs
@@ -10,19 +10,19 @@ use casper::rust::errors::CasperError;
 use casper::rust::genesis::contracts::proof_of_stake::ProofOfStake;
 use casper::rust::genesis::contracts::validator::Validator as GenesisValidator;
 use casper::rust::genesis::genesis::Genesis;
-use casper::rust::util::proto_util;
 use casper::rust::util::rholang::interpreter_util::{
     compute_deploys_checkpoint, compute_parents_post_state,
 };
 use casper::rust::util::rholang::runtime_manager::RuntimeManager;
 use casper::rust::util::rholang::system_deploy_enum::SystemDeployEnum;
+use casper::rust::util::{construct_deploy, proto_util};
 use crypto::rust::signatures::secp256k1::Secp256k1;
 use crypto::rust::signatures::signatures_alg::SignaturesAlg;
 use dashmap::DashSet;
 use models::rust::block::state_hash::StateHash;
 use models::rust::block_hash::BlockHash;
 use models::rust::block_implicits;
-use models::rust::casper::protocol::casper_message::{BlockMessage, Bond};
+use models::rust::casper::protocol::casper_message::{BlockMessage, Bond, ProcessedDeploy};
 use models::rust::validator::Validator;
 use prost::bytes::Bytes;
 use rholang::rust::interpreter::external_services::ExternalServices;
@@ -380,6 +380,260 @@ async fn run_compute_parents_post_state_finalized_skew_regression() {
     assert_eq!(
         rejected_without_skew, rejected_with_skew,
         "Rejected deploy set should be invariant to finalized-set skew for the same parent set."
+    );
+}
+
+#[test]
+fn compute_parents_post_state_should_fast_path_when_parent_dag_covers_secondary_parent() {
+    let stack_bytes = std::env::var("F1R3_COMPUTE_PARENTS_REGRESSION_STACK_BYTES")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(64 * 1024 * 1024);
+
+    let handle = std::thread::Builder::new()
+        .name("compute-parents-secondary-parent-merge".to_string())
+        .stack_size(stack_bytes)
+        .spawn(|| {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to build Tokio runtime");
+            runtime.block_on(run_compute_parents_dag_cover_fast_path_regression());
+        })
+        .expect("Failed to spawn regression test thread");
+
+    handle
+        .join()
+        .expect("Regression test thread panicked before completing");
+}
+
+async fn run_compute_parents_dag_cover_fast_path_regression() {
+    let secp = Secp256k1;
+    let (_validator_sk, validator_pk) = secp.new_key_pair();
+    let validator: Bytes = validator_pk.bytes.clone();
+    let shard_name = "test-shard".to_string();
+
+    let mut kvm = InMemoryStoreManager::new();
+    let mut block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+        .await
+        .expect("Failed to create block store");
+    let dag_storage = BlockDagKeyValueStorage::new(&mut kvm)
+        .await
+        .expect("Failed to create DAG storage");
+
+    let rspace_store = kvm
+        .r_space_stores()
+        .await
+        .expect("Failed to get rspace stores");
+    let mergeable_store = RuntimeManager::mergeable_store(&mut kvm)
+        .await
+        .expect("Failed to create mergeable store");
+    let (mut runtime_manager, _) = RuntimeManager::create_with_history(
+        rspace_store,
+        mergeable_store,
+        std::sync::Arc::new(Genesis::default_mergeable_tags()),
+        ExternalServices::noop(),
+    );
+
+    let genesis = Genesis {
+        shard_id: shard_name.clone(),
+        timestamp: 0,
+        block_number: 0,
+        proof_of_stake: ProofOfStake {
+            minimum_bond: 1,
+            maximum_bond: i64::MAX,
+            validators: vec![GenesisValidator {
+                pk: validator_pk.clone(),
+                stake: 100,
+            }],
+            epoch_length: 1000,
+            quarantine_length: 50000,
+            number_of_active_validators: 1,
+            fault_tolerance_threshold_ppm: 0,
+            pos_multi_sig_public_keys: vec![
+                "04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c".to_string(),
+                "042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14".to_string(),
+                "047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754".to_string(),
+            ],
+            pos_multi_sig_quorum: 2,
+        },
+        vaults: vec![casper::rust::genesis::contracts::vault::Vault {
+            vault_address:
+                rholang::rust::interpreter::util::vault_address::VaultAddress::from_public_key(
+                    &construct_deploy::DEFAULT_PUB,
+                )
+                .expect("Failed to create default deployer vault address"),
+            initial_balance: 9_000_000,
+        }],
+        supply: i64::MAX,
+        version: 1,
+        native_token_name: "F1R3CAP".to_string(),
+        native_token_symbol: "F1R3".to_string(),
+        native_token_decimals: 8,
+    };
+
+    let genesis_block = Genesis::create_genesis_block(&runtime_manager, &genesis)
+        .await
+        .expect("Failed to create genesis block");
+    block_store
+        .put_block_message(&genesis_block)
+        .expect("Failed to store genesis block");
+    dag_storage
+        .insert(
+            &genesis_block,
+            block_storage::rust::dag::block_dag_key_value_storage::InsertMode::Approved,
+        )
+        .expect("Failed to insert genesis in DAG");
+
+    let genesis_hash = genesis_block.block_hash.clone();
+    let genesis_state = proto_util::post_state_hash(&genesis_block);
+    let genesis_bonds = genesis_block.body.state.bonds.clone();
+
+    let main_raw = build_empty_block(
+        1,
+        1,
+        validator.clone(),
+        vec![genesis_hash.clone()],
+        genesis_state.clone(),
+        genesis_bonds.clone(),
+        shard_name.clone(),
+    );
+    let main = step_block(
+        &mut block_store,
+        &dag_storage,
+        &mut runtime_manager,
+        &main_raw,
+        validator.clone(),
+        shard_name.clone(),
+        genesis_hash.clone(),
+    )
+    .await
+    .expect("Failed to step main block");
+
+    let side_deploy = construct_deploy::source_deploy_now_full(
+        r#"@"secondary-parent-fast-path"!!(1)"#.to_string(),
+        None,
+        Some(1),
+        Some(construct_deploy::DEFAULT_SEC.clone()),
+        None,
+        Some(shard_name.clone()),
+    )
+    .expect("Failed to build side deploy");
+    let side_raw = block_implicits::get_random_block(
+        Some(1),
+        Some(2),
+        Some(genesis_state.clone()),
+        Some(StateHash::default()),
+        Some(validator.clone()),
+        Some(1),
+        Some(now_millis()),
+        Some(vec![genesis_hash.clone()]),
+        Some(Vec::new()),
+        Some(vec![ProcessedDeploy::empty(side_deploy)]),
+        Some(Vec::new()),
+        Some(genesis_bonds.clone()),
+        Some(shard_name.clone()),
+        None,
+    );
+    let side = step_block(
+        &mut block_store,
+        &dag_storage,
+        &mut runtime_manager,
+        &side_raw,
+        validator.clone(),
+        shard_name.clone(),
+        genesis_hash.clone(),
+    )
+    .await
+    .expect("Failed to step side block");
+    assert_eq!(
+        side.body.deploys.len(),
+        1,
+        "side block must process one deploy"
+    );
+    let side_statuses: Vec<_> = side
+        .body
+        .deploys
+        .iter()
+        .map(|pd| {
+            (
+                pd.is_failed,
+                pd.system_deploy_error.clone(),
+                pd.cost.cost,
+                pd.deploy_log.len(),
+            )
+        })
+        .collect();
+    assert!(
+        side.body.deploys.iter().all(|pd| !pd.is_failed),
+        "side deploy must execute cleanly: {:?}",
+        side_statuses
+    );
+    assert_ne!(
+        proto_util::post_state_hash(&side),
+        proto_util::post_state_hash(&main),
+        "side deploy must change state"
+    );
+
+    let cover_raw = build_empty_block(
+        2,
+        3,
+        validator.clone(),
+        vec![main.block_hash.clone(), side.block_hash.clone()],
+        proto_util::post_state_hash(&main),
+        main.body.state.bonds.clone(),
+        shard_name.clone(),
+    );
+    let cover = step_block(
+        &mut block_store,
+        &dag_storage,
+        &mut runtime_manager,
+        &cover_raw,
+        validator.clone(),
+        shard_name.clone(),
+        genesis_hash.clone(),
+    )
+    .await
+    .expect("Failed to step cover block");
+
+    let mut snapshot = mk_snapshot(
+        dag_storage
+            .get_representation()
+            .expect("dag representation"),
+        validator.clone(),
+        shard_name,
+        genesis_hash.clone(),
+    );
+    snapshot.dag.last_finalized_block_hash = genesis_hash;
+    let mut latest_messages = std::collections::BTreeMap::new();
+    latest_messages.insert(validator, cover.block_hash.clone());
+    runtime_manager.parents_post_state_cache.clear();
+    runtime_manager.block_index_cache.clear();
+
+    let (merged_state, rejected, _rejected_slashes) = compute_parents_post_state(
+        &block_store,
+        vec![cover.clone(), side.clone()],
+        &snapshot,
+        &runtime_manager,
+        &latest_messages,
+        None,
+        None,
+    )
+    .await
+    .expect("Failed to compute parents post-state");
+
+    assert!(
+        rejected.is_empty(),
+        "non-conflicting side deploy should merge cleanly"
+    );
+    assert_eq!(
+        merged_state,
+        proto_util::post_state_hash(&cover),
+        "a valid DAG-covering parent should already contain the secondary parent's effects"
+    );
+    assert!(
+        runtime_manager.parents_post_state_cache.is_empty(),
+        "DAG-covering parent fast path should not populate the merge cache"
     );
 }
 

--- a/docs/discoveries/2026-07-18-merge-recovery-finalization-gaps.md
+++ b/docs/discoveries/2026-07-18-merge-recovery-finalization-gaps.md
@@ -1,0 +1,92 @@
+# PR #114 (`fix/merge-recovery-finalization`) — commit-level absorption & FV-coverage analysis
+
+---
+doc_type: discovery
+discovered_by: claude-session-07b4ccc6
+date: 2026-07-18
+relevance: [PR-114, PR-129, sealed-floor-merge-squashed, fv-campaign]
+supersedes: file-level remainder inventory (2026-07-16, PR #127 phase-1 basis)
+---
+
+## Finding
+
+Commit-level analysis of the eight head commits of `fix/merge-recovery-finalization`
+(PR #114, `0f84eb38..9ec1096e`) against `sealed-floor-merge-squashed` at `298a476f`
+(post dev `32a45d02` + master `35ce65f1` merges). Four parallel read-only agents
+compared mechanisms content-level (none of the SHAs are ancestors of HEAD) and
+checked the FV surface (Rocq, TLA+, Kani, proptests, gate scripts) for coverage.
+
+### Absorbed — nothing lost if PR #114's branch is dropped (5 of 8)
+
+| Commit | Subject | Evidence at HEAD |
+|---|---|---|
+| `0f84eb38` | Stale invalid justification validation | `neglected_invalid_block` two-pass w/ `slash_targets` at `validate.rs:1346-1458`; Rocq T-9.13 `BugFixSlashAuthorization.v`, `AuthorizedSlashFlow.tla`, Kani harnesses, both regression tests; traceability rows confirmed. Only loss: one corrected doc-comment line (`validate.rs:20-21` still has stale wording). |
+| `f584e9e9` | Inclusion-leader gating | Superseded by `deploy_inclusion_progress()` (`block_creator.rs:1604`) + richer `BranchDeployInfo`; unit + integration tests present. |
+| `bec6325f` | Bounded non-leader fallback | All consts/fns present and extended (adaptive backpressure-aware cap `adaptive_fallback_ordinary_deploy_cap` at `:1858` that the branch lacks). |
+| `c58fcae5` | Canonical-admission starvation fix | `stranded_count` path intact (`block_creator.rs:105,1803-1822,1931-1938`); exact starvation-scenario tests present. |
+| `c32cfee9` | Canonical support + in-scope recovery | Content-identical at HEAD (`prefer_deploy_support_main_parent`, `finalized_ancestor_deploy_sigs`, `FinalityLagStats`, adaptive caps, 20 admission metrics, caps 32→128). Recovery covered by Rocq `Recovery.v` (T-NDA) + `recovery_no_double_apply.rs`; the parent-promotion heuristic itself is unit-test-only (acceptable). |
+
+### NOT absorbed — port targets for the new branch (3 of 8)
+
+**1. `9ec1096e` "Fix merge recovery finalization scope" — highest priority: proof↔code divergence.**
+All four mechanisms absent at HEAD:
+- `block_in_floor_merge_scope`: swaps `is_in_main_chain` → `is_dag_ancestor` in
+  `compute_parents_post_state`'s visible-block filter. HEAD (`interpreter_util.rs:1040,1081`)
+  still implements the PRE-fix predicate, while HEAD's own formal artifacts prove the
+  POST-fix behavior: `finalized_floor/theories/Selection.v` maps `anc_of` → `is_dag_ancestor`,
+  and `finalized-floor-verification.md:219,230` assert DAG-ancestry scope. The FV safety
+  argument is ahead of the code until this lands. Sits directly on the floor-divergence /
+  `ComputedPreStateMismatch` surface.
+- `rejected_buffer_has_recoverable_deploys` / `local_rejected_buffer_has_recoverable_deploys`:
+  canonical-won-aware recovery gating (HEAD still uses bare `buffer.non_empty()` at
+  `snapshot.rs:363-368`, `block_creator.rs:2347-2352`). Matches `DeployLifecycle.tla`
+  `PurgeRejectedBuf=TRUE` intent — again modeled, not implemented.
+- Expired rejected-buffer purge from storage+buffer in `prepare_user_deploys_with_policy`.
+- `RecoveryDeferred` propose-outcome taxonomy (propose_result/proposer/block_api/
+  heartbeat_proposer) — legitimate non-leader deferral no longer logged as warn/bug.
+
+**2. `6012c6a3` "Bound deploy admission by encoded bytes" — absent + uncovered.**
+HEAD took this commit's `ORDINARY_DEPLOY_PROPOSAL_CAP=128` raise but none of the byte
+machinery that motivated it: no `select_deploys_for_block(…, byte_budget)`,
+`deploy_encoded_len`, `DeploySelection`, 2 MiB / 512 KiB (backpressure) budgets,
+one-oversize-deploy progress guarantee, or the 5 byte metrics. Only defense against
+count-within-cap / serialized-size-blowout blocks. Already flagged as an open port
+decision in `docs/validation/fv-campaign-gap-analysis.md:47-52,106`.
+
+**3. `6981b37a` "Bound DAG pressure during finality recovery" — absent + uncovered.**
+Three mechanisms, none at HEAD; HEAD's heartbeat caps bound only LFB *lag*, never DAG
+*width*:
+- `EmptyFrontierPressure` empty-frontier backpressure across 5 propose paths + full
+  config knob `empty-frontier-max-unfinalized-blocks = 64` (casper_conf, defaults.conf,
+  CLI option, config_mapper).
+- `prune_dag_covered_parents` parent-set compaction in `compute_snapshot`.
+- `compute_parents_post_state` fast-path narrowing (`is_in_main_chain` → `is_dag_ancestor`
+  + empty-deploys guard) with deliberately reversed regression assertion — related to but
+  distinct from 9ec1096e's scope predicate; HEAD keeps the older broader fast path
+  (`interpreter_util.rs:874-880`).
+Rocq `Recovery.v` explicitly declares this capacity dimension out of scope ("orthogonal
+to this safety property"), so there is no formal coverage on either side.
+
+## Implications
+
+1. PR #114 must NOT be merged wholesale — 5/8 head commits would collide with
+   equal-or-better HEAD implementations. It also must not be closed-and-forgotten:
+   three commits carry unique, load-bearing content.
+2. Port order for the new branch (off the sealed-floor/dev line):
+   `9ec1096e` first (closes the proof↔code gap the FV campaign already asserts),
+   then `6012c6a3`, then `6981b37a`. Roughly ~1,500 lines total including tests.
+3. FV follow-ups for the port branch: byte-bound and width-bound have no formal
+   artifacts anywhere — decide whether to extend `DeployLifecycle.tla` (admission
+   bounds) and add a width-pressure model, or accept unit-test-only coverage with
+   an explicit gap note in `fv-campaign-gap-analysis.md`.
+4. Minor: port `0f84eb38`'s corrected module doc-comment to `validate.rs:20-21`.
+5. Full per-commit agent reports are in the session transcript (2026-07-18);
+   this doc is the durable summary.
+
+## Next steps
+
+- /multi-review on PR #114 to finalize its review context (comment posted to the PR
+  mirrors this analysis).
+- Create the port branch off dev after review; PR #114 can then be closed with the
+  port branch referenced, or kept as history per the maintainer's preference
+  (see project memory: do not close #114/#118 unilaterally).

--- a/models/src/rust/casper/protocol/casper_message.rs
+++ b/models/src/rust/casper/protocol/casper_message.rs
@@ -897,7 +897,9 @@ impl DeployData {
         }
     }
 
-    pub fn to_proto(dd: Signed<DeployData>) -> DeployDataProto {
+    pub fn to_proto(dd: Signed<DeployData>) -> DeployDataProto { Self::to_proto_ref(&dd) }
+
+    pub fn to_proto_ref(dd: &Signed<DeployData>) -> DeployDataProto {
         DeployDataProto {
             term: dd.data.term.clone(),
             timestamp: dd.data.time_stamp,

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -590,6 +590,8 @@ casper {
       # max-lag), so values below collapse to the pending floor and the
       # knob has no effect (a startup warning fires in that case).
       deploy-recovery-max-lag = 64
+
+      empty-frontier-max-unfinalized-blocks = 64
     }
   }
 

--- a/node/src/rust/configuration/commandline/config_mapper.rs
+++ b/node/src/rust/configuration/commandline/config_mapper.rs
@@ -374,6 +374,14 @@ impl ConfigMapper<Options> for NodeConf {
                 &mut self.casper.heartbeat_conf.advanced.deploy_recovery_max_lag,
                 run.heartbeat_advanced_deploy_recovery_max_lag,
             );
+            Self::try_override_value(
+                &mut self
+                    .casper
+                    .heartbeat_conf
+                    .advanced
+                    .empty_frontier_max_unfinalized_blocks,
+                run.heartbeat_advanced_empty_frontier_max_unfinalized_blocks,
+            );
         }
     }
 
@@ -498,6 +506,7 @@ mod tests {
         "--heartbeat-advanced-frontier-chase-max-lag=111",
         "--heartbeat-advanced-pending-deploy-max-lag=222",
         "--heartbeat-advanced-deploy-recovery-max-lag=333",
+        "--heartbeat-advanced-empty-frontier-max-unfinalized-blocks=444",
         "--synchrony-finalized-baseline-enabled=false",
         "--synchrony-finalized-baseline-max-distance=666666"
         ];
@@ -543,13 +552,14 @@ mod tests {
 
     #[test]
     fn test_parse_args_negative_advanced_lag_rejected() {
-        // The three advanced lag-cap flags use a value_parser that
+        // The advanced lag-cap flags use a value_parser that
         // rejects negative integers; a negative cap would silently
         // disable the corresponding code path in the proposer.
         for flag in &[
             "--heartbeat-advanced-frontier-chase-max-lag",
             "--heartbeat-advanced-pending-deploy-max-lag",
             "--heartbeat-advanced-deploy-recovery-max-lag",
+            "--heartbeat-advanced-empty-frontier-max-unfinalized-blocks",
         ] {
             let arg = format!("{flag}=-1");
             let argv = vec!["rnode", "run", &arg];
@@ -676,6 +686,7 @@ mod tests {
                 heartbeat_advanced_frontier_chase_max_lag: Some(111),
                 heartbeat_advanced_pending_deploy_max_lag: Some(222),
                 heartbeat_advanced_deploy_recovery_max_lag: Some(333),
+                heartbeat_advanced_empty_frontier_max_unfinalized_blocks: Some(444),
                 synchrony_finalized_baseline_enabled: Some(false),
                 synchrony_finalized_baseline_max_distance: Some(666666),
             })),
@@ -1056,6 +1067,14 @@ mod tests {
                 .advanced
                 .deploy_recovery_max_lag,
             333
+        );
+        assert_eq!(
+            default_config
+                .casper
+                .heartbeat_conf
+                .advanced
+                .empty_frontier_max_unfinalized_blocks,
+            444
         );
 
         // Round robin dispatcher fields

--- a/node/src/rust/configuration/commandline/options.rs
+++ b/node/src/rust/configuration/commandline/options.rs
@@ -572,6 +572,13 @@ pub struct RunOptions {
         hide_short_help = true
     )]
     pub heartbeat_advanced_deploy_recovery_max_lag: Option<i64>,
+
+    #[arg(
+        long = "heartbeat-advanced-empty-frontier-max-unfinalized-blocks",
+        value_parser = ValueParser::new(parse_non_negative_i64),
+        hide_short_help = true
+    )]
+    pub heartbeat_advanced_empty_frontier_max_unfinalized_blocks: Option<i64>,
 }
 
 /// Keygen subcommand - Generates a public/private key pair

--- a/node/src/rust/configuration/mod.rs
+++ b/node/src/rust/configuration/mod.rs
@@ -272,6 +272,7 @@ mod heartbeat_conf_hocon_tests {
               frontier-chase-max-lag = 1
               pending-deploy-max-lag = 33
               deploy-recovery-max-lag = 99
+              empty-frontier-max-unfinalized-blocks = 44
             }
             "#,
         );
@@ -285,6 +286,7 @@ mod heartbeat_conf_hocon_tests {
         assert_eq!(cfg.advanced.frontier_chase_max_lag, 1);
         assert_eq!(cfg.advanced.pending_deploy_max_lag, 33);
         assert_eq!(cfg.advanced.deploy_recovery_max_lag, 99);
+        assert_eq!(cfg.advanced.empty_frontier_max_unfinalized_blocks, 44);
     }
 
     #[test]
@@ -302,7 +304,6 @@ mod heartbeat_conf_hocon_tests {
         assert_eq!(cfg.self_propose_cooldown, Duration::from_secs(15));
         assert_eq!(cfg.stale_recovery_min_interval, Duration::from_secs(12));
         assert_eq!(cfg.deploy_finalization_grace, Duration::from_secs(25));
-        // Advanced block absent → all three fields default.
         assert_eq!(cfg.advanced, HeartbeatAdvancedConf::default());
     }
 
@@ -324,18 +325,20 @@ mod heartbeat_conf_hocon_tests {
         assert_eq!(cfg.advanced.frontier_chase_max_lag, 0);
         assert_eq!(cfg.advanced.pending_deploy_max_lag, 7);
         assert_eq!(cfg.advanced.deploy_recovery_max_lag, 64);
+        assert_eq!(cfg.advanced.empty_frontier_max_unfinalized_blocks, 64);
     }
 
     #[test]
     fn negative_advanced_lag_values_are_rejected() {
         // Negative caps would silently disable the corresponding code
         // path in the proposer (e.g. `lag <= cap` where cap < 0 is
-        // never true). Each of the three advanced fields rejects at
+        // never true). Each advanced field rejects at
         // deserialization time.
         for field in &[
             "frontier-chase-max-lag",
             "pending-deploy-max-lag",
             "deploy-recovery-max-lag",
+            "empty-frontier-max-unfinalized-blocks",
         ] {
             let hocon = format!(
                 r#"

--- a/node/src/rust/instances/heartbeat_proposer.rs
+++ b/node/src/rust/instances/heartbeat_proposer.rs
@@ -610,11 +610,22 @@ async fn check_lfb_and_propose(
                 })
             }
             ProposerResult::Failure(status, seq_num) => {
-                tracing::warn!(
-                    "Heartbeat: Propose failed with {} (seqNum {})",
+                if matches!(
                     status,
-                    seq_num
-                );
+                    ProposeStatus::Failure(ProposeFailure::RecoveryDeferred)
+                ) {
+                    tracing::debug!(
+                        "Heartbeat: Propose deferred with {} (seqNum {})",
+                        status,
+                        seq_num
+                    );
+                } else {
+                    tracing::warn!(
+                        "Heartbeat: Propose failed with {} (seqNum {})",
+                        status,
+                        seq_num
+                    );
+                }
                 // Only escalate backoff for explicit bug failures.
                 // Recoverable propose races should retry on the normal heartbeat cadence.
                 Ok(HeartbeatCheckResult {
@@ -1038,6 +1049,24 @@ mod tests {
             (count, func)
         }
 
+        fn create_recovery_deferred_propose_function() -> (Arc<AtomicUsize>, Arc<ProposeFunction>) {
+            use casper::rust::blocks::proposer::propose_result::{ProposeFailure, ProposeStatus};
+            use casper::rust::blocks::proposer::proposer::ProposerResult;
+
+            let count = Arc::new(AtomicUsize::new(0));
+            let count_clone = count.clone();
+            let func: Arc<ProposeFunction> = Arc::new(move |_casper, _is_async| {
+                count_clone.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async {
+                    Ok(ProposerResult::Failure(
+                        ProposeStatus::Failure(ProposeFailure::RecoveryDeferred),
+                        7,
+                    ))
+                })
+            });
+            (count, func)
+        }
+
         #[tokio::test]
         async fn do_heartbeat_check_triggers_propose_with_pending_deploys() {
             let validator = create_test_validator_identity();
@@ -1129,6 +1158,38 @@ mod tests {
                 1,
                 "Should trigger propose when LFB is stale and new parents exist"
             );
+        }
+
+        #[tokio::test]
+        async fn do_heartbeat_check_treats_recovery_deferred_as_non_bug() {
+            let validator = create_test_validator_identity();
+            let validator_id = validator.public_key.bytes.clone();
+            let mut snapshot =
+                casper::rust::casper::test_helpers::TestCasperWithSnapshot::create_empty_snapshot();
+            casper::rust::casper::test_helpers::TestCasperWithSnapshot::bond_validator_in_snapshot(
+                &mut snapshot,
+                validator_id.into(),
+            );
+            let lfb = create_lfb_with_age(60000);
+            let casper: Arc<dyn MultiParentCasper + Send + Sync> = Arc::new(
+                casper::rust::casper::test_helpers::TestCasperWithSnapshot::new(snapshot, lfb),
+            );
+            let (propose_count, propose_func) = create_recovery_deferred_propose_function();
+            let config = HeartbeatConf {
+                enabled: true,
+                check_interval: Duration::from_secs(1),
+                max_lfb_age: Duration::from_secs(1),
+                self_propose_cooldown: Duration::from_secs(15),
+                ..HeartbeatConf::default()
+            };
+
+            let result =
+                do_heartbeat_check(casper, &*propose_func, &validator, &config, false, false)
+                    .await
+                    .expect("heartbeat check");
+
+            assert_eq!(propose_count.load(Ordering::SeqCst), 1);
+            assert!(!result.bug_failure);
         }
 
         #[tokio::test]

--- a/node/src/rust/instances/heartbeat_proposer.rs
+++ b/node/src/rust/instances/heartbeat_proposer.rs
@@ -38,6 +38,41 @@ struct HeartbeatCheckResult {
     refresh_deploy_grace_window: bool,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct EmptyFrontierPressure {
+    unfinalized_blocks: usize,
+    max_unfinalized_blocks: usize,
+    backpressure: bool,
+}
+
+fn empty_frontier_pressure(
+    snapshot: &CasperSnapshot,
+    max_unfinalized_blocks: i64,
+    has_pending_deploys: bool,
+    has_new_parent_with_user_deploys: bool,
+    deploy_grace_active: bool,
+    self_recently_proposed: bool,
+) -> Result<EmptyFrontierPressure, casper::rust::errors::CasperError> {
+    let max_unfinalized_blocks = usize::try_from(max_unfinalized_blocks).unwrap_or(usize::MAX);
+    if has_pending_deploys
+        || has_new_parent_with_user_deploys
+        || deploy_grace_active
+        || !self_recently_proposed
+    {
+        return Ok(EmptyFrontierPressure {
+            max_unfinalized_blocks,
+            ..EmptyFrontierPressure::default()
+        });
+    }
+
+    let unfinalized_blocks = snapshot.dag.non_finalized_blocks()?.len();
+    Ok(EmptyFrontierPressure {
+        unfinalized_blocks,
+        max_unfinalized_blocks,
+        backpressure: unfinalized_blocks > max_unfinalized_blocks,
+    })
+}
+
 impl HeartbeatProposer {
     /// Create a heartbeat proposer stream that periodically checks if a block
     /// needs to be proposed to maintain liveness.
@@ -416,6 +451,9 @@ async fn check_lfb_and_propose(
     // Under active deploy-finalization recovery, allow a wider bounded chase window so
     // validators can keep up with fast parent growth without stalling on tight lag caps.
     // Outside deploy recovery, keep the tighter cap to avoid idle empty-block churn.
+    // (Port note: 6981b37a narrowed this cap during recovery via
+    // effective_frontier_chase_cap(min ..); this line's soak-tested policy widens
+    // instead, so only the width-backpressure mechanism is ported.)
     let deploy_recovery_frontier_chase_cap = if deploy_recovery_hint {
         std::cmp::max(2, deploy_recovery_max_lag)
     } else {
@@ -426,6 +464,26 @@ async fn check_lfb_and_propose(
     } else {
         frontier_chase_max_lag
     };
+    let empty_frontier_pressure = empty_frontier_pressure(
+        &snapshot,
+        config.advanced.empty_frontier_max_unfinalized_blocks,
+        has_pending_deploys,
+        has_new_parent_with_user_deploys,
+        deploy_grace_active,
+        self_recently_proposed,
+    )?;
+    let empty_frontier_backpressure = empty_frontier_pressure.backpressure;
+    if empty_frontier_backpressure {
+        tracing::info!(
+            target: "f1r3fly.casper.heartbeat.backpressure",
+            "Heartbeat: Empty frontier backpressure active (unfinalized_blocks={}, cap={}, lag={}, latest_height={}, lfb_height={})",
+            empty_frontier_pressure.unfinalized_blocks,
+            empty_frontier_pressure.max_unfinalized_blocks,
+            lfb_lag_blocks,
+            latest_block_number,
+            last_finalized_block_number
+        );
+    }
     let stale_recovery_interval_elapsed = frontier_age_ms >= stale_recovery_min_interval_ms;
     let stale_recovery_window_open = stale_recovery_interval_elapsed || deploy_recovery_hint;
 
@@ -470,15 +528,18 @@ async fn check_lfb_and_propose(
         has_new_parent_with_user_deploys && lfb_lag_blocks <= deploy_recovery_max_lag;
     let can_chase_frontier_while_ahead = lfb_lag_blocks <= effective_frontier_chase_cap
         && has_new_parents
+        && !empty_frontier_backpressure
         && (!self_proposed_too_recently || allow_cooldown_override_for_deploy_recovery);
     let frontier_follow_due = !has_pending_deploys
         && has_new_parents
+        && !empty_frontier_backpressure
         && can_follow_frontier_without_pending_deploys
         && (!self_recently_proposed
             || can_chase_frontier_while_ahead
             || allow_frontier_follow_while_ahead_for_deploy_parent);
     let stale_lfb_recovery_due = lfb_is_stale
         && stale_recovery_window_open
+        && !empty_frontier_backpressure
         && (!self_recently_proposed || can_chase_frontier_while_ahead || deploy_grace_active);
     let lag_recovery_leader = is_lag_recovery_leader(&snapshot, validator_identity);
     let lag_recovery_threshold = pending_deploy_max_lag;
@@ -489,12 +550,14 @@ async fn check_lfb_and_propose(
         && lfb_lag_blocks > 0
         && lag_recovery_leader
         && stale_recovery_window_open
+        && !empty_frontier_backpressure
         && (!self_proposed_too_recently || deploy_grace_active)
         && !stale_lfb_recovery_due;
     let high_lag_recovery_due = !has_pending_deploys
         && lfb_lag_blocks > lag_recovery_threshold
         && lag_recovery_leader
         && stale_recovery_window_open
+        && !empty_frontier_backpressure
         && (!self_proposed_too_recently || deploy_grace_active);
     // Convergence recovery: when the LFB is stale and we have unjustified peer blocks,
     // propose a convergence block that references all known tips. This breaks the deadlock
@@ -505,7 +568,8 @@ async fn check_lfb_and_propose(
         && self_recently_proposed
         && !can_chase_frontier_while_ahead
         && frontier_is_stale
-        && stale_recovery_window_open;
+        && stale_recovery_window_open
+        && !empty_frontier_backpressure;
     let should_propose = pending_deploys_due
         || pending_deploy_backstop_due
         || frontier_follow_due
@@ -652,7 +716,13 @@ async fn check_lfb_and_propose(
             }
         }
     } else {
-        let reason = if !lfb_is_stale {
+        let reason = if empty_frontier_backpressure {
+            format!(
+                "empty frontier backpressure: unfinalized_blocks={} exceeds cap {}; no pending deploys or deploy-carrying peer parent",
+                empty_frontier_pressure.unfinalized_blocks,
+                empty_frontier_pressure.max_unfinalized_blocks
+            )
+        } else if !lfb_is_stale {
             if has_pending_deploys
                 && self_recently_proposed
                 && !can_propose_pending_deploys_while_ahead
@@ -1009,9 +1079,13 @@ mod tests {
     // Tests that call do_heartbeat_check directly for deterministic behavior
 
     mod decision_logic_tests {
+        use std::collections::BTreeMap;
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         use casper::rust::casper::MultiParentCasper;
+        use models::rust::block_metadata::BlockMetadata;
+        use models::rust::casper::protocol::casper_message::Justification;
+        use prost::bytes::Bytes;
 
         use super::*;
 
@@ -1065,6 +1139,189 @@ mod tests {
                 })
             });
             (count, func)
+        }
+
+        fn test_hash(byte: u8) -> BlockHash { Bytes::from(vec![byte; 32]) }
+
+        fn test_validator(byte: u8) -> Bytes {
+            Bytes::from(vec![byte; models::rust::validator::LENGTH])
+        }
+
+        fn add_test_metadata(
+            snapshot: &mut CasperSnapshot,
+            hash: BlockHash,
+            sender: Bytes,
+            parents: Vec<BlockHash>,
+            block_number: i64,
+            finalized: bool,
+            justifications: Vec<Justification>,
+        ) {
+            let metadata = BlockMetadata {
+                block_hash: hash.clone(),
+                parents: parents.clone(),
+                sender,
+                justifications,
+                weight_map: BTreeMap::new(),
+                block_number,
+                sequence_number: block_number as i32,
+                invalid: false,
+                directly_finalized: finalized,
+                finalized,
+                fault_tolerance_value: 1.0,
+            };
+
+            snapshot.dag.dag_set.insert(hash.clone());
+            let mut height_hashes = snapshot
+                .dag
+                .height_map
+                .get(&block_number)
+                .cloned()
+                .unwrap_or_default();
+            height_hashes.insert(hash.clone());
+            snapshot.dag.height_map.insert(block_number, height_hashes);
+            snapshot
+                .dag
+                .block_number_map
+                .insert(hash.clone(), block_number);
+            for parent in &parents {
+                let mut children = snapshot
+                    .dag
+                    .child_map
+                    .get(parent)
+                    .cloned()
+                    .unwrap_or_default();
+                children.insert(hash.clone());
+                snapshot.dag.child_map.insert(parent.clone(), children);
+            }
+            if let Some(parent) = parents.first() {
+                snapshot
+                    .dag
+                    .main_parent_map
+                    .insert(hash.clone(), parent.clone());
+            }
+            if finalized {
+                snapshot.dag.finalized_blocks_set.insert(hash.clone());
+                snapshot.dag.last_finalized_block_hash = hash.clone();
+                snapshot.last_finalized_block = hash.clone();
+            }
+            snapshot
+                .dag
+                .block_metadata_index
+                .write()
+                .add(metadata)
+                .expect("insert test block metadata");
+        }
+
+        fn add_test_branch(
+            snapshot: &mut CasperSnapshot,
+            sender: Bytes,
+            start_byte: u8,
+            parent: BlockHash,
+            blocks: i64,
+            tip_justifications: Vec<Justification>,
+        ) -> BlockHash {
+            let mut parent = parent;
+            for height in 1..=blocks {
+                let hash = test_hash(start_byte + height as u8);
+                let justifications = if height == blocks {
+                    tip_justifications.clone()
+                } else {
+                    Vec::new()
+                };
+                add_test_metadata(
+                    snapshot,
+                    hash.clone(),
+                    sender.clone(),
+                    vec![parent],
+                    height,
+                    false,
+                    justifications,
+                );
+                parent = hash;
+            }
+            parent
+        }
+
+        fn wide_unfinalized_snapshot(
+            validator_id: Bytes,
+        ) -> (
+            CasperSnapshot,
+            models::rust::casper::protocol::casper_message::BlockMessage,
+        ) {
+            let mut snapshot =
+                casper::rust::casper::test_helpers::TestCasperWithSnapshot::create_empty_snapshot();
+            casper::rust::casper::test_helpers::TestCasperWithSnapshot::bond_validator_in_snapshot(
+                &mut snapshot,
+                validator_id.clone().into(),
+            );
+
+            let lfb_hash = test_hash(1);
+            add_test_metadata(
+                &mut snapshot,
+                lfb_hash.clone(),
+                validator_id.clone(),
+                Vec::new(),
+                0,
+                true,
+                Vec::new(),
+            );
+
+            let self_tip_hash = test_hash(0x18);
+            let self_tip = add_test_branch(
+                &mut snapshot,
+                validator_id.clone(),
+                0x10,
+                lfb_hash.clone(),
+                8,
+                vec![Justification {
+                    validator: validator_id.clone(),
+                    latest_block_hash: self_tip_hash,
+                }],
+            );
+            let peer_validator = test_validator(0x44);
+            let peer_tip = add_test_branch(
+                &mut snapshot,
+                peer_validator.clone(),
+                0x30,
+                lfb_hash.clone(),
+                8,
+                Vec::new(),
+            );
+
+            snapshot
+                .dag
+                .latest_messages_map
+                .insert(validator_id, self_tip);
+            snapshot
+                .dag
+                .latest_messages_map
+                .insert(peer_validator, peer_tip);
+
+            assert!(
+                snapshot.dag.non_finalized_blocks().unwrap().len() > 4,
+                "test fixture should exceed empty-frontier pressure cap"
+            );
+
+            let mut lfb = create_lfb_with_age(60000);
+            lfb.block_hash = lfb_hash;
+            (snapshot, lfb)
+        }
+
+        fn empty_frontier_backpressure_config() -> HeartbeatConf {
+            HeartbeatConf {
+                enabled: true,
+                check_interval: Duration::from_secs(1),
+                max_lfb_age: Duration::from_millis(1),
+                self_propose_cooldown: Duration::from_secs(15),
+                stale_recovery_min_interval: Duration::from_millis(0),
+                advanced: casper::rust::casper_conf::HeartbeatAdvancedConf {
+                    frontier_chase_max_lag: 20,
+                    pending_deploy_max_lag: 20,
+                    deploy_recovery_max_lag: 64,
+                    empty_frontier_max_unfinalized_blocks: 4,
+                },
+                ..HeartbeatConf::default()
+            }
         }
 
         #[tokio::test]
@@ -1325,6 +1582,54 @@ mod tests {
                 propose_count.load(Ordering::SeqCst),
                 1,
                 "Should propose when storage has pending deploys, even if deploys_in_scope is empty"
+            );
+        }
+
+        #[tokio::test]
+        async fn do_heartbeat_check_suppresses_empty_frontier_when_unfinalized_width_is_high() {
+            let validator = create_test_validator_identity();
+            let validator_id = validator.public_key.bytes.clone();
+            let (snapshot, lfb) = wide_unfinalized_snapshot(validator_id);
+
+            let casper: Arc<dyn MultiParentCasper + Send + Sync> = Arc::new(
+                casper::rust::casper::test_helpers::TestCasperWithSnapshot::new(snapshot, lfb),
+            );
+            let (propose_count, propose_func) = create_counting_propose_function();
+            let config = empty_frontier_backpressure_config();
+
+            let result =
+                do_heartbeat_check(casper, &*propose_func, &validator, &config, false, false).await;
+
+            assert!(result.is_ok(), "do_heartbeat_check should succeed");
+            assert_eq!(
+                propose_count.load(Ordering::SeqCst),
+                0,
+                "Should not create empty frontier-follow proposals when unresolved DAG width exceeds cap"
+            );
+        }
+
+        #[tokio::test]
+        async fn do_heartbeat_check_allows_pending_deploys_under_empty_frontier_pressure() {
+            let validator = create_test_validator_identity();
+            let validator_id = validator.public_key.bytes.clone();
+            let (snapshot, lfb) = wide_unfinalized_snapshot(validator_id);
+
+            let casper: Arc<dyn MultiParentCasper + Send + Sync> = Arc::new(
+                casper::rust::casper::test_helpers::TestCasperWithSnapshot::new_with_pending_deploys(
+                    snapshot, lfb, 1,
+                ),
+            );
+            let (propose_count, propose_func) = create_counting_propose_function();
+            let config = empty_frontier_backpressure_config();
+
+            let result =
+                do_heartbeat_check(casper, &*propose_func, &validator, &config, false, false).await;
+
+            assert!(result.is_ok(), "do_heartbeat_check should succeed");
+            assert_eq!(
+                propose_count.load(Ordering::SeqCst),
+                1,
+                "Pending deploys should bypass empty-frontier backpressure"
             );
         }
     }

--- a/node/src/rust/instances/proposer_instance.rs
+++ b/node/src/rust/instances/proposer_instance.rs
@@ -224,7 +224,9 @@ impl<T: TransportLayer + Send + Sync + 'static> ProposerInstance<T> {
                                     }
                                 }
                                 None => {
-                                    if propose_result.is_no_new_deploys() {
+                                    if propose_result.is_no_new_deploys()
+                                        || propose_result.is_recovery_deferred()
+                                    {
                                         tracing::info!("Propose: {}", propose_result.propose_status)
                                     } else {
                                         tracing::error!(


### PR DESCRIPTION
## Summary

Ports the three commits from `fix/merge-recovery-finalization` (PR #114) that the
integrated line does not already carry, per the commit-level absorption analysis in
`docs/discoveries/2026-07-18-merge-recovery-finalization-gaps.md` (included in this PR)
and the [context comment on PR #114](https://github.com/F1R3FLY-io/f1r3node-rust/pull/114#issuecomment-5011006362).

The other five head commits of #114 were verified as already absorbed (equivalent or
superseded implementations with equal-or-better test coverage) and are **not** re-ported.
This PR supersedes #114's unique content; #114's final disposition (close with reference
vs. keep as history) remains the maintainer's call.

Base: the integrated sealed-floor line (`sealed-floor-merge-squashed` after the dev
`32a45d02` and master `35ce65f1` merges).

## Port 1 — `e3e3ae90` (from #114's `9ec1096e`): merge-recovery finalization scope

**Closes a proof↔code divergence.** The FV campaign's artifacts already prove the fixed
behavior — `finalized_floor/theories/Selection.v` maps its ancestry relation to
`is_dag_ancestor`, and `DeployLifecycle.tla` models the buffer purge (`PurgeRejectedBuf=TRUE`)
— but the code still implemented the pre-fix predicates. This port aligns them:

- `block_in_floor_merge_scope`: `is_in_main_chain` → `is_dag_ancestor` in
  `compute_parents_post_state`'s visible-block filter, so a finalized below-floor
  co-parent branch outside the floor's main-parent spine is correctly dropped from merge
  scope (the `ComputedPreStateMismatch` / floor-divergence surface), + backstop test
- Recoverable-buffer gating: `rejected_buffer_has_recoverable_deploys` /
  `local_rejected_buffer_has_recoverable_deploys` replace bare `non_empty()` — buffers
  holding only canonical-won or expired sigs no longer trigger futile recovery blocks
- Expired rejected-buffer purge from deploy storage + buffer in
  `prepare_user_deploys_with_policy`
- `RecoveryDeferred` propose outcome: legitimate non-leader recovery deferral is
  non-bug (debug, not warn) across proposer / block_api / heartbeat

## Port 2 — `c965107b` (from #114's `6012c6a3`): encoded-bytes admission bound

Closes the size-dimension gap flagged in `docs/validation/fv-campaign-gap-analysis.md:47`
(the count-cap raise to 128 had been absorbed without the byte machinery that motivated it):

- Unified `select_deploys_for_block(deploys, cap, reserve_tail, byte_budget)` replaces
  count-only selection; `deploy_encoded_len` via prost `encoded_len`
- `USER_DEPLOY_BYTE_PROPOSAL_BUDGET` = 2 MiB (512 KiB under finality backpressure),
  threaded as a shared decrementing budget across retry → ordinary → in-scope-recovery
- Progress carve-out: one oversize deploy is still admitted when it alone exceeds the budget
- `PreparedUserDeploys` byte accounting + 5 admission byte metrics

## Port 3 — `43c4dc79` (from #114's `6981b37a`): DAG-width backpressure

The only mechanism bounding unfinalized-DAG **width** (existing heartbeat caps bound only
LFB **lag** — a wide fan at similar height passes them):

- `EmptyFrontierPressure` + `empty_frontier_pressure()`: a validator that recently
  self-proposed, with no deploy pressure, stops emitting empty frontier-follow /
  stale-recovery / convergence blocks once unfinalized-DAG width exceeds the cap;
  `!empty_frontier_backpressure` gates all six propose-decision paths, pending-deploy
  proposing deliberately ungated
- Config knob `empty-frontier-max-unfinalized-blocks = 64` (defaults.conf, casper_conf,
  CLI option, config-mapper + HOCON override)
- `prune_dag_covered_parents` in `compute_snapshot`: collapses the parent set to a single
  deploy-free parent that DAG-covers all others
- `compute_parents_post_state` fast path narrowed (`is_in_main_chain` → `is_dag_ancestor`
  + empty-deploys guard); regression-spec assertion deliberately reversed (a DAG-covering
  empty parent now legitimately skips the merge)

## Deliberate port deltas (inherited context NOT taken)

- **Chase-cap policy kept from this line**: `6981b37a` narrowed the deploy-recovery
  frontier-chase cap (`min` with 2); this line's soak-tested policy deliberately widens it.
  Only the width-backpressure mechanism was ported (noted in a code comment at the site).
- **No `lag_recovery_leader` gate on convergence recovery** — inherited context from
  #114's lineage, not part of `6981b37a`'s diff.
- Spec code updated to current APIs (`create_genesis_block` by shared ref, no useless
  `.into()`).

## Verification

- `cargo check` + `clippy -D warnings` clean for casper + node including test targets
- Heartbeat module 11/11 (both width-backpressure tests + `RecoveryDeferred`)
- Snapshot module 11/11 (incl. `parent_selection_prunes_dag_covered_parents`)
- Node configuration 15/15 (incl. HOCON/CLI override of the new knob)
- Regression spec 4/4 (incl. the full-runtime fast-path pin, ~7s)
- Port-1 backstops 9/9 (incl. `floor_scope_drops_finalized_off_main_dag_ancestors`)
- Both byte-budget tests + 50-test block_creator sweep + config-cap integration tests

## FV follow-ups (tracked, not in this PR)

The byte-bound and width-bound have no formal artifacts on either lineage; whether to
extend `DeployLifecycle.tla` (admission bounds) and add a width-pressure model, or accept
unit-test-only coverage with an explicit note in `fv-campaign-gap-analysis.md`, is an open
decision recorded in the discovery doc.

---
Corrections applied versus your draft: title reflects all three ports rather than only 9ec1096e; the stale "Excluded" paragraph is replaced by the port-delta section (those exclusions were temporary sequencing within port 1, later restored in port 3); the verification list covers all three commits' evidence; and the trailing empty bullet is gone. Ready to use for gh pr create against dev — want me to open it?

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786967055&installation_id=145946300&pr_number=133&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F133&signature=eae108d5931015e625d94bc4b32b57db6a89fc9297fc9577d7592b929a5a90da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->