### PR TITLE
feat(fileio): minimal File agent + rholang-parser bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,7 +5136,7 @@ dependencies = [
 [[package]]
 name = "rholang-parser"
 version = "0.1.0"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=7588a3a#7588a3ab09e244a148166549527865de179de9b2"
 dependencies = [
  "bitvec",
  "nonempty-collections",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "rholang-tree-sitter"
 version = "0.1.2"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=7588a3a#7588a3ab09e244a148166549527865de179de9b2"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "rholang-tree-sitter-proc-macro"
 version = "0.1.2"
-source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=527af8a#527af8afb37f6cad470516fe316076f120b9c353"
+source = "git+https://github.com/F1R3FLY-io/rholang-rs?rev=7588a3a#7588a3ab09e244a148166549527865de179de9b2"
 dependencies = [
  "anyhow",
  "quote",
@@ -6245,7 +6245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ utoipa = "5"
 validated = "1.0"
 serial_test = "3.1"
 metrics-util = "0.17"
-rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "527af8a" }
+rholang-parser = { git = "https://github.com/F1R3FLY-io/rholang-rs", rev = "7588a3a" }
 reqwest = "0.12"
 
 [profile.dev]

--- a/rholang/src/rust/interpreter/io/agents.rs
+++ b/rholang/src/rust/interpreter/io/agents.rs
@@ -1,0 +1,25 @@
+//! Rholang agent-class sources for the File I/O FIP.
+//!
+//! Each constant is the raw text of an `agent` block (per rholang-rs
+//! PR #94's sugar) that expects its enclosing scope to bind the
+//! native-URN names it references. That factoring lets one string
+//! serve two purposes:
+//!
+//! 1. **Integration tests** wrap the block in a `new`-scope that
+//!    binds the native URNs and directly exercises the agent's
+//!    methods, isolating the agent-layer semantics from the rest
+//!    of the FS-agent stack.
+//! 2. **The `Fs` agent's genesis deploy** (Phase 2) embeds the
+//!    same block inside its own `new`-scope, which binds the
+//!    native URNs via `NormalizerEnv` injection and never exposes
+//!    them outward. User code reaches these agents only through
+//!    the `Fs` methods that construct them.
+//!
+//! Native URNs each `.rho` file expects:
+//!
+//! - `file.rho` — `nRead`, `nSize`, `nClose` (extended as the
+//!   `File` surface grows in follow-up PRs).
+
+/// Source of the `File` agent block. Expects `File`, `nRead`,
+/// `nSize`, `nClose` to be bound in the enclosing scope.
+pub const FILE_AGENT_SRC: &str = include_str!("agents/file.rho");

--- a/rholang/src/rust/interpreter/io/agents/file.rho
+++ b/rholang/src/rust/interpreter/io/agents/file.rho
@@ -1,0 +1,109 @@
+// File agent — wraps a native fd with the FIP `File` method surface.
+//
+// This is the MINIMAL surface: `read`, `size`, `close`, `default`.
+// Extended in follow-up PRs with `write`, `seek`, `tell`, `truncate`,
+// `flush`, `readAt`, `writeAt`, `lockRange`, `chmod`, `chown`, plus
+// line-based `text` / `lines` / `mapReduceLines*`.
+//
+// This file is an `agent` block that expects the enclosing scope
+// to bind:
+//   - `File`               — the agent's constructor channel
+//   - `nRead`, `nSize`,
+//     `nClose`             — fixed-channel Pars for the native
+//                            primitives, obtained via `NormalizerEnv`
+//                            injection at compile time (see
+//                            `interpreter::io::injections`).
+//
+// Constructor calling convention: the `@fd` formal is a process
+// pattern, so the caller sends the fd as a plain Process arg
+// (e.g. `File!(*replyChan, fd)`). The constructor stashes it on
+// a per-instance subchannel keyed on `*this`, and every method
+// peeks (`<<-`) that subchannel to read the fd without removing
+// it. Standard Rholang per-instance-state pattern -- see
+// agent_private_state.rho in the parser corpus.
+//
+// Method dispatch calling convention: the agent-block sugar
+// desugars methods to match arms of shape
+// `[*return, "methodName", ...formals] => body`. Compose via
+// either raw sends in that literal shape
+// (`fileAgent!(*replyChan, "read", n)`) or the method-call
+// sugar `fileAgent!read(n)` (which desugars to
+// `fileAgent!?("read", n)` → `fileAgent!(*tmp, "read", n) |
+// for(_ <- tmp) cont` — return channel first, matches the
+// agent-dispatch shape).
+//
+// Native-call convention: the fileio native handlers destructure
+// args as ack-FIRST (`let [ack, arg0, ..., argN] = ...`),
+// matching what the `!?` sync-send and `try/catch`'s SendReceive
+// source generate. So method bodies use `try @<pat> <-
+// nX!?(args) { ok } catch @[code, msg] { err }` cleanly -- no
+// explicit send-then-for-then-match cascade needed.
+//
+// The genesis-installed `Fs` agent embeds this block inside its
+// own `new`-scope that provides the native URN bindings and
+// never exposes them outward. User code reaches `File` instances
+// through `Fs.openFile`.
+//
+// Default-arm reply idiom: the agent-block sugar desugars
+// `default(...@args) { body }` to `_ => body`. Note that `args`
+// (in-scope name, bound by the outer `for(...@args <= this)`)
+// is still visible in `body` -- and its first element is the
+// caller's return channel (as a Process via `*return`). To
+// reply, destructure `args` in the default body and re-quote
+// the head into a Name to send on. See the `default` arm below.
+agent File {
+  constructor(@fd) {
+    // `@fd` binds the incoming Process (Int) directly; persist it
+    // under a `*this`-keyed subchannel for methods to peek.
+    @(*this, "fd")!(fd)
+  } |
+
+  method read(n) {
+    for (@fd <<- @(*this, "fd")) {
+      try @[bytes] <- nRead!?(fd, n) {
+        return!([true, bytes])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method size() {
+    for (@fd <<- @(*this, "fd")) {
+      try @[n] <- nSize!?(fd) {
+        return!([true, n])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method close() {
+    // Bare `try <- source { ... }` — no result pattern, success
+    // branch just fires. Native `close` produces `[true]`.
+    for (@fd <<- @(*this, "fd")) {
+      try <- nClose!?(fd) {
+        return!([true])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  default(...@args) {
+    // `args` is in scope via the outer `for(...@args <= this)`
+    // in the desugared dispatch loop. Its first element is the
+    // caller's return channel as a Process (from the send's
+    // auto-deref of the reply-channel Name); the rest is
+    // `[methodName, ...formals]`. Peel out the return via a
+    // match, re-quote to a Name with `@`, and reply.
+    match args {
+      [returnProc, ...rest] => {
+        @returnProc!([false, "FSERR_UNSUPPORTED", ("File agent has no method:", rest)])
+      }
+    }
+  }
+}

--- a/rholang/src/rust/interpreter/io/mod.rs
+++ b/rholang/src/rust/interpreter/io/mod.rs
@@ -10,6 +10,7 @@
 //! user-facing code goes through the `Fs` agent under `rho:io:fs:1.*`
 //! per the FIP.
 
+pub mod agents;
 pub mod handle_table;
 pub mod injections;
 pub mod mode;

--- a/rholang/src/rust/interpreter/system_processes.rs
+++ b/rholang/src/rust/interpreter/system_processes.rs
@@ -2128,7 +2128,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_open"));
         };
-        let [path_par, mode_par, ack] = args.as_slice() else {
+        let [ack, path_par, mode_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_open"));
         };
         let (Some(path_str), Some(mode_str)) =
@@ -2191,7 +2191,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_close"));
         };
-        let [fd_par, ack] = args.as_slice() else {
+        let [ack, fd_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_close"));
         };
         let Some(fd) = RhoNumber::unapply(fd_par) else {
@@ -2238,7 +2238,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_read"));
         };
-        let [fd_par, n_par, ack] = args.as_slice() else {
+        let [ack, fd_par, n_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_read"));
         };
         let (Some(fd), Some(n)) = (RhoNumber::unapply(fd_par), RhoNumber::unapply(n_par)) else {
@@ -2318,7 +2318,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_write"));
         };
-        let [fd_par, bytes_par, ack] = args.as_slice() else {
+        let [ack, fd_par, bytes_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_write"));
         };
         let (Some(fd), Some(bytes)) =
@@ -2368,7 +2368,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_seek"));
         };
-        let [fd_par, offset_par, whence_par, ack] = args.as_slice() else {
+        let [ack, fd_par, offset_par, whence_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_seek"));
         };
         let (Some(fd), Some(offset), Some(whence)) = (
@@ -2442,7 +2442,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_tell"));
         };
-        let [fd_par, ack] = args.as_slice() else {
+        let [ack, fd_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_tell"));
         };
         let Some(fd) = RhoNumber::unapply(fd_par) else {
@@ -2486,7 +2486,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_size"));
         };
-        let [fd_par, ack] = args.as_slice() else {
+        let [ack, fd_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_size"));
         };
         let Some(fd) = RhoNumber::unapply(fd_par) else {
@@ -2532,7 +2532,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_truncate"));
         };
-        let [fd_par, n_par, ack] = args.as_slice() else {
+        let [ack, fd_par, n_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_truncate"));
         };
         let (Some(fd), Some(n)) = (RhoNumber::unapply(fd_par), RhoNumber::unapply(n_par)) else {
@@ -2598,7 +2598,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_flush"));
         };
-        let [fd_par, ack] = args.as_slice() else {
+        let [ack, fd_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_flush"));
         };
         let Some(fd) = RhoNumber::unapply(fd_par) else {
@@ -2649,7 +2649,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_stat"));
         };
-        let [path_par, ack] = args.as_slice() else {
+        let [ack, path_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_stat"));
         };
         let Some(path_str) = RhoString::unapply(path_par) else {
@@ -2706,7 +2706,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_entries"));
         };
-        let [path_par, ack] = args.as_slice() else {
+        let [ack, path_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_entries"));
         };
         let Some(path_str) = RhoString::unapply(path_par) else {
@@ -2816,7 +2816,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_exists"));
         };
-        let [path_par, ack] = args.as_slice() else {
+        let [ack, path_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_exists"));
         };
         let Some(path_str) = RhoString::unapply(path_par) else {
@@ -2864,7 +2864,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_rename"));
         };
-        let [from_par, to_par, ack] = args.as_slice() else {
+        let [ack, from_par, to_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_rename"));
         };
         let (Some(from_str), Some(to_str)) =
@@ -2914,7 +2914,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_copy_file"));
         };
-        let [from_par, to_par, ack] = args.as_slice() else {
+        let [ack, from_par, to_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_copy_file"));
         };
         let (Some(from_str), Some(to_str)) =
@@ -2954,7 +2954,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_remove_file"));
         };
-        let [path_par, ack] = args.as_slice() else {
+        let [ack, path_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_remove_file"));
         };
         let Some(path_str) = RhoString::unapply(path_par) else {
@@ -2994,7 +2994,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_remove_dir"));
         };
-        let [path_par, recursive_par, ack] = args.as_slice() else {
+        let [ack, path_par, recursive_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_remove_dir"));
         };
         let (Some(path_str), Some(recursive)) = (
@@ -3046,7 +3046,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_chmod"));
         };
-        let [path_par, mode_bits_par, ack] = args.as_slice() else {
+        let [ack, path_par, mode_bits_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_chmod"));
         };
         let (Some(path_str), Some(mode_bits)) = (
@@ -3118,7 +3118,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_quarantine"));
         };
-        let [root_par, rel_par, ack] = args.as_slice() else {
+        let [ack, root_par, rel_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_quarantine"));
         };
         let (Some(root_str), Some(rel_str)) =
@@ -3178,7 +3178,7 @@ impl SystemProcesses {
         else {
             return Err(illegal_argument_error("native_chown"));
         };
-        let [path_par, owner_par, group_par, ack] = args.as_slice() else {
+        let [ack, path_par, owner_par, group_par] = args.as_slice() else {
             return Err(illegal_argument_error("native_chown"));
         };
         let (Some(path_str), Some(owner_str), Some(group_str)) = (

--- a/rholang/tests/fileio_file_agent_spec.rs
+++ b/rholang/tests/fileio_file_agent_spec.rs
@@ -1,0 +1,337 @@
+//! End-to-end tests for the `File` agent (Phase 2 of the File I/O
+//! implementation).
+//!
+//! The `agent File { ... }` block in `io/agents/file.rho` is
+//! self-contained syntactically but expects the enclosing scope to
+//! bind the native-URN names it references (`nRead`, `nSize`,
+//! `nClose`). These tests wrap the agent block in that scope,
+//! construct a `File` instance from a real fd returned by
+//! `nativeOpen`, and invoke each method through the dispatch
+//! machinery — exercising the full stack:
+//!
+//! - `agent` block sugar (rholang-rs PR #94) → dispatch
+//!   for-comprehension.
+//! - Native URN injection via `NormalizerEnv` (f1r3node-rust PR
+//!   #132) → fixed-channel `Par` resolution.
+//! - The 19 native handlers themselves (PR #120) → `tokio::fs`.
+//! - The `is_replay` guard on every handler (PR #137) → replay
+//!   safety.
+//! - Shared `FileHandleTable` across all handlers (PR #137
+//!   `0ac2a4df`) → fd allocated by `nativeOpen` visible to
+//!   `nativeRead` / `nativeSize` / `nativeClose`.
+//!
+//! Any regression in any of those layers would surface here.
+//!
+//! Also exercises the `!?` sync-send + `try/catch` sugar
+//! composition against native handlers: the handlers now
+//! destructure args as ack-FIRST (see PR #139 commit history),
+//! matching what `!?` / SendReceive generate. File.rho method
+//! bodies use the FIP-style
+//! `try @<pat> <- nX!?(args) { ok } catch @[code, msg] { err }`
+//! form directly, no send-then-for-then-match workaround.
+//!
+//! And the `default(...@args) { body }` reply idiom: `args` is
+//! in scope via the outer `for(...@args <= this)` binding, its
+//! first element is the caller's return channel (as a Process
+//! from send's auto-deref), and the default arm destructures it
+//! to reply with FSERR_UNSUPPORTED.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::io::agents::FILE_AGENT_SRC;
+use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
+use rholang::rust::interpreter::system_processes::FixedChannels;
+use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+#[allow(clippy::type_complexity)]
+async fn mk_runtime() -> RhoRuntimeImpl {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+    let (runtime, _, _): (
+        RhoRuntimeImpl,
+        RhoRuntimeImpl,
+        Arc<
+            Box<
+                dyn HistoryRepository<Par, BindPattern, ListParWithRandom, TaggedContinuation>
+                    + Send
+                    + Sync
+                    + 'static,
+            >,
+        >,
+    ) = create_runtimes_with_services(store, false, &mut Vec::new(), ExternalServices::noop())
+        .await;
+    runtime
+}
+
+fn temp_path(tag: &str) -> String {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "fileio_file_agent_spec_{tag}_{pid}_{ts}",
+        pid = std::process::id(),
+        ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    p.to_string_lossy().into_owned()
+}
+
+/// The four native URNs the `File` agent + test harness need.
+/// Populated as a `NormalizerEnv` so the enclosing `new`-scope's
+/// URN bindings resolve to the fixed-channel `Par`s.
+fn file_agent_env() -> HashMap<String, Par> {
+    let mut env: HashMap<String, Par> = HashMap::new();
+    env.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/read".to_string(),
+        FixedChannels::native_read(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/size".to_string(),
+        FixedChannels::native_size(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/close".to_string(),
+        FixedChannels::native_close(),
+    );
+    env
+}
+
+/// Wrap `body` in the outer `new`-scope + inject the `File` agent
+/// block. The body has `File` (agent constructor), `nOpen` (native
+/// open URN — separate from the ones the agent needs), and a
+/// `@"sink"` channel to publish observable results on.
+fn wrap(body: &str, path: &str) -> String {
+    format!(
+        r#"new
+     File,
+     nOpen(`rho:io:fs:native:1.0.0/open`),
+     nRead(`rho:io:fs:native:1.0.0/read`),
+     nSize(`rho:io:fs:native:1.0.0/size`),
+     nClose(`rho:io:fs:native:1.0.0/close`),
+     openAck
+   in {{
+     {FILE_AGENT_SRC}
+     |
+     nOpen!(*openAck, "{path}", "r") |
+     for (@[true, fd] <- openAck) {{
+       // File's constructor uses `@fd` (process pattern), so we
+       // pass the fd Process directly. Agent constructor desugars
+       // to `for(__r, @fd <= File)`; caller sends
+       // `File!(replyChan_as_process, fd)` -- return channel
+       // first (as Process via η-deref), then user-declared
+       // formals. Send args are Processes throughout.
+       new fileRet in {{
+         File!(*fileRet, fd) |
+         // Bind `fileAgent` as a Name (no `@` in pattern) so the
+         // body can use it directly as a send channel:
+         // `fileAgent!(...)`. File's constructor published
+         // `bundle+{{*this}}` on __r; the received value is a
+         // bundled name that behaves as a normal send target.
+         for (fileAgent <- fileRet) {{
+           {body}
+         }}
+       }}
+     }}
+   }}"#
+    )
+}
+
+async fn observe_sink(runtime: &RhoRuntimeImpl) -> String {
+    let sink_channel = Par::default().with_exprs(vec![models::rhoapi::Expr {
+        expr_instance: Some(models::rhoapi::expr::ExprInstance::GString(
+            "sink".to_string(),
+        )),
+    }]);
+    let data = runtime.get_data(&sink_channel).await;
+    data.into_iter()
+        .flat_map(|d| d.a.pars)
+        .map(|p| format!("{p:?}"))
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// End-to-end: open a file, wrap the fd in a `File` agent, call
+/// `read(n)`, publish the result to `@"sink"`, verify the returned
+/// bytes match the file contents.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_read_returns_file_contents() {
+    let path = temp_path("read");
+    std::fs::write(&path, b"hello, file agent").expect("precondition write");
+
+    // Agent dispatch pattern is [*return, "method", ...formals], so
+    // raw send order is: (returnChan_process, methodName, args...).
+    let body = r#"
+        new readRet in {
+          fileAgent!(*readRet, "read", 17) |
+          for (@result <- readRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &path);
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-read".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    // Expected: [true, GByteArray(...)] where the bytes spell out
+    // "hello, file agent" (ASCII 104,101,108,108,111,44,32,102,...)
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains("GByteArray([104, 101, 108, 108, 111, 44, 32, 102, 105, 108, 101, 32, 97, 103, 101, 110, 116])"),
+        "expected the ASCII bytes of \"hello, file agent\" on sink, got: {sink}"
+    );
+}
+
+/// `size()` returns the file's byte length via `nativeSize`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_size_returns_byte_length() {
+    let path = temp_path("size");
+    std::fs::write(&path, b"1234567890").expect("precondition write");
+
+    let body = r#"
+        new sizeRet in {
+          fileAgent!(*sizeRet, "size") |
+          for (@result <- sizeRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &path);
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-size".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains("GInt(10)"),
+        "expected size=10 on sink, got: {sink}"
+    );
+}
+
+/// `close()` produces `[true]` on the ack channel; a subsequent
+/// `read()` on the same agent should surface `FSERR_CLOSED` (the
+/// native handler's response when the fd is no longer in the
+/// `FileHandleTable`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_close_then_read_reports_closed() {
+    let path = temp_path("close");
+    std::fs::write(&path, b"gone soon").expect("precondition write");
+
+    let body = r#"
+        new closeRet in {
+          fileAgent!(*closeRet, "close") |
+          for (@closeResult <- closeRet) {
+            @"sink"!(("close", closeResult)) |
+            new readRet in {
+              fileAgent!(*readRet, "read", 10) |
+              for (@readResult <- readRet) {
+                @"sink"!(("read-after-close", readResult))
+              }
+            }
+          }
+        }
+    "#;
+    let src = wrap(body, &path);
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-close".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        sink.contains(r#"GString("close")"#),
+        "expected 'close' tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("read-after-close")"#),
+        "expected 'read-after-close' tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("FSERR_CLOSED")"#),
+        "expected FSERR_CLOSED on the second read, got: {sink}"
+    );
+}
+
+/// Unknown methods hit the `default` arm, which destructures
+/// `args` (in scope via the outer `for(...@args <= this)` of the
+/// desugared dispatch loop) to peel out the caller's return
+/// channel and reply with `FSERR_UNSUPPORTED`. Locks in the
+/// idiom for default-arm replies plus the observable
+/// FSERR_UNSUPPORTED payload.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_unknown_method_returns_unsupported() {
+    let path = temp_path("unknown");
+    std::fs::write(&path, b"anything").expect("precondition write");
+
+    let body = r#"
+        new unkRet in {
+          fileAgent!(*unkRet, "nonexistent", "arg1") |
+          for (@result <- unkRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &path);
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-unknown".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        sink.contains("GBool(false)"),
+        "expected error tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("FSERR_UNSUPPORTED")"#),
+        "expected FSERR_UNSUPPORTED code on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("nonexistent")"#),
+        "expected the method name in the error payload, got: {sink}"
+    );
+}

--- a/rholang/tests/fileio_lifecycle_spec.rs
+++ b/rholang/tests/fileio_lifecycle_spec.rs
@@ -107,9 +107,9 @@ async fn open_then_read_shares_fd_table() {
         r#"new nOpen(`rho:io:fs:native:1.0.0/open`),
                 nRead(`rho:io:fs:native:1.0.0/read`),
                 openAck, readAck in {{
-             nOpen!("{path}", "r", *openAck) |
+             nOpen!(*openAck, "{path}", "r") |
              for (@[true, fd] <- openAck) {{
-               nRead!(fd, 5, *readAck) |
+               nRead!(*readAck, fd, 5) |
                for (@result <- readAck) {{ @"sink"!(result) }}
              }}
            }}"#
@@ -170,9 +170,9 @@ async fn successful_deploy_leaves_fds_in_table() {
 
     let term = format!(
         r#"new nOpen(`rho:io:fs:native:1.0.0/open`), ack1, ack2 in {{
-             nOpen!("{path_a}", "r", *ack1) |
+             nOpen!(*ack1, "{path_a}", "r") |
              for (@_ <- ack1) {{
-               nOpen!("{path_b}", "r", *ack2) |
+               nOpen!(*ack2, "{path_b}", "r") |
                for (@_ <- ack2) {{ Nil }}
              }}
            }}"#
@@ -223,7 +223,7 @@ async fn erroring_deploy_rolls_back_fd_allocations() {
     // to revert rspace + truncate the fd table.
     let term = format!(
         r#"new nOpen(`rho:io:fs:native:1.0.0/open`), ack in {{
-             nOpen!("{path}", "r", *ack) |
+             nOpen!(*ack, "{path}", "r") |
              for (@[true, _] <- ack) {{ @0!(1 / 0) }}
            }}"#
     );

--- a/rholang/tests/fileio_replay_spec.rs
+++ b/rholang/tests/fileio_replay_spec.rs
@@ -165,7 +165,7 @@ async fn exists_replays_false_after_file_is_created_between_runs() {
     let path_for_mutate = path.clone();
     let term = format!(
         r#"new nExists(`rho:io:fs:native:1.0.0/exists`), ret in {{
-             nExists!("{path_for_term}", *ret) |
+             nExists!(*ret, "{path_for_term}") |
              for (@_ <- ret) {{ Nil }}
            }}"#
     );
@@ -197,7 +197,7 @@ async fn exists_replays_true_after_file_is_deleted_between_runs() {
     let path_for_mutate = path.clone();
     let term = format!(
         r#"new nExists(`rho:io:fs:native:1.0.0/exists`), ret in {{
-             nExists!("{path_for_term}", *ret) |
+             nExists!(*ret, "{path_for_term}") |
              for (@_ <- ret) {{ Nil }}
            }}"#
     );
@@ -223,7 +223,7 @@ async fn stat_replays_original_metadata_after_file_is_modified() {
     let path_for_mutate = path.clone();
     let term = format!(
         r#"new nStat(`rho:io:fs:native:1.0.0/stat`), ret in {{
-             nStat!("{path_for_term}", *ret) |
+             nStat!(*ret, "{path_for_term}") |
              for (@_ <- ret) {{ Nil }}
            }}"#
     );


### PR DESCRIPTION
## Summary

First rung of Phase 2: the minimal `File` agent wrapping the native fd surface, plus a rholang-parser pin bump that brings in the try/catch sugar Phase 2 needs.

## Commits

- **`03172f5e`** — `chore(deps): bump rholang-parser to master tip (7588a3a)`. Pin was at `527af8a` (after PRs #93/#94/#95 landed) but before PR #96 (try/catch sugar). Bumping to `7588a3a` (PR #96 merge) brings in try/catch sugar, hygiene fix (`2f247dc`), and SR/SM cleanup (`eb85eff`). Empty state hash unchanged; no genesis-installed `.rho` uses the newly-recognized syntax.
- **`684c9ff4`** — `feat(fileio): minimal File agent (read/size/close/default)`. See below.

## File agent

`rholang/src/rust/interpreter/io/agents/file.rho` — the `agent File { constructor / method read / method size / method close / default }` block. Uses agent-block sugar (rholang-rs PR #94), `!?` sync-send + try/catch sugar (PR #96), and `NormalizerEnv` injection to reach the native primitives — all FIP-style, no workarounds.

Factored as a standalone block (not wrapped in its own `new`) so the same string serves two purposes:
- Integration tests wrap it in a `new`-scope that binds the native URNs and drives the agent directly.
- The Phase-2 `Fs` agent's genesis deploy (future PR) will embed it inside its own scope, never exposing the URN bindings outward.

Rust plumbing: `rholang/src/rust/interpreter/io/agents.rs` exposes `pub const FILE_AGENT_SRC: &str = include_str!("agents/file.rho");`. Registered via `pub mod agents;` in `io/mod.rs`.

### Method surface

| Method | Signature | Delegates to |
|--------|-----------|--------------|
| `read(n)` | `[true, bytes]` or `[false, code, msg]` | `nativeRead(fd, n)` |
| `size()` | `[true, n]` or error tuple | `nativeSize(fd)` |
| `close()` | `[true]` or error tuple | `nativeClose(fd)` |
| `default(...@args)` | `[false, "FSERR_UNSUPPORTED", ...]` | — |

### Per-instance state

Constructor uses `@fd` (process pattern), receives the fd Int directly, stashes on `@(*this, "fd")`. Methods peek (`<<-`) non-consumingly. Standard Rholang per-instance-state pattern.

### Default-arm reply idiom

The agent-block sugar desugars `default(...@args) { body }` to `_ => body`. This is correct: the outer `for(...@args <= this)` already binds `args` in scope for every match arm, so the default body has access to the full incoming args list. Its first element is the caller's return channel as a Process (from send's auto-deref of the reply-channel Name). The default arm destructures it and re-quotes with `@` to reply:

```rholang
default(...@args) {
  match args {
    [returnProc, ...rest] => {
      @returnProc!([false, "FSERR_UNSUPPORTED",
                    ("File agent has no method:", rest)])
    }
  }
}
```

## Native-handler ack-first swap (folded into the same commit)

Every fileio native handler in `system_processes.rs` swapped from `let [args..., ack] = args.as_slice()` (ack LAST) to `let [ack, args...] = args.as_slice()` (ack FIRST). Variable names preserved; only positions moved.

**Why**: `!?` sync-send and try/catch's SendReceive source both PREPEND the ephemeral return channel (verified in `p_send_sync_normalizer.rs:35-39` and `p_input_normalizer.rs:148,164`). Before the swap, `nRead!?(fd, n)` inside a `try/catch` sent `(*tmp, fd, n)`, the handler read `fd_par = *tmp` (a Name), failed `RhoNumber::unapply`, and returned `IllegalArgumentError`. After the swap, the sugar composes directly and File.rho methods use the FIP-style `try @<pat> <- nX!?(args) { ok } catch @[code, msg] { err }` form verbatim — half the lines vs. an alternative hand-rolled send-then-for-then-match cascade.

Callers updated: 6 raw-send call sites across three integration test files reordered to ack-first.

## Tests

4 integration tests in `rholang/tests/fileio_file_agent_spec.rs`. Together they exercise the full stack top-to-bottom: agent-block sugar → dispatch → NormalizerEnv injection → native handlers → replay guards → shared `FileHandleTable`. Any regression in any layer surfaces here.

- **`file_agent_read_returns_file_contents`** — opens `"hello, file agent"`, calls `read(17)`, asserts the returned `GByteArray` is the expected ASCII bytes.
- **`file_agent_size_returns_byte_length`** — `size()` returns `GInt(10)` for a 10-byte file.
- **`file_agent_close_then_read_reports_closed`** — after `close()`, a subsequent `read()` surfaces `FSERR_CLOSED` from the native handler. Also validates that fd-table state persists across the agent's method invocations.
- **`file_agent_unknown_method_returns_unsupported`** — unknown method hits the default arm; asserts the reply is `[false, "FSERR_UNSUPPORTED", ...]` with the offending method name in the payload.

## Test plan

- [x] `cargo build -p rholang` clean
- [x] `cargo test -p rholang --test fileio_file_agent_spec` — 4 pass
- [x] `cargo test -p rholang --lib io::` — 37 pass (unchanged)
- [x] `cargo test -p rholang --lib` — 233 pass (unchanged)
- [x] `cargo test -p rholang --test fileio_lifecycle_spec` — 3 pass
- [x] `cargo test -p rholang --test fileio_replay_spec` — 3 pass
- [x] `cargo test -p rholang --test injection_runtime_spec` — 2 pass
- [x] `cargo test -p casper --test mod empty_state_hash_should_be_the_same_as_hard_coded_cached_value` passes
- [x] `cargo fmt -p rholang` clean
- [x] Pre-push hook (workspace fmt/clippy/deny + full test matrix) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
