### PR TITLE
[agent] fix(soak): delay-tolerant schedule gate, 60h weekend window; …

### DIFF
--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -18,7 +18,7 @@ on:
         type: choice
         options:
           - daily-24h
-          - weekend-72h
+          - weekend-60h
 
 permissions:
   contents: read
@@ -46,21 +46,32 @@ jobs:
         id: resolve
         env:
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_SCHEDULE: ${{ github.event.schedule }}
           INPUT_DURATION: ${{ inputs.duration }}
           INPUT_TARGET_REF: ${{ inputs.target_ref }}
         shell: bash -euo pipefail {0}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$INPUT_DURATION" = "weekend-72h" ]; then
-              duration_seconds=259200
+            if [ "$INPUT_DURATION" = "weekend-60h" ]; then
+              duration_seconds=216000
             else
               duration_seconds=86400
             fi
             target_ref="$INPUT_TARGET_REF"
             should_run=true
           else
-            pacific_hour="$(TZ=America/Los_Angeles date +%H)"
-            pacific_weekday="$(TZ=America/Los_Angeles date +%u)"
+            # GitHub delivers cron triggers minutes-to-hours late, so gate on
+            # the cron's intended slot (most recent occurrence at or before
+            # now), not the wall clock at execution time.
+            cron_hour="$(awk '{print $2}' <<<"$EVENT_SCHEDULE")"
+            now_epoch="$(date -u +%s)"
+            slot_epoch="$(date -u -d "$(date -u +%F) ${cron_hour}:00:00" +%s)"
+            if [ "$slot_epoch" -gt "$now_epoch" ]; then
+              slot_epoch=$((slot_epoch - 86400))
+            fi
+            pacific_hour="$(TZ=America/Los_Angeles date -d "@${slot_epoch}" +%H)"
+            pacific_weekday="$(TZ=America/Los_Angeles date -d "@${slot_epoch}" +%u)"
+            echo "cron=$EVENT_SCHEDULE slot=$(date -u -d "@${slot_epoch}" +%FT%TZ) pacific_hour=$pacific_hour pacific_weekday=$pacific_weekday"
             target_ref=dev
             should_run=false
             duration_seconds=86400
@@ -68,11 +79,11 @@ jobs:
               should_run=true
             elif [ "$pacific_hour" = "22" ] && [ "$pacific_weekday" -eq 5 ]; then
               should_run=true
-              duration_seconds=259200
+              duration_seconds=216000
             fi
           fi
           run_benchmarks=false
-          if [ "$duration_seconds" = "259200" ]; then
+          if [ "$duration_seconds" = "216000" ]; then
             run_benchmarks=true
           fi
           {
@@ -154,7 +165,7 @@ jobs:
     needs: [schedule_gate, launch_runner]
     if: needs.schedule_gate.outputs.should_run == 'true'
     runs-on: [self-hosted, linux, x64, f1r3fly-rust-ci-ephemeral, oracle-cloud]
-    timeout-minutes: 4560
+    timeout-minutes: 3840
     concurrency:
       group: merge-recovery-soak-${{ needs.schedule_gate.outputs.duration_seconds }}
       cancel-in-progress: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ This repo was extracted from `F1R3FLY-io/f1r3fly` (`rust/dev` branch). Key diffe
 | Document | Purpose | Location |
 |----------|---------|----------|
 | User Stories | Business needs and acceptance criteria | `docs/UserStories.md` |
-| Tasks/Epochs | Implementation tracking | `docs/ToDos.md` |
+| Tasks/Epics | Implementation tracking | `docs/ToDos.md` |
 | Completed Work | Historical reference | `docs/CompletedTasks.md` |
 | Backlog | Deferred items | `docs/Backlog.md` |
 | Work Logs | Session progress | `docs/work-logs/*.md` |
@@ -230,8 +230,8 @@ This applies to all slash commands and scripts that create configuration files.
 #### Task Management
 - `/nextTask` - Find and select next task to work on
 - `/implement` - Begin implementation of a task
-- `/epoch-review` - Preview and summarize epochs
-- `/epoch-hygiene` - Archive completed epochs
+- `/epic-review` - Preview and summarize epics
+- `/epic-hygiene` - Archive completed epics
 
 #### Workspace Sync
 - `/harmonize` - Sync workspace policies into this repo

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -41,7 +41,7 @@ title: "Abstract provisioning layer so testbed can run on AWS or GCP, not just O
 category: feature_idea
 priority: p3
 added_at: 2026-04-13
-related_epoch: EPOCH-009
+related_epic: EPIC-009
 ---
 ```
 
@@ -56,7 +56,7 @@ related_epoch: EPOCH-009
 
 **When Unblocked:** After a second concrete deployment target is requested (e.g. user explicitly wants AWS for a production benchmark). Premature to abstract against one known provider only.
 
-**Related work:** EPOCH-009 establishes the OCI implementation that this would generalize. `vps-*` Justfile prefix is already chosen to outlive OCI-only.
+**Related work:** EPIC-009 establishes the OCI implementation that this would generalize. `vps-*` Justfile prefix is already chosen to outlive OCI-only.
 
 ---
 
@@ -69,7 +69,7 @@ title: "Inter-shard consensus (cross-shard bridge between two independent shards
 category: feature_idea
 priority: p3
 added_at: 2026-04-13
-related_epoch: EPOCH-009
+related_epic: EPIC-009
 ---
 ```
 
@@ -92,9 +92,9 @@ related_epoch: EPOCH-009
 5. Multi-shard genesis ceremony + configuration schema (~50 lines)
 6. Integration tests for multi-shard deployments (~400 lines)
 
-**When Unblocked:** Requires design doc + architectural review. Not ready for promotion to active epoch until the hierarchical-shard model is fully specified and the bridge protocol has a reviewed spec.
+**When Unblocked:** Requires design doc + architectural review. Not ready for promotion to active epic until the hierarchical-shard model is fully specified and the bridge protocol has a reviewed spec.
 
-**Related work:** EPOCH-009 stands up a **single-shard** distributed testbed on OCI. If BACKLOG-FI-001 is promoted, the testbed from EPOCH-009 would extend naturally to a 4-VPS multi-shard topology.
+**Related work:** EPIC-009 stands up a **single-shard** distributed testbed on OCI. If BACKLOG-FI-001 is promoted, the testbed from EPIC-009 would extend naturally to a 4-VPS multi-shard topology.
 
 ---
 
@@ -130,7 +130,7 @@ expected_resolution: "When system-integration updates services.yml to point to f
 
 When a backlog item is ready for active development:
 
-1. Create an epoch in `docs/ToDos.md` based on the backlog item
+1. Create an epic in `docs/ToDos.md` based on the backlog item
 2. Create or link a user story in `docs/UserStories.md` if needed
 3. Remove the item from this backlog (or mark as `promoted: true`)
 4. Add a note referencing the original backlog ID

--- a/docs/CompletedTasks.md
+++ b/docs/CompletedTasks.md
@@ -6,7 +6,7 @@ last_updated: 2026-04-15
 
 # Completed Tasks
 
-This document archives completed epochs and tasks for historical reference and progress tracking.
+This document archives completed epics and tasks for historical reference and progress tracking.
 
 **Document Structure**
 - Active work: `docs/ToDos.md`
@@ -16,17 +16,17 @@ This document archives completed epochs and tasks for historical reference and p
 
 ---
 
-## Completed Epochs
+## Completed Epics
 
-<!-- Epochs are listed in reverse chronological order (newest first) -->
+<!-- Epics are listed in reverse chronological order (newest first) -->
 
 ---
 
-### EPOCH-R03: CI/CD Pipeline
+### EPIC-R03: CI/CD Pipeline
 
 ```yaml
 ---
-epoch_id: EPOCH-R03
+epic_id: EPIC-R03
 title: "CI/CD Pipeline"
 status: complete
 priority: p1
@@ -50,11 +50,11 @@ tasks:
 
 ---
 
-### EPOCH-R02: Developer Tooling and Hooks
+### EPIC-R02: Developer Tooling and Hooks
 
 ```yaml
 ---
-epoch_id: EPOCH-R02
+epic_id: EPIC-R02
 title: "Developer Tooling and Hooks"
 status: complete
 priority: p1
@@ -91,11 +91,11 @@ tasks:
 
 ---
 
-### EPOCH-R01: Repository Extraction
+### EPIC-R01: Repository Extraction
 
 ```yaml
 ---
-epoch_id: EPOCH-R01
+epic_id: EPIC-R01
 title: "Repository Extraction"
 status: complete
 priority: p0
@@ -119,7 +119,7 @@ tasks:
 
 ## Completion Statistics
 
-| Period | Epochs Completed | Tasks Completed | Notes |
+| Period | Epics Completed | Tasks Completed | Notes |
 |--------|------------------|-----------------|-------|
 | 2026-03 | 3 | 9 | Repo bootstrap: extraction, tooling, CI |
 

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -7,9 +7,9 @@ mr_status:
   target_branch: master
 ---
 
-# Tasks and Epochs
+# Tasks and Epics
 
-This document tracks implementation work through **epochs** (logical groupings of related tasks).
+This document tracks implementation work through **epics** (logical groupings of related tasks).
 
 **Document Structure**
 - Active work: This file (`docs/ToDos.md`)
@@ -43,17 +43,17 @@ mr_status:
 
 ---
 
-## Active Epochs
+## Active Epics
 
-<!-- Epochs ordered by priority. EPOCH-001/002 are system-integration alignment (US-001). EPOCH-003-008 are migration (US-002). -->
+<!-- Epics ordered by priority. EPIC-001/002 are system-integration alignment (US-001). EPIC-003-008 are migration (US-002). -->
 
 ---
 
-### EPOCH-001: System-Integration Alignment
+### EPIC-001: System-Integration Alignment
 
 ```yaml
 ---
-epoch_id: EPOCH-001
+epic_id: EPIC-001
 title: "System-Integration Alignment"
 status: in_progress
 priority: p1
@@ -88,7 +88,7 @@ tasks:
   - id: TASK-001-4
     title: "Verify shard starts with updated genesis and network config"
     status: complete
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     completed_at: 2026-04-13T20:55:00Z
     blocked_by: []
     acceptance:
@@ -116,11 +116,11 @@ tasks:
 
 ---
 
-### EPOCH-002: Separate Monitoring from Shard Compose
+### EPIC-002: Separate Monitoring from Shard Compose
 
 ```yaml
 ---
-epoch_id: EPOCH-002
+epic_id: EPIC-002
 title: "Separate Monitoring from Shard Compose"
 status: pending
 priority: p2
@@ -133,7 +133,7 @@ tasks:
   - id: TASK-002-1
     title: "Extract Prometheus and Grafana into docker/monitoring.yml"
     status: complete
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     completed_at: 2026-04-13T21:35:00Z
     acceptance:
       - "docker/monitoring.yml contains prometheus and grafana services"
@@ -155,11 +155,11 @@ tasks:
 
 ---
 
-### EPOCH-003: Merge Critical PRs into f1r3node
+### EPIC-003: Merge Critical PRs into f1r3node
 
 ```yaml
 ---
-epoch_id: EPOCH-003
+epic_id: EPIC-003
 title: "Merge Critical PRs into f1r3node"
 status: pending
 priority: p0
@@ -170,7 +170,7 @@ claimed_by: null
 claimed_at: null
 external: true
 external_repo: F1R3FLY-io/f1r3node
-coordination_note: "This epoch is executed by the agent in f1r3node. Track progress via /tmp/migrationPlan.md phase_1_critical_prs status."
+coordination_note: "This epic is executed by the agent in f1r3node. Track progress via /tmp/migrationPlan.md phase_1_critical_prs status."
 tasks:
   - id: TASK-003-1
     title: "Verify new_parser branch status"
@@ -210,27 +210,27 @@ tasks:
 
 **Scope:**
 - Included: Merging blocking and ready PRs into f1r3node rust/dev
-- Excluded: Any work in f1r3node-rust (that starts in EPOCH-004)
+- Excluded: Any work in f1r3node-rust (that starts in EPIC-004)
 
 **Notes:**
 - The 11-PR Reified RSpaces chain has a sequential dependency — each PR targets the previous one
 - Chain base (#328) depends on `new_parser` branch which depends on `rholang-rs#83`
-- Monitor `/tmp/migrationPlan.md` for `phase_1_critical_prs.status` to know when to start EPOCH-004
+- Monitor `/tmp/migrationPlan.md` for `phase_1_critical_prs.status` to know when to start EPIC-004
 
 ---
 
-### EPOCH-004: Code Sync to f1r3node-rust
+### EPIC-004: Code Sync to f1r3node-rust
 
 ```yaml
 ---
-epoch_id: EPOCH-004
+epic_id: EPIC-004
 title: "Code Sync to f1r3node-rust"
 status: in_progress
 priority: p0
 user_story: US-002
-blocked_by: [EPOCH-003]
+blocked_by: [EPIC-003]
 created_at: 2026-04-09
-claimed_by: claude-session-epoch004
+claimed_by: claude-session-epic004
 claimed_at: 2026-04-17T19:19:55Z
 source_branch: rust/staging
 source_head: fb59611fbf2be202a6d6450850de1435c9dec7a4
@@ -238,7 +238,7 @@ tasks:
   - id: TASK-004-1
     title: "Sync Rust workspace crates from f1r3node rust/staging"
     status: review
-    claimed_by: claude-session-epoch004
+    claimed_by: claude-session-epic004
     claimed_at: 2026-04-17T19:19:55Z
     completed_at: 2026-04-29T18:50:45Z
     notes:
@@ -307,26 +307,26 @@ tasks:
 
 **Scope:**
 - Included: All Rust crates, CI/CD, Docker, scripts, local dev config, version tagging
-- Excluded: Issue migration (EPOCH-005), external repo updates (EPOCH-006)
+- Excluded: Issue migration (EPIC-005), external repo updates (EPIC-006)
 
 **Notes:**
-- The code delta is ~4 releases (v0.4.9-v0.4.11) plus the critical PRs from EPOCH-003
+- The code delta is ~4 releases (v0.4.9-v0.4.11) plus the critical PRs from EPIC-003
 - Docker image renamed from `f1r3fly-rust-node` to `f1r3fly-rust`
 - Version drops the `rust-` tag prefix (no longer needed in a Rust-only repo)
 - Run tests per-crate to avoid LMDB lock contention (see commit f2b4b5f)
 
 ---
 
-### EPOCH-005: Issue Migration
+### EPIC-005: Issue Migration
 
 ```yaml
 ---
-epoch_id: EPOCH-005
+epic_id: EPIC-005
 title: "Issue Migration"
 status: complete
 priority: p1
 user_story: US-002
-blocked_by: [EPOCH-004]
+blocked_by: [EPIC-004]
 created_at: 2026-04-09
 claimed_by: claude-session-migrate
 claimed_at: 2026-04-17T19:35:00Z
@@ -369,16 +369,16 @@ tasks:
 
 ---
 
-### EPOCH-006: External Repo Updates
+### EPIC-006: External Repo Updates
 
 ```yaml
 ---
-epoch_id: EPOCH-006
+epic_id: EPIC-006
 title: "External Repo Updates"
 status: pending
 priority: p1
 user_story: US-002
-blocked_by: [EPOCH-004]
+blocked_by: [EPIC-004]
 created_at: 2026-04-09
 claimed_by: null
 claimed_at: null
@@ -416,16 +416,16 @@ tasks:
 
 ---
 
-### EPOCH-007: PR Cleanup & Redirect
+### EPIC-007: PR Cleanup & Redirect
 
 ```yaml
 ---
-epoch_id: EPOCH-007
+epic_id: EPIC-007
 title: "PR Cleanup & Redirect"
 status: pending
 priority: p1
 user_story: US-002
-blocked_by: [EPOCH-004]
+blocked_by: [EPIC-004]
 created_at: 2026-04-09
 claimed_by: null
 claimed_at: null
@@ -452,20 +452,20 @@ tasks:
 
 **Scope:**
 - Included: Commenting and closing PRs on f1r3node
-- Excluded: Tier 1/2 PRs (handled in EPOCH-003)
+- Excluded: Tier 1/2 PRs (handled in EPIC-003)
 
 ---
 
-### EPOCH-008: Deprecation & Archive
+### EPIC-008: Deprecation & Archive
 
 ```yaml
 ---
-epoch_id: EPOCH-008
+epic_id: EPIC-008
 title: "Deprecation & Archive"
 status: pending
 priority: p2
 user_story: US-002
-blocked_by: [EPOCH-005, EPOCH-006, EPOCH-007]
+blocked_by: [EPIC-005, EPIC-006, EPIC-007]
 created_at: 2026-04-09
 claimed_by: null
 claimed_at: null
@@ -515,24 +515,24 @@ tasks:
 
 ---
 
-### EPOCH-009: Distributed OCI Testbed for Latency Benchmarking
+### EPIC-009: Distributed OCI Testbed for Latency Benchmarking
 
 ```yaml
 ---
-epoch_id: EPOCH-009
+epic_id: EPIC-009
 title: "Distributed OCI Testbed for Latency Benchmarking"
 status: in_progress
 priority: p2
 user_story: US-003
 blocked_by: []
 created_at: 2026-04-13
-claimed_by: claude-session-epoch009
+claimed_by: claude-session-epic009
 claimed_at: 2026-04-13T19:00:00Z
 tasks:
   - id: TASK-009-1
     title: "OCI VPS provisioning scripts"
     status: review
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     completed_at: 2026-04-13T19:05:00Z
     acceptance:
       - "scripts/remote/oci-provision.sh creates a dedicated f1r3node-rust-testbed-vcn in us-sanjose-1"
@@ -548,7 +548,7 @@ tasks:
   - id: TASK-009-2
     title: "Image distribution via docker save + scp + load"
     status: review
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     blocked_by: [TASK-009-1]
     completed_at: 2026-04-13T19:10:00Z
     acceptance:
@@ -563,7 +563,7 @@ tasks:
   - id: TASK-009-3
     title: "Distributed compose file split"
     status: review
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     claimed_at: 2026-04-13T19:15:00Z
     completed_at: 2026-04-13T19:30:00Z
     blocked_by: [TASK-009-1]
@@ -581,7 +581,7 @@ tasks:
   - id: TASK-009-4
     title: "Justfile recipes for end-to-end orchestration"
     status: review
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     claimed_at: 2026-04-13T19:40:00Z
     completed_at: 2026-04-13T19:58:00Z
     blocked_by: [TASK-009-1, TASK-009-2, TASK-009-3]
@@ -601,7 +601,7 @@ tasks:
   - id: TASK-009-5
     title: "Port latency benchmark (Scala -> native grpcurl/curl)"
     status: review
-    claimed_by: claude-session-epoch009
+    claimed_by: claude-session-epic009
     claimed_at: 2026-04-13T21:19:00Z
     completed_at: 2026-04-13T21:25:00Z
     blocked_by: [TASK-009-4]
@@ -628,21 +628,21 @@ tasks:
 - Included: OCI provisioning, image distribution, distributed compose, deploy/teardown automation, latency benchmark port
 - Excluded: Inter-shard consensus (Option B, ~1,500+ LOC of consensus work — see BACKLOG-FI-001)
 - Excluded: Non-OCI providers (Tata cloud, etc.)
-- Excluded: Throughput, chaos, or whiteblock-plan benchmarks (future epochs)
+- Excluded: Throughput, chaos, or whiteblock-plan benchmarks (future epics)
 - Excluded: Production-grade secrets management (using `scp` for TLS keys for now)
 
 **Notes:**
 - Uses arm64 (VM.Standard.A1.Flex) for free-tier eligibility and production representativeness
-- Image distribution intentionally uses `docker save/load` rather than registry pull, to keep this epoch self-contained until the OCIR CI switch lands
+- Image distribution intentionally uses `docker save/load` rather than registry pull, to keep this epic self-contained until the OCIR CI switch lands
 - TLS keys for bootstrap are shipped via `scp` (acceptable for a throwaway testbed)
 
 ---
 
-### EPOCH-010: Soak Benchmark Metrics & Reporting
+### EPIC-010: Soak Benchmark Metrics & Reporting
 
 ```yaml
 ---
-epoch_id: EPOCH-010
+epic_id: EPIC-010
 title: "Soak Benchmark Metrics & Reporting"
 status: in_progress
 priority: p2
@@ -699,7 +699,7 @@ tasks:
 ---
 ```
 
-**Context:** Implements US-004 plus the delivery/reporting design agreed 2026-07-15: the 72h soak concludes Mondays (weekly cadence); metrics are published to a GitHub Pages trend dashboard (pull) and a plain-text ONS email (push); regressions gate releases. Full design rationale, alternatives considered (email-only, Discussions, bot-committed reports), and open questions are in `docs/work-logs/task-EPOCH-010-2026-07-15T20-57Z.md`.
+**Context:** Implements US-004 plus the delivery/reporting design agreed 2026-07-15: the 72h soak concludes Mondays (weekly cadence); metrics are published to a GitHub Pages trend dashboard (pull) and a plain-text ONS email (push); regressions gate releases. Full design rationale, alternatives considered (email-only, Discussions, bot-committed reports), and open questions are in `docs/work-logs/task-EPIC-010-2026-07-15T20-57Z.md`.
 
 **Scope:**
 - Included: metrics emission, resource sampling, compare+gate, Pages dashboard, ONS email
@@ -708,13 +708,13 @@ tasks:
 
 ---
 
-## Epoch Dependency Graph
+## Epic Dependency Graph
 
 ```
-EPOCH-001 (system-integration alignment)    EPOCH-003 (f1r3node: merge critical PRs)
-EPOCH-002 (monitoring separation)               |
+EPIC-001 (system-integration alignment)    EPIC-003 (f1r3node: merge critical PRs)
+EPIC-002 (monitoring separation)               |
                                                  v
-                                            EPOCH-004 (f1r3node-rust: code sync)
+                                            EPIC-004 (f1r3node-rust: code sync)
                                                  |
                                             +----+----+----+
                                             |    |    |    |
@@ -725,7 +725,7 @@ EPOCH-002 (monitoring separation)               |
                                             +----+----+
                                                  |
                                                  v
-                                            EPOCH-008
+                                            EPIC-008
                                          (deprecation/archive)
 ```
 
@@ -750,7 +750,7 @@ EPOCH-002 (monitoring separation)               |
 3. **Implement**: Use `/implement` to execute with full context
 4. **Complete**: Mark `status: complete` when acceptance criteria met
 5. **Signal**: Update completion signals in `/tmp/migrationPlan.md`
-6. **Move epoch**: When all tasks complete, move epoch to `docs/CompletedTasks.md`
+6. **Move epic**: When all tasks complete, move epic to `docs/CompletedTasks.md`
 
 ---
 

--- a/docs/UserStories.md
+++ b/docs/UserStories.md
@@ -6,11 +6,11 @@ last_updated: 2026-04-15
 
 # User Stories
 
-This document captures user stories that drive feature development. User stories are reverse-engineered from completed epochs and updated as new features are planned.
+This document captures user stories that drive feature development. User stories are reverse-engineered from completed epics and updated as new features are planned.
 
 **Document Structure**
 - Active stories: This file (`docs/UserStories.md`)
-- Implementation tracking: `docs/ToDos.md` (epochs and tasks)
+- Implementation tracking: `docs/ToDos.md` (epics and tasks)
 - Completed work: `docs/CompletedTasks.md`
 
 **Format:** Each story follows the standard template:
@@ -25,11 +25,11 @@ This document captures user stories that drive feature development. User stories
 ---
 
 
-#### US-004: 72-hour merge-recovery soak benchmark metrics
+#### US-004: 60-hour merge-recovery soak benchmark metrics
 
-> As a **release engineer validating consensus changes**, I want **capture benchmark metrics from the 72-hour merge-recovery soak (per-iteration throughput, failure rate, and node resource/finalization measurements) with a machine-readable summary artifact** so that **sustained-load performance and stability are measurable and comparable across releases instead of pass/fail only**.
+> As a **release engineer validating consensus changes**, I want **capture benchmark metrics from the 60-hour merge-recovery soak (per-iteration throughput, failure rate, and node resource/finalization measurements) with a machine-readable summary artifact** so that **sustained-load performance and stability are measurable and comparable across releases instead of pass/fail only**.
 
-**Implemented in:** EPOCH-010
+**Implemented in:** EPIC-010
 
 **Status:** Planned
 
@@ -47,7 +47,7 @@ This document captures user stories that drive feature development. User stories
 
 > As a **platform operator**, I want **f1r3node-rust's Docker configuration to be directly compatible with the system-integration orchestration tooling** so that **the migration from dual Scala/Rust support to Rust-only can proceed without manual fixups**.
 
-**Implemented in:** EPOCH-001, EPOCH-002
+**Implemented in:** EPIC-001, EPIC-002
 
 **Acceptance Criteria:**
 - [x] Genesis wallets.txt identical between repos (20 wallets, correct balances)
@@ -65,7 +65,7 @@ This document captures user stories that drive feature development. User stories
 
 > As a **F1R3FLY developer**, I want **the Rust blockchain node to live in a standalone repository (f1r3node-rust) with clean Cargo-only tooling** so that **we can iterate faster without Nix/SBT/Scala build complexity and contributors only need standard Rust tooling**.
 
-**Implemented in:** EPOCH-003 through EPOCH-008
+**Implemented in:** EPIC-003 through EPIC-008
 
 **Acceptance Criteria:**
 - [ ] All critical PRs (Reified RSpaces #328-#338) merged in f1r3node before cutover
@@ -85,7 +85,7 @@ This document captures user stories that drive feature development. User stories
 
 > As a **platform engineer**, I want **to deploy a single F1R3FLY shard across two isolated OCI VPSes and run repeatable latency benchmarks against it** so that **we can measure network-latency-bound consensus performance and detect regressions as the node evolves**.
 
-**Implemented in:** EPOCH-009
+**Implemented in:** EPIC-009
 
 **Status:** In Progress
 
@@ -102,22 +102,22 @@ This document captures user stories that drive feature development. User stories
 
 ---
 
-## Relationship to Epochs
+## Relationship to Epics
 
-User stories capture the **why** (user need and benefit). Epochs capture the **what** (technical implementation tasks).
+User stories capture the **why** (user need and benefit). Epics capture the **what** (technical implementation tasks).
 
 | Artifact | Purpose | Location |
 |----------|---------|----------|
 | User Story | Business/user need | `docs/UserStories.md` |
-| Epoch | Implementation scope | `docs/ToDos.md` |
-| Task | Technical work item | Nested in epoch YAML |
+| Epic | Implementation scope | `docs/ToDos.md` |
+| Task | Technical work item | Nested in epic YAML |
 | Acceptance Criteria | Definition of done | In user story |
 
 **Workflow:**
 1. Identify user need -> Create user story
-2. Design solution -> Create epoch with tasks
+2. Design solution -> Create epic with tasks
 3. Implement -> Work through tasks via `/nextTask` and `/implement`
-4. Complete -> Mark epoch complete, update story status
+4. Complete -> Mark epic complete, update story status
 
 ---
 

--- a/docs/discoveries/2026-04-09-reified-rspaces-dependency-chain.md
+++ b/docs/discoveries/2026-04-09-reified-rspaces-dependency-chain.md
@@ -1,7 +1,7 @@
 ---
 doc_type: discovery
 discovered_by: claude-session
-relevance: [EPOCH-001, EPOCH-002]
+relevance: [EPIC-001, EPIC-002]
 ---
 
 ## Finding
@@ -28,7 +28,7 @@ new_parser branch (f1r3node)
 
 ## Implications
 
-- EPOCH-001 TASK-001-1 must verify both `new_parser` status and `rholang-rs#83` before any merge work begins
+- EPIC-001 TASK-001-1 must verify both `new_parser` status and `rholang-rs#83` before any merge work begins
 - The agent in f1r3node should check: `git branch -a | grep new_parser` and review `rholang-rs` PR #83 status
 - If `rholang-rs#83` is unmerged, this becomes the true critical path — everything else waits
 - The `rholang-parser` git rev in `Cargo.toml` will need updating to include #83's changes

--- a/docs/soak-benchmarks.md
+++ b/docs/soak-benchmarks.md
@@ -1,8 +1,8 @@
-# Weekend Soak Benchmarks (EPOCH-010)
+# Weekend Soak Benchmarks (EPIC-010)
 
-The 72-hour merge-recovery soak (Friday 22:00 Pacific → Monday) produces
+The 60-hour merge-recovery soak (Friday 22:00 Pacific → Monday morning) produces
 week-over-week benchmark metrics instead of pass/fail only. Design history and
-decisions: [work log](work-logs/task-EPOCH-010-2026-07-15T20-57Z.md), story
+decisions: [work log](work-logs/task-EPIC-010-2026-07-15T20-57Z.md), story
 US-004 in [UserStories.md](UserStories.md).
 
 ## Where to look
@@ -73,8 +73,8 @@ oci ons subscription delete --subscription-id <subscription-ocid>
 
 ## Operational notes
 
-- Benchmarks run **only** in the 72h weekend soak (`duration_seconds ==
-  259200`); the Mon–Thu 24h soaks are unchanged.
+- Benchmarks run **only** in the 60h weekend soak (`duration_seconds ==
+  216000`); the Mon–Thu 24h soaks are unchanged.
 - The dashboard site deploys from the soak workflow via GitHub Pages
   (Settings → Pages → source "GitHub Actions" must be enabled once).
 - Metric emission is fail-soft end-to-end: a broken segment or missing

--- a/docs/vps-cloud-testing.md
+++ b/docs/vps-cloud-testing.md
@@ -53,7 +53,7 @@ Followers on VPS-2 use `40410-40455` to avoid collisions — see [`docker/conf/v
 - Genesis ceremony completes (all validators sign, block #0 finalized)
 - Finalization advances past block #0 via heartbeat or user deploys
 - `curl http://<host>:<http-port>/api/status` returns `{peers, nodes}` matching expected count
-- Added validators can bond via `rholang/examples/bond/bond.rho` — see [TASK-001-4 notes in ToDos.md](./ToDos.md#epoch-001-system-integration-alignment) for evidence
+- Added validators can bond via `rholang/examples/bond/bond.rho` — see [TASK-001-4 notes in ToDos.md](./ToDos.md#epic-001-system-integration-alignment) for evidence
 
 ---
 
@@ -513,8 +513,8 @@ Run `just vps-down` when done.
 
 ## References
 
-- [EPOCH-001 in docs/ToDos.md](./ToDos.md#epoch-001-system-integration-alignment) — TASK-001-4 covers the local verification path
-- [EPOCH-009 in docs/ToDos.md](./ToDos.md#epoch-009-distributed-oci-testbed-for-latency-benchmarking) — distributed testbed implementation tasks
+- [EPIC-001 in docs/ToDos.md](./ToDos.md#epic-001-system-integration-alignment) — TASK-001-4 covers the local verification path
+- [EPIC-009 in docs/ToDos.md](./ToDos.md#epic-009-distributed-oci-testbed-for-latency-benchmarking) — distributed testbed implementation tasks
 - [US-003 in docs/UserStories.md](./UserStories.md#us-003-distributed-oci-testbed-for-latency-benchmarking) — user story
 - [scripts/remote/README.md](../scripts/remote/README.md) — script-level usage, config, naming convention
 - [docker/README.md](../docker/README.md) — local compose flow details (image build, ports, monitoring)

--- a/docs/work-logs/task-004-1-2026-04-17T19-19-55Z.md
+++ b/docs/work-logs/task-004-1-2026-04-17T19-19-55Z.md
@@ -1,8 +1,8 @@
 ---
 doc_type: work_log
 task_id: TASK-004-1
-epoch_id: EPOCH-004
-claimed_by: claude-session-epoch004
+epic_id: EPIC-004
+claimed_by: claude-session-epic004
 claimed_at: 2026-04-17T19:19:55Z
 handoff_status: ready
 source_repo: F1R3FLY-io/f1r3node
@@ -16,7 +16,7 @@ target_branch: staging
 ## Goal
 
 Bring all 11 Rust workspace crates in f1r3node-rust to parity with f1r3node
-`rust/staging` HEAD (6ee5c390), while preserving EPOCH-001/002/009
+`rust/staging` HEAD (6ee5c390), while preserving EPIC-001/002/009
 customizations that do not exist upstream.
 
 ## Approach
@@ -42,7 +42,7 @@ Never copy from source:
 
 ## Preserve (local customizations)
 
-EPOCH-001/002/009 work already landed here:
+EPIC-001/002/009 work already landed here:
 - `docker/genesis/wallets.txt` (20-wallet version)
 - `docker/monitoring.yml`
 - `docker/shard.vps1.yml`, `docker/shard.vps2.yml`
@@ -56,7 +56,7 @@ EPOCH-001/002/009 work already landed here:
 
 - [x] Phase 0 — coordination setup (`/tmp/migrationPlan.md`, this work log, ToDos.md claim)
 - [x] Phase 1 — Rust source sync (all 11 crates + root Cargo.{toml,lock} + cliff.toml)
-- [x] Phase 2 — Docker/CI/scripts (added `scripts/{version,release}.sh`, `docker/.env.example`; preserved EPOCH-001/002/009 customizations; `.github/workflows/` left alone to preserve local `ci.yml`)
+- [x] Phase 2 — Docker/CI/scripts (added `scripts/{version,release}.sh`, `docker/.env.example`; preserved EPIC-001/002/009 customizations; `.github/workflows/` left alone to preserve local `ci.yml`)
 - [x] Phase 3 — docs sync (added `docs/{archive,block-storage,comm,crypto,data-flows,graphz,models,node,patterns,shared,README.md,schnorr-frost-*.md}`; copied `CHANGELOG.md`); node version already at 0.4.10 from sync
 - [x] Phase 4 — `cargo build --workspace` passes (exit 0, 1m 00s); `cargo test -p crypto --lib` passes (29/29)
 
@@ -64,7 +64,7 @@ EPOCH-001/002/009 work already landed here:
 
 ### CI workflow divergence
 
-Target has a local `.github/workflows/ci.yml` (from commit 63110ca "add nightly release pipeline with auto-versioning and changelog generation") which replaces upstream's `build-test-and-deploy.yml` + `release.yml`. I did **not** sync the upstream workflows because they would conflict. EPOCH-004 AC for CI ("build-test-and-deploy.yml ported", "release.yml ported") may need reinterpretation: the target already has an equivalent (simpler) workflow. User decision needed on whether to port the upstream workflows, replace `ci.yml` with them, or mark the AC as satisfied by the local workflow.
+Target has a local `.github/workflows/ci.yml` (from commit 63110ca "add nightly release pipeline with auto-versioning and changelog generation") which replaces upstream's `build-test-and-deploy.yml` + `release.yml`. I did **not** sync the upstream workflows because they would conflict. EPIC-004 AC for CI ("build-test-and-deploy.yml ported", "release.yml ported") may need reinterpretation: the target already has an equivalent (simpler) workflow. User decision needed on whether to port the upstream workflows, replace `ci.yml` with them, or mark the AC as satisfied by the local workflow.
 
 ### Image-name inconsistency (pre-existing)
 
@@ -80,23 +80,23 @@ Local fixes `21e9b6c`, `0ef64e1`, `a548db3`, `bab5d6d` (Linux CI clippy) turned 
 
 ### Preserved local customizations
 
-All EPOCH-001/002/009 work intact:
-- `docker/monitoring.yml` (EPOCH-002 split from shard.yml)
-- `docker/shard.vps{1,2}.yml`, `docker/.env.remote.template`, `docker/conf/{bootstrap,validator1-remote,validator2-remote,readonly-remote}.conf` (EPOCH-009)
-- `docker/genesis/wallets.txt` (20-wallet, validator3=500T from EPOCH-001)
-- `docker/{shard,standalone,observer,validator4}.yml` (EPOCH-001 network + env var rename, OCIR image URL)
+All EPIC-001/002/009 work intact:
+- `docker/monitoring.yml` (EPIC-002 split from shard.yml)
+- `docker/shard.vps{1,2}.yml`, `docker/.env.remote.template`, `docker/conf/{bootstrap,validator1-remote,validator2-remote,readonly-remote}.conf` (EPIC-009)
+- `docker/genesis/wallets.txt` (20-wallet, validator3=500T from EPIC-001)
+- `docker/{shard,standalone,observer,validator4}.yml` (EPIC-001 network + env var rename, OCIR image URL)
 - `docker/helm/f1r3fly/values.yaml`, `docker/minikube/minikube-values.yaml` (OCIR image URL)
 - `docker/conf/default.conf`, `docker/conf/standalone-dev.conf` (extensive local comments)
 - `docker/README.md` (target's custom readme)
 - `scripts/bench/{latency-benchmark,profile-casper-latency}.sh`, `scripts/remote/`, `scripts/setup-hooks.sh`
 - `Justfile` recipes, `README.md`, `run-local/data/`
-- `.gitignore` (EPOCH-001 security commit 4b6a82b)
+- `.gitignore` (EPIC-001 security commit 4b6a82b)
 
 ## Sync summary
 
 ```
 Source:  F1R3FLY-io/f1r3node rust/staging @ 6ee5c390a189227b4632186e065b1a964fab5b9e (rust-v0.4.10 tip + WebSocket startup replay)
-Target:  F1R3FLY-io/f1r3node-rust staging  @ a03a1ba (local EPOCH-001/002/009 work)
+Target:  F1R3FLY-io/f1r3node-rust staging  @ a03a1ba (local EPIC-001/002/009 work)
 Changes: ~627 files touched (593 modified, 2 deleted, 32 new)
 Node binary version: 0.1.0 -> 0.4.10 (matches upstream)
 ```

--- a/docs/work-logs/task-004-1-resync-fb59611f-2026-04-29T18-50-45Z.md
+++ b/docs/work-logs/task-004-1-resync-fb59611f-2026-04-29T18-50-45Z.md
@@ -1,7 +1,7 @@
 ---
 doc_type: work_log
 task_id: TASK-004-1
-epoch_id: EPOCH-004
+epic_id: EPIC-004
 claimed_by: claude-session-resync-fb59611f
 claimed_at: 2026-04-29T18:50:45Z
 handoff_status: ready

--- a/docs/work-logs/task-EPIC-010-2026-07-15T20-57Z.md
+++ b/docs/work-logs/task-EPIC-010-2026-07-15T20-57Z.md
@@ -1,6 +1,6 @@
 ---
 doc_type: work-log
-epoch: EPOCH-010
+epic: EPIC-010
 user_story: US-004
 branch: hotfix/72-soak-benchmark
 created_by: claude-session-07b4ccc6
@@ -32,7 +32,7 @@ on a hosted runner), `.github/workflows/release.yml` (soak_gate job,
 Residuals are the two manual next_steps above plus a visual pass on the
 dashboard after the first Pages deploy.
 
-# EPOCH-010: Soak Benchmark Metrics & Reporting — design handoff
+# EPIC-010: Soak Benchmark Metrics & Reporting — design handoff
 
 ## What this is
 
@@ -111,7 +111,7 @@ budget ~3-6h of the 72h window.
   (system-integration) already samples total node RSS — reuse its output for
   the subprocess provider rather than re-instrumenting.
 - Finalization latency precedent: `scripts/bench/profile-casper-latency.sh`
-  (EPOCH-009 / TASK-009-5) parses Rust JSON logs (`f1r3fly.propose.timing`,
+  (EPIC-009 / TASK-009-5) parses Rust JSON logs (`f1r3fly.propose.timing`,
   `f1r3fly.casper`) for p50/p95 — same parse targets apply here.
 - Pages deploy: use the official `actions/deploy-pages` route (Settings →
   Pages → source "GitHub Actions"); keep the metrics history as JSON files in
@@ -121,7 +121,7 @@ budget ~3-6h of the 72h window.
 
 The 2026-07-15 merge train (PRs #122, #123) landed the merge-recovery port on
 dev, and the fairness-gate incident (see PR #122 discussion; revert commit
-bb3ad9b4) demonstrated exactly the failure mode this epoch guards against: a
+bb3ad9b4) demonstrated exactly the failure mode this epic guards against: a
 consensus change that passed unit tests but blew node RSS to 7GB and stalled
 finalization under sustained load. Peak-RSS and finalization-latency trends
 from a weekly soak would have caught it before merge.

--- a/docs/work-logs/task-sync-2026-04-29T20-27Z.md
+++ b/docs/work-logs/task-sync-2026-04-29T20-27Z.md
@@ -11,14 +11,14 @@ prev_sync_base: 6ee5c390a189227b4632186e065b1a964fab5b9e
 target_branch: dev
 ---
 
-# Code sync from f1r3node rust/dev (post-EPOCH-004 follow-up)
+# Code sync from f1r3node rust/dev (post-EPIC-004 follow-up)
 
 ## Goal
 Bring the 11-crate Rust workspace + docs to parity with f1r3node `rust/dev` HEAD
-(rust v0.4.13), keeping all EPOCH-001/002/009 local customizations intact.
+(rust v0.4.13), keeping all EPIC-001/002/009 local customizations intact.
 
 ## Approach
-Same envelope as TASK-004-1 (EPOCH-004):
+Same envelope as TASK-004-1 (EPIC-004):
 
 1. Phase 1 — Rust crate sources, tests, `Cargo.toml`s, root `Cargo.{toml,lock}`,
    `cliff.toml`
@@ -38,7 +38,7 @@ Same envelope as TASK-004-1 (EPOCH-004):
   `rspace-bench/`, `rholang-cli/`, `rholang-server/`, `examples/`
 - Repo-only: `bors.toml`, `coding_guidelines.md`
 
-## Preserved (EPOCH-001/002/009)
+## Preserved (EPIC-001/002/009)
 - `docker/{shard,standalone,observer,validator4}.yml`
   (`f1r3fly-shard` net, `F1R3FLY_IMAGE`, OCIR URLs)
 - `docker/monitoring.yml`, `docker/shard.vps{1,2}.yml`,
@@ -71,7 +71,7 @@ Same envelope as TASK-004-1 (EPOCH-004):
 
 ```
 Source:   F1R3FLY-io/f1r3node rust/dev @ 95be4feb6b3594333b1675c6231d7b2bcffd51a6 (rust v0.4.13)
-Target:   F1R3FLY-io/f1r3node-rust dev @ 1214ada (post-EPOCH-004 sync)
+Target:   F1R3FLY-io/f1r3node-rust dev @ 1214ada (post-EPIC-004 sync)
 Changes:  558 modified, 2 deleted, ~22 new tracked + 7 untracked Cargo.lock
 Diff:     +16,691 / -13,256 lines
 Version:  node 0.4.10 -> 0.4.13
@@ -80,7 +80,7 @@ Version:  node 0.4.10 -> 0.4.13
 ## Discoveries (this sync)
 
 ### Rust changes regressed local clippy allows
-The EPOCH-004 sync added crate-level `#![allow(...)]` blocks (~40 lints per
+The EPIC-004 sync added crate-level `#![allow(...)]` blocks (~40 lints per
 crate) to make `cargo clippy --workspace -- -D warnings` clean. Upstream
 doesn't have those allows, so rsync removed them. `cargo build` is clean,
 but clippy with `-D warnings` will fail again (esp. on the
@@ -97,7 +97,7 @@ warned about `new() without Default`. After grepping, no caller uses
 not re-add it. If clippy `-D warnings` is restored, re-add it then.
 
 ### `Blake2b256Hash` PartialEq + Hash regression
-EPOCH-004 fixed `derived_hash_with_manual_eq` by adding `PartialEq` to the
+EPIC-004 fixed `derived_hash_with_manual_eq` by adding `PartialEq` to the
 derive and removing the manual impl. Upstream has not absorbed that fix —
 the manual impl is back. Build still works (only clippy lint).
 

--- a/scripts/bench/soak-gate-thresholds.json
+++ b/scripts/bench/soak-gate-thresholds.json
@@ -1,5 +1,5 @@
 {
-  "comment": "Week-over-week regression gates for the 72h soak (EPOCH-010, maintainer-approved 2026-07-15). Passive metrics gate the run and releases; active-segment metrics warn.",
+  "comment": "Week-over-week regression gates for the 60h soak (EPIC-010, maintainer-approved 2026-07-15). Passive metrics gate the run and releases; active-segment metrics warn.",
   "failure_rate_max_increase_pts": 0.05,
   "rss_peak_max_increase_pct": 0.20,
   "finalization_p95_max_increase_pct": 0.20,

--- a/scripts/remote/README.md
+++ b/scripts/remote/README.md
@@ -1,6 +1,6 @@
 # Remote testbed scripts
 
-Provisioning and teardown scripts for the F1R3FLY distributed OCI testbed (EPOCH-009 / US-003).
+Provisioning and teardown scripts for the F1R3FLY distributed OCI testbed (EPIC-009 / US-003).
 
 **Naming convention.** Script names use an `oci-` prefix for cloud-specific work (e.g. `oci-provision.sh`, `oci-destroy.sh`) and no prefix for cloud-agnostic work (`deploy.sh`, `status.sh`, `teardown.sh`, `image-transfer.sh`). The wrapping Justfile recipes use a neutral `vps-` prefix so the user-facing interface stays stable when other providers (AWS, GCP) are added — see `docs/Backlog.md` BACKLOG-FI-002.
 

--- a/site/soak-dashboard/index.html
+++ b/site/soak-dashboard/index.html
@@ -59,7 +59,7 @@
 </head>
 <body>
 <h1>Weekend soak benchmarks</h1>
-<p class="sub">72-hour merge-recovery soak, weekly (concludes Mondays) —
+<p class="sub">60-hour merge-recovery soak, weekly (concludes Monday mornings) —
   <span id="verdict-slot"></span>
   <a href="data/latest-report.md">latest report</a> ·
   <a href="data/history.json">raw data</a></p>


### PR DESCRIPTION
…EPOCH->EPIC migration

- schedule_gate now derives the Pacific slot from the firing cron (github.event.schedule) instead of the wall clock, so GitHub's 1-3.5h cron delivery delays no longer skip every launch (root cause of the missing weekend soak report email)
- weekend soak 72h -> 60h (216000s) so the report email lands Monday morning; dispatch option renamed to weekend-60h; soak job timeout 4560 -> 3840 minutes
- migrate Agile EPOCH-NNN / epoch_id: to EPIC-NNN / epic_id: across tracking docs, CLAUDE.md command names, work logs (incl. renaming task-EPOCH-010 work log), and derived soak docs, per the workspace epic-terminology migration; consensus-domain 'epoch' uses in docs/casper and docs/rholang left untouched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787262637&installation_model_id=426883&pr_number=138&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F138&signature=61a072e3ca1c1e4a2f4f10ce85e8e41018a728fd5bce526d0270960a7db8b671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->