### PR TITLE
feat(fileio): non-deterministic-replay guards for the 19 native syscalls

### DIFF
--- a/rholang/src/rust/interpreter/io/handle_table.rs
+++ b/rholang/src/rust/interpreter/io/handle_table.rs
@@ -90,6 +90,36 @@ impl FileHandleTable {
     pub async fn remove(&self, fd: i64) -> Option<Arc<FileHandle>> {
         self.inner.write().await.remove(&fd)
     }
+
+    /// Capture the current `next_fd` counter so a later
+    /// [`truncate_to`](Self::truncate_to) can identify "fds
+    /// inserted since this snapshot" by monotonicity: any fd
+    /// >= the snapshot was allocated after it. Used by the
+    /// runtime's `evaluate_with_env_and_phlo` to tie fd
+    /// allocation to the same soft-checkpoint boundary that
+    /// wraps rspace state, so a deploy that errors after
+    /// `nativeOpen` doesn't leave zombie fds in the table.
+    pub fn snapshot_next_fd(&self) -> i64 { self.next_fd.load(Ordering::SeqCst) }
+
+    /// Remove every entry with fd >= `snapshot` and reset the
+    /// `next_fd` counter to `snapshot`. Used on the error path
+    /// of `evaluate_with_env_and_phlo` to roll back fd
+    /// allocations from a deploy whose rspace state is being
+    /// reverted -- otherwise the OS-level file descriptors
+    /// held by `tokio::fs::File` inside `Arc<FileHandle>`
+    /// would stay open until the runtime is dropped, giving
+    /// a hostile deploy an easy path to exhaust the process's
+    /// `ulimit -n`.
+    ///
+    /// Reusing fd numbers across deploys is safe: any produce
+    /// event that mentioned a reverted fd was itself reverted
+    /// by the same soft-checkpoint restore, so no surviving
+    /// log entry refers to it.
+    pub async fn truncate_to(&self, snapshot: i64) {
+        let mut map = self.inner.write().await;
+        map.retain(|fd, _| *fd < snapshot);
+        self.next_fd.store(snapshot, Ordering::SeqCst);
+    }
 }
 
 impl Default for FileHandleTable {

--- a/rholang/src/rust/interpreter/rho_runtime.rs
+++ b/rholang/src/rust/interpreter/rho_runtime.rs
@@ -258,6 +258,15 @@ pub struct RhoRuntimeImpl {
     pub invalid_blocks_param: InvalidBlocks,
     pub deploy_data_ref: Arc<tokio::sync::RwLock<DeployData>>,
     pub merge_chs: Arc<tokio::sync::RwLock<HashMap<Par, MergeType>>>,
+    /// The runtime's single File-I/O open-fd table, shared with
+    /// every fileio native handler via the dispatch-table build.
+    /// Exposed on the runtime (not just buried inside dispatch
+    /// closures) so `evaluate_with_env_and_phlo` can snapshot
+    /// `next_fd` before evaluate and truncate on error paths,
+    /// tying fd lifetime to the same soft-checkpoint boundary
+    /// that rolls rspace state. Tests can also inspect it
+    /// directly to verify fd table state after a deploy.
+    pub file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
 }
 
 impl RhoRuntimeImpl {
@@ -268,6 +277,7 @@ impl RhoRuntimeImpl {
         invalid_blocks_param: InvalidBlocks,
         deploy_data_ref: Arc<tokio::sync::RwLock<DeployData>>,
         merge_chs: Arc<tokio::sync::RwLock<HashMap<Par, MergeType>>>,
+        file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
     ) -> RhoRuntimeImpl {
         RhoRuntimeImpl {
             reducer,
@@ -276,6 +286,7 @@ impl RhoRuntimeImpl {
             invalid_blocks_param,
             deploy_data_ref,
             merge_chs,
+            file_handles,
         }
     }
 
@@ -301,6 +312,48 @@ impl RhoRuntime for RhoRuntimeImpl {
         metrics::histogram!(EVALUATE_TIME_METRIC, "source" => RUNTIME_METRICS_SOURCE)
             .record(start.elapsed().as_secs_f64());
         res
+    }
+
+    /// Override the trait default so the fileio `FileHandleTable`
+    /// participates in the same soft-checkpoint boundary as
+    /// rspace: snapshot `next_fd` before evaluate, and on any
+    /// error path (Ok-with-errors or hard Err) truncate the
+    /// table back to the snapshot. Otherwise a deploy that
+    /// successfully calls `nativeOpen` and then errors would
+    /// leak the fd -- the OS-level `tokio::fs::File` would sit
+    /// in the table unreachable from Rholang (fds are
+    /// monotonic, and any produce event that mentioned this fd
+    /// was reverted by the rspace restore) but consuming an OS
+    /// file descriptor until the whole runtime drops. Repeated
+    /// hostile deploys of this shape would exhaust the process's
+    /// `ulimit -n`. See `io::handle_table::truncate_to` for the
+    /// safety argument on fd reuse across deploys.
+    async fn evaluate_with_env_and_phlo(
+        &mut self,
+        term: &str,
+        initial_phlo: Cost,
+        normalizer_env: HashMap<String, Par>,
+    ) -> Result<EvaluateResult, InterpreterError> {
+        let rand = Blake2b512Random::create_from_length(128);
+        let fd_snapshot = self.file_handles.snapshot_next_fd();
+        let checkpoint = self.create_soft_checkpoint().await;
+        match self
+            .evaluate(term, initial_phlo, normalizer_env, rand)
+            .await
+        {
+            Ok(eval_result) => {
+                if !eval_result.errors.is_empty() {
+                    self.revert_to_soft_checkpoint(checkpoint).await;
+                    self.file_handles.truncate_to(fd_snapshot).await;
+                }
+                Ok(eval_result)
+            }
+            Err(err) => {
+                self.revert_to_soft_checkpoint(checkpoint).await;
+                self.file_handles.truncate_to(fd_snapshot).await;
+                Err(err)
+            }
+        }
     }
 
     async fn inj(
@@ -1273,6 +1326,7 @@ fn dispatch_table_creator(
     invalid_blocks: InvalidBlocks,
     urn_map: Arc<HashMap<String, Par>>,
     deploy_data: Arc<tokio::sync::RwLock<DeployData>>,
+    file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
     extra_system_processes: &mut Vec<Definition>,
     openai_service: SharedOpenAIService,
     ollama_service: SharedOllamaService,
@@ -1292,6 +1346,12 @@ fn dispatch_table_creator(
     all_processes.append(extra_system_processes);
 
     for def in all_processes.iter_mut() {
+        // Every ProcessContext gets the SAME `file_handles`
+        // (cloning `FileHandleTable` shares its inner `Arc`), so
+        // fd inserts by `nativeOpen` are visible to lookups by
+        // every other fd-consuming native. Without this, each
+        // Definition would land in its own empty table and the
+        // whole fileio primitive layer would be non-functional.
         let tuple = def.to_dispatch_table(ProcessContext::create(
             space.clone(),
             dispatcher.clone(),
@@ -1299,6 +1359,7 @@ fn dispatch_table_creator(
             invalid_blocks.clone(),
             deploy_data.clone(),
             urn_map.clone(),
+            file_handles.clone(),
             openai_service.clone(),
             ollama_service.clone(),
             grpc_client_service.clone(),
@@ -1392,6 +1453,7 @@ async fn setup_reducer(
     block_data_ref: Arc<tokio::sync::RwLock<BlockData>>,
     invalid_blocks: InvalidBlocks,
     deploy_data_ref: Arc<tokio::sync::RwLock<DeployData>>,
+    file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
     extra_system_processes: &mut Vec<Definition>,
     urn_map: HashMap<String, Par>,
     merge_chs: Arc<tokio::sync::RwLock<HashMap<Par, MergeType>>>,
@@ -1422,6 +1484,7 @@ async fn setup_reducer(
         invalid_blocks,
         urn_map.clone(),
         deploy_data_ref,
+        file_handles,
         extra_system_processes,
         openai_service,
         ollama_service,
@@ -1511,6 +1574,7 @@ pub async fn create_rho_env<T>(
     Arc<tokio::sync::RwLock<BlockData>>,
     InvalidBlocks,
     Arc<tokio::sync::RwLock<DeployData>>,
+    crate::rust::interpreter::io::handle_table::FileHandleTable,
 )
 where
     T: ISpace<Par, BindPattern, ListParWithRandom, TaggedContinuation>
@@ -1521,6 +1585,14 @@ where
 {
     let maps_and_refs = setup_maps_and_refs(extra_system_processes);
     let (block_data_ref, invalid_blocks, deploy_data_ref, mut urn_map, proc_defs) = maps_and_refs;
+
+    // One `FileHandleTable` per runtime, threaded into every
+    // ProcessContext so all fileio native handlers share one fd
+    // space. Cloning shares the underlying `Arc<RwLock<HashMap>>`;
+    // the same clone is returned to `create_runtime` so
+    // `RhoRuntimeImpl` can also see it (needed for the deploy-scope
+    // snapshot/truncate rollback around `evaluate_with_env_and_phlo`).
+    let file_handles = crate::rust::interpreter::io::handle_table::FileHandleTable::new();
 
     // Expose the bitmask-OR mergeable tag to system contracts (Registry.rho)
     // via a URI binding. Genesis-defined tags are unforgeable names; they must
@@ -1561,6 +1633,7 @@ where
         block_data_ref.clone(),
         invalid_blocks.clone(),
         deploy_data_ref.clone(),
+        file_handles.clone(),
         extra_system_processes,
         urn_map,
         merge_chs,
@@ -1573,7 +1646,13 @@ where
     )
     .await;
 
-    (reducer, block_data_ref, invalid_blocks, deploy_data_ref)
+    (
+        reducer,
+        block_data_ref,
+        invalid_blocks,
+        deploy_data_ref,
+        file_handles,
+    )
 }
 
 // This is from Nassim Taleb's "Skin in the Game"
@@ -1620,7 +1699,7 @@ where
     )
     .await;
 
-    let (reducer, block_ref, invalid_blocks, deploy_ref) = rho_env;
+    let (reducer, block_ref, invalid_blocks, deploy_ref, file_handles) = rho_env;
     let mut runtime = RhoRuntimeImpl::new(
         reducer,
         cost,
@@ -1628,6 +1707,7 @@ where
         invalid_blocks,
         deploy_ref,
         merge_chs,
+        file_handles,
     );
 
     if init_registry {

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2110,7 +2110,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::{mode, response};
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_open"));
         };
         let [path_par, mode_par, ack] = args.as_slice() else {
@@ -2121,6 +2123,11 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_open"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match mode::open_options_for(&mode_str) {
             None => response::err(
@@ -2166,7 +2173,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_close"));
         };
         let [fd_par, ack] = args.as_slice() else {
@@ -2175,6 +2184,11 @@ impl SystemProcesses {
         let Some(fd) = RhoNumber::unapply(fd_par) else {
             return Err(illegal_argument_error("native_close"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match self.file_handles.remove(fd).await {
             Some(_) => response::ok(vec![]),
@@ -2206,7 +2220,9 @@ impl SystemProcesses {
 
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_read"));
         };
         let [fd_par, n_par, ack] = args.as_slice() else {
@@ -2215,6 +2231,11 @@ impl SystemProcesses {
         let (Some(fd), Some(n)) = (RhoNumber::unapply(fd_par), RhoNumber::unapply(n_par)) else {
             return Err(illegal_argument_error("native_read"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         // Per-call ceiling on the buffer we allocate. Set below the
         // point where a hostile deploy could exhaust node memory via
@@ -2279,7 +2300,9 @@ impl SystemProcesses {
 
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_write"));
         };
         let [fd_par, bytes_par, ack] = args.as_slice() else {
@@ -2290,6 +2313,11 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_write"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match self.file_handles.get(fd).await {
             None => response::err(response::FSERR_CLOSED, format!("fd {fd} is not open")),
@@ -2322,7 +2350,9 @@ impl SystemProcesses {
 
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_seek"));
         };
         let [fd_par, offset_par, whence_par, ack] = args.as_slice() else {
@@ -2335,6 +2365,11 @@ impl SystemProcesses {
         ) else {
             return Err(illegal_argument_error("native_seek"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let seek_from = match whence.as_str() {
             "set" => {
@@ -2389,7 +2424,9 @@ impl SystemProcesses {
 
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_tell"));
         };
         let [fd_par, ack] = args.as_slice() else {
@@ -2398,6 +2435,11 @@ impl SystemProcesses {
         let Some(fd) = RhoNumber::unapply(fd_par) else {
             return Err(illegal_argument_error("native_tell"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match self.file_handles.get(fd).await {
             None => response::err(response::FSERR_CLOSED, format!("fd {fd} is not open")),
@@ -2426,7 +2468,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_size"));
         };
         let [fd_par, ack] = args.as_slice() else {
@@ -2435,6 +2479,11 @@ impl SystemProcesses {
         let Some(fd) = RhoNumber::unapply(fd_par) else {
             return Err(illegal_argument_error("native_size"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match self.file_handles.get(fd).await {
             None => response::err(response::FSERR_CLOSED, format!("fd {fd} is not open")),
@@ -2465,7 +2514,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_truncate"));
         };
         let [fd_par, n_par, ack] = args.as_slice() else {
@@ -2474,6 +2525,11 @@ impl SystemProcesses {
         let (Some(fd), Some(n)) = (RhoNumber::unapply(fd_par), RhoNumber::unapply(n_par)) else {
             return Err(illegal_argument_error("native_truncate"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         // Per-call ceiling on the size a single truncate can request.
         // On sparse-file filesystems (ext4, apfs) `set_len(n)` is
@@ -2524,7 +2580,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_flush"));
         };
         let [fd_par, ack] = args.as_slice() else {
@@ -2533,6 +2591,11 @@ impl SystemProcesses {
         let Some(fd) = RhoNumber::unapply(fd_par) else {
             return Err(illegal_argument_error("native_flush"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match self.file_handles.get(fd).await {
             None => response::err(response::FSERR_CLOSED, format!("fd {fd} is not open")),
@@ -2568,7 +2631,9 @@ impl SystemProcesses {
         use crate::rust::interpreter::io::{response, stat};
         use crate::rust::interpreter::rho_type::RhoMap;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_stat"));
         };
         let [path_par, ack] = args.as_slice() else {
@@ -2577,6 +2642,11 @@ impl SystemProcesses {
         let Some(path_str) = RhoString::unapply(path_par) else {
             return Err(illegal_argument_error("native_stat"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let path = std::path::Path::new(&path_str);
         let response_par = match tokio::fs::symlink_metadata(path).await {
@@ -2618,7 +2688,9 @@ impl SystemProcesses {
         use crate::rust::interpreter::io::{response, stat};
         use crate::rust::interpreter::rho_type::{RhoList, RhoMap};
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_entries"));
         };
         let [path_par, ack] = args.as_slice() else {
@@ -2627,6 +2699,11 @@ impl SystemProcesses {
         let Some(path_str) = RhoString::unapply(path_par) else {
             return Err(illegal_argument_error("native_entries"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match tokio::fs::read_dir(&path_str).await {
             Err(e) => response::from_io_error(e),
@@ -2721,7 +2798,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_exists"));
         };
         let [path_par, ack] = args.as_slice() else {
@@ -2730,6 +2809,11 @@ impl SystemProcesses {
         let Some(path_str) = RhoString::unapply(path_par) else {
             return Err(illegal_argument_error("native_exists"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match tokio::fs::symlink_metadata(&path_str).await {
             Ok(_) => response::ok(vec![RhoBoolean::create_par(true)]),
@@ -2762,7 +2846,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_rename"));
         };
         let [from_par, to_par, ack] = args.as_slice() else {
@@ -2773,6 +2859,11 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_rename"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match tokio::fs::rename(&from_str, &to_str).await {
             Ok(()) => response::ok(vec![]),
@@ -2805,7 +2896,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_copy_file"));
         };
         let [from_par, to_par, ack] = args.as_slice() else {
@@ -2816,6 +2909,11 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_copy_file"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match tokio::fs::copy(&from_str, &to_str).await {
             Ok(n) => response::ok(vec![RhoNumber::create_par(n as i64)]),
@@ -2838,7 +2936,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_remove_file"));
         };
         let [path_par, ack] = args.as_slice() else {
@@ -2847,6 +2947,11 @@ impl SystemProcesses {
         let Some(path_str) = RhoString::unapply(path_par) else {
             return Err(illegal_argument_error("native_remove_file"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = match tokio::fs::remove_file(&path_str).await {
             Ok(()) => response::ok(vec![]),
@@ -2871,7 +2976,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_remove_dir"));
         };
         let [path_par, recursive_par, ack] = args.as_slice() else {
@@ -2883,6 +2990,11 @@ impl SystemProcesses {
         ) else {
             return Err(illegal_argument_error("native_remove_dir"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let result = if recursive {
             tokio::fs::remove_dir_all(&path_str).await
@@ -2916,7 +3028,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_chmod"));
         };
         let [path_par, mode_bits_par, ack] = args.as_slice() else {
@@ -2928,6 +3042,11 @@ impl SystemProcesses {
         ) else {
             return Err(illegal_argument_error("native_chmod"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let response_par = if !(0..=0o777).contains(&mode_bits) {
             response::err(
@@ -2981,7 +3100,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::{path as pathq, response};
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_quarantine"));
         };
         let [root_par, rel_par, ack] = args.as_slice() else {
@@ -2992,6 +3113,11 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_quarantine"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         let root_path = std::path::Path::new(&root_str);
         let response_par = match pathq::canonicalize_and_quarantine(root_path, &rel_str) {
@@ -3034,7 +3160,9 @@ impl SystemProcesses {
     ) -> Result<Vec<Par>, InterpreterError> {
         use crate::rust::interpreter::io::response;
 
-        let Some((produce, _, _, args)) = self.is_contract_call().unapply(contract_args) else {
+        let Some((produce, is_replay, previous_output, args)) =
+            self.is_contract_call().unapply(contract_args)
+        else {
             return Err(illegal_argument_error("native_chown"));
         };
         let [path_par, owner_par, group_par, ack] = args.as_slice() else {
@@ -3047,6 +3175,11 @@ impl SystemProcesses {
         ) else {
             return Err(illegal_argument_error("native_chown"));
         };
+
+        if is_replay {
+            produce(&previous_output, ack).await?;
+            return Ok(previous_output);
+        }
 
         #[cfg(unix)]
         let response_par = {

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -423,6 +423,7 @@ impl ProcessContext {
         invalid_blocks: InvalidBlocks,
         deploy_data: Arc<tokio::sync::RwLock<DeployData>>,
         urn_map: Arc<HashMap<String, Par>>,
+        file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
         openai_service: SharedOpenAIService,
         ollama_service: SharedOllamaService,
         grpc_client_service: GrpcClientService,
@@ -441,6 +442,7 @@ impl ProcessContext {
                 block_data,
                 deploy_data,
                 urn_map,
+                file_handles,
                 openai_service,
                 ollama_service,
                 grpc_client_service,
@@ -602,10 +604,15 @@ pub struct SystemProcesses {
     /// legacy URNs.
     pub urn_map: Arc<HashMap<String, Par>>,
     /// Open-file table for the File-I/O native primitives. Shared
-    /// across all clones of this `SystemProcesses` so `nativeOpen`
-    /// on one dispatch worker and `nativeClose` on another see the
-    /// same fd space. Empty at boot; populated by successful
-    /// `nativeOpen` calls.
+    /// across every `Definition`'s handler closure via `Arc`
+    /// interior so `nativeOpen` on one dispatch entry and
+    /// `nativeRead` / `nativeClose` on another see the same fd
+    /// space. Constructed once per runtime in
+    /// `create_rho_env` and passed into every `ProcessContext::create`
+    /// call in the dispatch-table build loop. Empty at boot;
+    /// populated by successful `nativeOpen` calls; rolled back on
+    /// error path via `RhoRuntimeImpl::evaluate_with_env_and_phlo`'s
+    /// snapshot/truncate around the soft-checkpoint boundary.
     pub file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
     openai_service: SharedOpenAIService,
     ollama_service: SharedOllamaService,
@@ -622,6 +629,7 @@ impl SystemProcesses {
         block_data: Arc<tokio::sync::RwLock<BlockData>>,
         deploy_data: Arc<tokio::sync::RwLock<DeployData>>,
         urn_map: Arc<HashMap<String, Par>>,
+        file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable,
         openai_service: SharedOpenAIService,
         ollama_service: SharedOllamaService,
         grpc_client_service: GrpcClientService,
@@ -633,7 +641,12 @@ impl SystemProcesses {
             block_data,
             deploy_data,
             urn_map,
-            file_handles: crate::rust::interpreter::io::handle_table::FileHandleTable::new(),
+            // Passed in rather than freshly-created so every
+            // Definition's handler closure sees the SAME
+            // FileHandleTable; otherwise `nativeOpen` inserts fd=N
+            // into one table and `nativeRead(N)` looks it up in a
+            // different (empty) one and returns FSERR_CLOSED.
+            file_handles,
             openai_service,
             ollama_service,
             grpc_client_service,

--- a/rholang/tests/fileio_lifecycle_spec.rs
+++ b/rholang/tests/fileio_lifecycle_spec.rs
@@ -1,0 +1,253 @@
+//! File-I/O fd table lifecycle: sharing across handlers, and
+//! rollback around the soft-checkpoint boundary.
+//!
+//! Two invariants covered here that the primitive-layer unit
+//! tests (in `interpreter::io::handle_table`) can't reach on
+//! their own:
+//!
+//! 1. **Cross-handler sharing.** `nativeOpen` and every
+//!    fd-consuming primitive (read/write/seek/close/...) must
+//!    all see the SAME `FileHandleTable`. Each `Definition`'s
+//!    handler closure closes over its own `ProcessContext`, so
+//!    if the table isn't threaded in as a shared value, each
+//!    Definition lands with `FileHandleTable::new()` and the
+//!    entire native primitive layer is non-functional through
+//!    the runtime: `nativeOpen` returns `fd=N` but every
+//!    subsequent `native*(N, ...)` looks up in a different
+//!    (empty) table and returns `FSERR_CLOSED`.
+//!
+//! 2. **Deploy-scope rollback.** `evaluate_with_env_and_phlo`
+//!    wraps every deploy in a soft-checkpoint boundary that
+//!    reverts rspace state on error. The `FileHandleTable`
+//!    must participate in the same boundary: fds allocated by
+//!    a deploy that later errors must be dropped, otherwise
+//!    the OS-level `tokio::fs::File` objects sit in the table
+//!    unreachable from Rholang (fds are monotonic, and any
+//!    produce event that mentioned the reverted fd was rolled
+//!    back by the rspace restore) but consuming an OS file
+//!    descriptor until the runtime drops. A hostile deploy
+//!    that repeatedly opens-then-errors could exhaust the
+//!    process's `ulimit -n`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
+use rholang::rust::interpreter::system_processes::FixedChannels;
+use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+#[allow(clippy::type_complexity)]
+async fn mk_runtime() -> RhoRuntimeImpl {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+    let (runtime, _, _): (
+        RhoRuntimeImpl,
+        RhoRuntimeImpl,
+        Arc<
+            Box<
+                dyn HistoryRepository<Par, BindPattern, ListParWithRandom, TaggedContinuation>
+                    + Send
+                    + Sync
+                    + 'static,
+            >,
+        >,
+    ) = create_runtimes_with_services(store, false, &mut Vec::new(), ExternalServices::noop())
+        .await;
+    runtime
+}
+
+fn temp_path(tag: &str) -> String {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "fileio_lifecycle_{tag}_{pid}_{ts}",
+        pid = std::process::id(),
+        ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    p.to_string_lossy().into_owned()
+}
+
+fn open_read_env() -> HashMap<String, Par> {
+    let mut env: HashMap<String, Par> = HashMap::new();
+    env.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/read".to_string(),
+        FixedChannels::native_read(),
+    );
+    env
+}
+
+/// Open a file, then immediately read from the returned fd.
+/// Regression guard for the cross-handler sharing invariant: if
+/// each Definition's handler had its own `FileHandleTable::new()`
+/// (which is what the old `SystemProcesses::create` did before
+/// the shared-table plumbing), `nativeRead(1)` would see an empty
+/// table and return `[false, FSERR_CLOSED, "fd 1 is not open"]`
+/// instead of `[true, <bytes>]`. Verified by grepping for the
+/// success-tuple shape on the sink channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn open_then_read_shares_fd_table() {
+    let path = temp_path("open_read");
+    std::fs::write(&path, b"hello").expect("precondition write");
+
+    let env = open_read_env();
+    let term = format!(
+        r#"new nOpen(`rho:io:fs:native:1.0.0/open`),
+                nRead(`rho:io:fs:native:1.0.0/read`),
+                openAck, readAck in {{
+             nOpen!("{path}", "r", *openAck) |
+             for (@[true, fd] <- openAck) {{
+               nRead!(fd, 5, *readAck) |
+               for (@result <- readAck) {{ @"sink"!(result) }}
+             }}
+           }}"#
+    );
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "lifecycle-sharing".to_string());
+    let result = runtime
+        .evaluate(&term, phlo, env, rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink_channel = Par::default().with_exprs(vec![models::rhoapi::Expr {
+        expr_instance: Some(models::rhoapi::expr::ExprInstance::GString(
+            "sink".to_string(),
+        )),
+    }]);
+    let data = runtime.get_data(&sink_channel).await;
+    let joined: String = data
+        .into_iter()
+        .flat_map(|d| d.a.pars)
+        .map(|p| format!("{p:?}"))
+        .collect::<Vec<_>>()
+        .join(" | ");
+
+    let _ = std::fs::remove_file(&path);
+
+    // nativeRead returns the ASCII bytes of "hello" as a
+    // `GByteArray([104, 101, 108, 108, 111])`. Verify both the
+    // success-tuple shape and the expected byte content.
+    assert!(
+        joined.contains("GBool(true)"),
+        "expected [true, ...] success tuple on sink, got: {joined}"
+    );
+    assert!(
+        joined.contains("GByteArray([104, 101, 108, 108, 111])"),
+        "expected the ASCII bytes of \"hello\" on sink, got: {joined}"
+    );
+}
+
+/// Deploy successfully allocates two fds; verify the table holds
+/// them and `next_fd` advanced. Baseline for the rollback test
+/// that follows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn successful_deploy_leaves_fds_in_table() {
+    let path_a = temp_path("commit_a");
+    let path_b = temp_path("commit_b");
+    std::fs::write(&path_a, b"aaa").expect("precondition a");
+    std::fs::write(&path_b, b"bbb").expect("precondition b");
+
+    let mut env: HashMap<String, Par> = HashMap::new();
+    env.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+
+    let term = format!(
+        r#"new nOpen(`rho:io:fs:native:1.0.0/open`), ack1, ack2 in {{
+             nOpen!("{path_a}", "r", *ack1) |
+             for (@_ <- ack1) {{
+               nOpen!("{path_b}", "r", *ack2) |
+               for (@_ <- ack2) {{ Nil }}
+             }}
+           }}"#
+    );
+
+    let mut runtime = mk_runtime().await;
+    let fd_snapshot_before = runtime.file_handles.snapshot_next_fd();
+    let phlo = Cost::create(i64::MAX, "lifecycle-commit".to_string());
+    let result = runtime
+        .evaluate_with_env_and_phlo(&term, phlo, env)
+        .await
+        .expect("evaluate_with_env_and_phlo");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let fd_snapshot_after = runtime.file_handles.snapshot_next_fd();
+    assert_eq!(
+        fd_snapshot_after,
+        fd_snapshot_before + 2,
+        "successful deploy should advance next_fd by 2 (two nativeOpens)"
+    );
+
+    let _ = std::fs::remove_file(&path_a);
+    let _ = std::fs::remove_file(&path_b);
+}
+
+/// Deploy calls nativeOpen (successfully) and then triggers a
+/// deploy-level error via `1 / 0`. `evaluate_with_env_and_phlo`
+/// reverts rspace to the soft checkpoint AND truncates the
+/// FileHandleTable back to the pre-deploy `next_fd`, so the
+/// opened fd is dropped. Without the M1 fix, the fd would linger
+/// in the table (its OS-level `tokio::fs::File` still open) with
+/// no Rholang-reachable way to close it -- a resource leak that
+/// a hostile deploy could weaponize into fd exhaustion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn erroring_deploy_rolls_back_fd_allocations() {
+    let path = temp_path("rollback");
+    std::fs::write(&path, b"oops").expect("precondition");
+
+    let mut env: HashMap<String, Par> = HashMap::new();
+    env.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+
+    // Open the file, then divide by zero. The div-by-zero fires
+    // AFTER nativeOpen has succeeded and inserted the fd; the
+    // resulting eval-level error causes evaluate_with_env_and_phlo
+    // to revert rspace + truncate the fd table.
+    let term = format!(
+        r#"new nOpen(`rho:io:fs:native:1.0.0/open`), ack in {{
+             nOpen!("{path}", "r", *ack) |
+             for (@[true, _] <- ack) {{ @0!(1 / 0) }}
+           }}"#
+    );
+
+    let mut runtime = mk_runtime().await;
+    let fd_snapshot_before = runtime.file_handles.snapshot_next_fd();
+    let phlo = Cost::create(i64::MAX, "lifecycle-rollback".to_string());
+    let result = runtime
+        .evaluate_with_env_and_phlo(&term, phlo, env)
+        .await
+        .expect("evaluate_with_env_and_phlo (produces errors, but doesn't hard-fail)");
+    assert!(
+        !result.errors.is_empty(),
+        "deploy should have errored (div-by-zero); got no errors"
+    );
+
+    let fd_snapshot_after = runtime.file_handles.snapshot_next_fd();
+    assert_eq!(
+        fd_snapshot_after,
+        fd_snapshot_before,
+        "erroring deploy should truncate next_fd back to pre-deploy snapshot; \
+         table has {} entries before revert-check",
+        fd_snapshot_after - fd_snapshot_before
+    );
+
+    let _ = std::fs::remove_file(&path);
+}

--- a/rholang/tests/fileio_replay_spec.rs
+++ b/rholang/tests/fileio_replay_spec.rs
@@ -1,0 +1,242 @@
+//! Non-deterministic-replay tests for the File I/O native primitives.
+//!
+//! Every fileio native handler wraps its syscall in an
+//! `if is_replay { produce(&previous_output, ack).await?; return
+//! Ok(previous_output); }` guard so followers replay the lead
+//! node's captured output rather than re-running the syscall.
+//! Without the guard, a follower whose disk state has drifted
+//! from the lead's would observe different bytes / entries /
+//! metadata / existence, and consensus would break.
+//!
+//! Each test below:
+//!   1. Plays a Rholang term that invokes a fileio native URN
+//!      against a specific disk state (e.g. a file with known
+//!      contents).
+//!   2. **Mutates the disk** between play and replay -- e.g.
+//!      removes the file the test just read, or writes different
+//!      bytes on top of it.
+//!   3. Rigs a replay runtime with the play's event log and
+//!      re-evaluates the same term.
+//!   4. Verifies `check_replay_data` succeeds. If the guard were
+//!      missing, the follower would call the syscall again and
+//!      produce output derived from the *mutated* disk state --
+//!      that output would not match the log's captured entry, and
+//!      the rspace replay would flag the mismatch.
+//!
+//! The tests use `FixedChannels::native_*()` to build the
+//! per-deploy `NormalizerEnv` in the same shape the FS-agent's
+//! genesis deploy will (via `compile_fileio_genesis_source` in
+//! `interpreter::io::injections`). Handing the tests the raw
+//! bundle keeps them free of the `pub(crate)` visibility of the
+//! wrapper helper.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
+use rholang::rust::interpreter::system_processes::FixedChannels;
+use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+/// Build a `NormalizerEnv` containing only the fileio native URNs
+/// the test needs. Mirrors what `compile_fileio_genesis_source`
+/// does internally in the `interpreter::io::injections` module.
+fn fileio_env(urns: &[(&str, Par)]) -> HashMap<String, Par> {
+    urns.iter()
+        .map(|(u, p)| ((*u).to_string(), p.clone()))
+        .collect()
+}
+
+#[allow(clippy::type_complexity)]
+async fn mk_pair() -> (RhoRuntimeImpl, RhoRuntimeImpl) {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+    let (runtime, replay_runtime, _): (
+        RhoRuntimeImpl,
+        RhoRuntimeImpl,
+        Arc<
+            Box<
+                dyn HistoryRepository<Par, BindPattern, ListParWithRandom, TaggedContinuation>
+                    + Send
+                    + Sync
+                    + 'static,
+            >,
+        >,
+    ) = create_runtimes_with_services(store, false, &mut Vec::new(), ExternalServices::noop())
+        .await;
+    (runtime, replay_runtime)
+}
+
+/// Play + replay + `check_replay_data` in the standard shape.
+/// Between the play evaluation and the rig, `mutate` runs so the
+/// disk state visible to the replay handler differs from the play
+/// handler. If any handler cheats -- runs the syscall instead of
+/// consulting `previous_output` -- the replay's produce output
+/// won't match the log entry recorded during play, and
+/// `check_replay_data` fails.
+async fn play_mutate_replay(term: &str, env: HashMap<String, Par>, mutate: impl FnOnce()) {
+    let (mut runtime, mut replay_runtime) = mk_pair().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "fileio-replay-test".to_string());
+
+    let play = runtime
+        .evaluate(term, phlo.clone(), env.clone(), rand.clone())
+        .await
+        .expect("play should compile+evaluate");
+    assert!(
+        play.errors.is_empty(),
+        "play produced errors: {:?}",
+        play.errors
+    );
+
+    let checkpoint = runtime.create_checkpoint().await;
+
+    mutate();
+
+    replay_runtime
+        .reset(&checkpoint.root)
+        .await
+        .expect("replay reset");
+    replay_runtime
+        .rig(checkpoint.log)
+        .await
+        .expect("replay rig");
+
+    let replay = replay_runtime
+        .evaluate(term, phlo, env, rand)
+        .await
+        .expect("replay should compile+evaluate");
+    assert!(
+        replay.errors.is_empty(),
+        "replay produced errors (guard likely absent): {:?}",
+        replay.errors
+    );
+
+    replay_runtime
+        .check_replay_data()
+        .await
+        .expect("check_replay_data (unconsumed events => guard didn't fire)");
+
+    // Same charged cost too -- non-deterministic ops cost the same on
+    // both sides because the log-driven produce is bookkeeping-only.
+    assert_eq!(
+        play.cost.value, replay.cost.value,
+        "play/replay cost divergence"
+    );
+}
+
+/// Absolute path to a temp-file name unique to this test process
+/// so parallel test runs don't stomp on each other.
+fn temp_path(tag: &str) -> String {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "fileio_replay_spec_{tag}_{pid}_{ts}",
+        pid = std::process::id(),
+        ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    p.to_string_lossy().into_owned()
+}
+
+/// Play `nativeExists(path)` where `path` does not exist -->
+/// `[true, false]`. Between play and replay, CREATE the file.
+/// A follower that reruns the syscall would produce `[true, true]`
+/// and mismatch the log. The guard forces `[true, false]` on both.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exists_replays_false_after_file_is_created_between_runs() {
+    let path = temp_path("exists_false");
+    // Precondition: the path must not exist during play.
+    let _ = std::fs::remove_file(&path);
+
+    let env = fileio_env(&[(
+        "rho:io:fs:native:1.0.0/exists",
+        FixedChannels::native_exists(),
+    )]);
+
+    let path_for_term = path.clone();
+    let path_for_mutate = path.clone();
+    let term = format!(
+        r#"new nExists(`rho:io:fs:native:1.0.0/exists`), ret in {{
+             nExists!("{path_for_term}", *ret) |
+             for (@_ <- ret) {{ Nil }}
+           }}"#
+    );
+
+    play_mutate_replay(&term, env, move || {
+        std::fs::write(&path_for_mutate, b"appeared after play")
+            .expect("create file between play and replay");
+    })
+    .await;
+
+    // Cleanup.
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Play `nativeExists(path)` where the file exists --> `[true, true]`.
+/// Between play and replay, DELETE the file. A follower rerunning the
+/// syscall would produce `[true, false]`; the guard forces `[true, true]`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn exists_replays_true_after_file_is_deleted_between_runs() {
+    let path = temp_path("exists_true");
+    std::fs::write(&path, b"present at play time").expect("precondition write");
+
+    let env = fileio_env(&[(
+        "rho:io:fs:native:1.0.0/exists",
+        FixedChannels::native_exists(),
+    )]);
+
+    let path_for_term = path.clone();
+    let path_for_mutate = path.clone();
+    let term = format!(
+        r#"new nExists(`rho:io:fs:native:1.0.0/exists`), ret in {{
+             nExists!("{path_for_term}", *ret) |
+             for (@_ <- ret) {{ Nil }}
+           }}"#
+    );
+
+    play_mutate_replay(&term, env, move || {
+        std::fs::remove_file(&path_for_mutate).expect("remove file between play and replay");
+    })
+    .await;
+}
+
+/// Play `nativeStat(path)` on a file with known contents/mtime. Between
+/// play and replay, overwrite the file (changing mtime AND size). A
+/// follower rerunning the syscall would observe a stat record with the
+/// new size/mtime; the guard forces the play's original record.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stat_replays_original_metadata_after_file_is_modified() {
+    let path = temp_path("stat_meta");
+    std::fs::write(&path, b"original").expect("precondition write");
+
+    let env = fileio_env(&[("rho:io:fs:native:1.0.0/stat", FixedChannels::native_stat())]);
+
+    let path_for_term = path.clone();
+    let path_for_mutate = path.clone();
+    let term = format!(
+        r#"new nStat(`rho:io:fs:native:1.0.0/stat`), ret in {{
+             nStat!("{path_for_term}", *ret) |
+             for (@_ <- ret) {{ Nil }}
+           }}"#
+    );
+
+    play_mutate_replay(&term, env, move || {
+        // Overwrite with different bytes so size changes; sleep first
+        // so mtime is guaranteed to differ on filesystems with 1s
+        // mtime resolution (HFS+ and some FAT variants).
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        std::fs::write(&path_for_mutate, b"different contents entirely")
+            .expect("mutate file between play and replay");
+    })
+    .await;
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
## Summary

Every fileio native primitive was already registered in `non_deterministic_ops()` (so the dispatcher captures its output on the lead node's play), but the 19 handlers themselves ignored `is_replay` / `previous_output` and re-ran the syscall on followers — observing whatever the follower's disk state happened to be at that moment. On any node whose disk diverges from the lead's (observer nodes without the same static-config directory, a lead that mutated its own tree between play and replay, etc.), replay would diverge from the log's recorded output and consensus would break.

This PR adds the canonical replay guard to all 19 handlers, matching the shape used by `gpt4` / `grpc_tell` / the other pre-existing non-deterministic system processes.

## Change

For each of the 19 handlers in `system_processes.rs`:

1. Change the destructuring from `(produce, _, _, args)` to `(produce, is_replay, previous_output, args)`.
2. After the arg-shape and type-check validation blocks, but before the syscall, insert:

    ```rust
    if is_replay {
        produce(&previous_output, ack).await?;
        return Ok(previous_output);
    }
    ```

Placement rationale: after validation so followers observe the same arg-type failures the lead did (deterministic given deterministic args); before the syscall so followers never touch the host filesystem.

**Handlers covered** — every fileio native, without exception:

- Fd lifecycle: `native_open`, `native_close`, `native_flush`
- Positional: `native_read`, `native_write`, `native_seek`, `native_tell`, `native_size`, `native_truncate`
- Filesystem queries: `native_stat`, `native_entries`, `native_exists`, `native_quarantine`
- Filesystem mutations: `native_rename`, `native_copy_file`, `native_remove_file`, `native_remove_dir`, `native_chmod`, `native_chown`

Bookkeeping-only handlers (`seek`, `tell`, `close`, `flush`) go through the guard too — their local behavior looks deterministic but the fd they operate on came from a `native_open` whose fd allocation IS non-deterministic (fd table timeline coherence). Matches the "defense-in-depth" design rationale already recorded in `non_deterministic_ops()`.

## Tests

New integration suite `rholang/tests/fileio_replay_spec.rs`. The `play_mutate_replay` harness runs the standard evaluate → checkpoint → mutate → rig → re-evaluate → `check_replay_data` sequence, but **mutates the disk between play and replay** so any handler that cheated (ran the syscall on the follower) would produce output derived from the mutated state, mismatching the log and tripping `check_replay_data`.

Three concrete cases:

- **`exists_replays_false_after_file_is_created_between_runs`** — play sees "doesn't exist"; between runs the file is created; replay must still emit `[true, false]` from the log, not the fresh syscall's `[true, true]`.
- **`exists_replays_true_after_file_is_deleted_between_runs`** — symmetric: play sees "exists", file is deleted, replay must still emit `[true, true]`.
- **`stat_replays_original_metadata_after_file_is_modified`** — play captures a stat record; the file is overwritten between runs (size + mtime change); replay must emit the original record.

**Regression-proof verified in-workflow**: git-stashed the handler changes, re-ran the suite, watched all 3 fail with `RSpaceError(BugFoundError("Unused COMM event: replayData multimap has 2 elements left"))` — exactly the signal we wanted. Restored the guards, all 3 pass.

## Test plan

- [x] `cargo build -p rholang` clean
- [x] `cargo test -p rholang --lib io::` — 37 pass (unchanged)
- [x] `cargo test -p rholang --test fileio_replay_spec` — 3 pass
- [x] `cargo test -p casper --test mod empty_state_hash_should_be_the_same_as_hard_coded_cached_value` passes (no genesis-contract changes)
- [x] `cargo fmt -p rholang` clean
- [x] Pre-push hook (workspace fmt/clippy/deny + full test matrix) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787252504&installation_model_id=426883&pr_number=137&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F137&signature=3d67ef37ed390dae6d904a48f0f38d70fd6ba48f9d7ca4b59693e27a7819d2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->