### PR TITLE
feat(fileio): extend File agent with write/seek/tell/truncate/flush

### DIFF
--- a/rholang/src/rust/interpreter/io/agents/file.rho
+++ b/rholang/src/rust/interpreter/io/agents/file.rho
@@ -1,15 +1,18 @@
 // File agent — wraps a native fd with the FIP `File` method surface.
 //
-// This is the MINIMAL surface: `read`, `size`, `close`, `default`.
-// Extended in follow-up PRs with `write`, `seek`, `tell`, `truncate`,
-// `flush`, `readAt`, `writeAt`, `lockRange`, `chmod`, `chown`, plus
-// line-based `text` / `lines` / `mapReduceLines*`.
+// Currently ships: `read`, `write`, `seek`, `tell`, `size`,
+// `truncate`, `flush`, `close`, `default`. Extended in follow-up
+// PRs with `readAt`, `writeAt`, `lockRange` (all need range-lock
+// infrastructure, Phase 4), `chmod`, `chown` (need mode-string
+// parser), plus line-based `text` / `lines` / `mapReduceLines*`.
 //
 // This file is an `agent` block that expects the enclosing scope
 // to bind:
 //   - `File`               — the agent's constructor channel
-//   - `nRead`, `nSize`,
-//     `nClose`             — fixed-channel Pars for the native
+//   - `nRead`, `nWrite`,
+//     `nSeek`, `nTell`,
+//     `nSize`, `nTruncate`,
+//     `nFlush`, `nClose`   — fixed-channel Pars for the native
 //                            primitives, obtained via `NormalizerEnv`
 //                            injection at compile time (see
 //                            `interpreter::io::injections`).
@@ -73,6 +76,73 @@ agent File {
     for (@fd <<- @(*this, "fd")) {
       try @[n] <- nSize!?(fd) {
         return!([true, n])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method write(bytes) {
+    // Writes `bytes` at the current position and advances it.
+    // Requires the fd to have been opened in a writeable mode
+    // ("w", "a", "r+", "w+", or their "x"-suffixed variants);
+    // otherwise the native returns FSERR_PERM.
+    for (@fd <<- @(*this, "fd")) {
+      try @[nWritten] <- nWrite!?(fd, bytes) {
+        return!([true, nWritten])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method seek(offset, whence) {
+    // `whence` is "set" (absolute; requires non-negative offset),
+    // "cur" (relative to current position), or "end" (relative to
+    // file end). Returns the new absolute position.
+    for (@fd <<- @(*this, "fd")) {
+      try @[newPos] <- nSeek!?(fd, offset, whence) {
+        return!([true, newPos])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method tell() {
+    for (@fd <<- @(*this, "fd")) {
+      try @[pos] <- nTell!?(fd) {
+        return!([true, pos])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method truncate(n) {
+    // Sets the file size to `n` bytes, padding with zeros if the
+    // file grows. Requires a writeable fd. Native imposes a per-
+    // call ceiling (MAX_TRUNCATE_BYTES = 16 GiB); larger `n`
+    // returns FSERR_BAD_ARG.
+    for (@fd <<- @(*this, "fd")) {
+      try <- nTruncate!?(fd, n) {
+        return!([true])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method flush() {
+    // Forces a durable write via `sync_all` (data + metadata).
+    for (@fd <<- @(*this, "fd")) {
+      try <- nFlush!?(fd) {
+        return!([true])
       }
       catch @[code, msg] {
         return!([false, code, msg])

--- a/rholang/tests/fileio_file_agent_spec.rs
+++ b/rholang/tests/fileio_file_agent_spec.rs
@@ -84,7 +84,7 @@ fn temp_path(tag: &str) -> String {
     p.to_string_lossy().into_owned()
 }
 
-/// The four native URNs the `File` agent + test harness need.
+/// The native URNs the `File` agent + test harness need.
 /// Populated as a `NormalizerEnv` so the enclosing `new`-scope's
 /// URN bindings resolve to the fixed-channel `Par`s.
 fn file_agent_env() -> HashMap<String, Par> {
@@ -98,8 +98,28 @@ fn file_agent_env() -> HashMap<String, Par> {
         FixedChannels::native_read(),
     );
     env.insert(
+        "rho:io:fs:native:1.0.0/write".to_string(),
+        FixedChannels::native_write(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/seek".to_string(),
+        FixedChannels::native_seek(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/tell".to_string(),
+        FixedChannels::native_tell(),
+    );
+    env.insert(
         "rho:io:fs:native:1.0.0/size".to_string(),
         FixedChannels::native_size(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/truncate".to_string(),
+        FixedChannels::native_truncate(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/flush".to_string(),
+        FixedChannels::native_flush(),
     );
     env.insert(
         "rho:io:fs:native:1.0.0/close".to_string(),
@@ -109,22 +129,28 @@ fn file_agent_env() -> HashMap<String, Par> {
 }
 
 /// Wrap `body` in the outer `new`-scope + inject the `File` agent
-/// block. The body has `File` (agent constructor), `nOpen` (native
-/// open URN — separate from the ones the agent needs), and a
-/// `@"sink"` channel to publish observable results on.
-fn wrap(body: &str, path: &str) -> String {
+/// block. Takes `mode` so writeable-fd tests can use `"w+"` or
+/// `"r+"` while read-only tests use `"r"`. The body has `File`
+/// (agent constructor) and a `@"sink"` channel to publish
+/// observable results on.
+fn wrap_with_mode(body: &str, path: &str, mode: &str) -> String {
     format!(
         r#"new
      File,
      nOpen(`rho:io:fs:native:1.0.0/open`),
      nRead(`rho:io:fs:native:1.0.0/read`),
+     nWrite(`rho:io:fs:native:1.0.0/write`),
+     nSeek(`rho:io:fs:native:1.0.0/seek`),
+     nTell(`rho:io:fs:native:1.0.0/tell`),
      nSize(`rho:io:fs:native:1.0.0/size`),
+     nTruncate(`rho:io:fs:native:1.0.0/truncate`),
+     nFlush(`rho:io:fs:native:1.0.0/flush`),
      nClose(`rho:io:fs:native:1.0.0/close`),
      openAck
    in {{
      {FILE_AGENT_SRC}
      |
-     nOpen!(*openAck, "{path}", "r") |
+     nOpen!(*openAck, "{path}", "{mode}") |
      for (@[true, fd] <- openAck) {{
        // File's constructor uses `@fd` (process pattern), so we
        // pass the fd Process directly. Agent constructor desugars
@@ -147,6 +173,9 @@ fn wrap(body: &str, path: &str) -> String {
    }}"#
     )
 }
+
+/// Read-only convenience wrapper — opens `path` with mode "r".
+fn wrap(body: &str, path: &str) -> String { wrap_with_mode(body, path, "r") }
 
 async fn observe_sink(runtime: &RhoRuntimeImpl) -> String {
     let sink_channel = Par::default().with_exprs(vec![models::rhoapi::Expr {
@@ -333,5 +362,203 @@ async fn file_agent_unknown_method_returns_unsupported() {
     assert!(
         sink.contains(r#"GString("nonexistent")"#),
         "expected the method name in the error payload, got: {sink}"
+    );
+}
+
+/// `write(bytes)` writes at the current position and returns
+/// `[true, nWritten]`. Follow-up `seek(0, "set")` + `read` reads
+/// them back, proving the write reached disk and that fd-table
+/// state persists across four method invocations
+/// (write → seek → read → sink).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_write_then_readback_roundtrip() {
+    let path = temp_path("write_roundtrip");
+    // Precondition: file must exist for "w+" to succeed on all
+    // platforms (macOS's `w+` is fine on missing files too, but
+    // touching first keeps the test portable).
+    std::fs::write(&path, b"").expect("precondition touch");
+
+    // Write 5 bytes, seek to start, read them back. Publish the
+    // read result on @"sink" for inspection.
+    //
+    // `"68656c6c6f".hexToBytes()` gives the ASCII bytes of
+    // "hello". Using .hexToBytes() rather than
+    // "hello".toByteArray() because the latter protobuf-encodes
+    // the string as a Rholang Par -- not what we want on disk.
+    let body = r#"
+        new writeRet, seekRet, readRet in {
+          fileAgent!(*writeRet, "write", "68656c6c6f".hexToBytes()) |
+          for (@_ <- writeRet) {
+            fileAgent!(*seekRet, "seek", 0, "set") |
+            for (@_ <- seekRet) {
+              fileAgent!(*readRet, "read", 5) |
+              for (@result <- readRet) { @"sink"!(result) }
+            }
+          }
+        }
+    "#;
+    let src = wrap_with_mode(body, &path, "w+");
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-write-roundtrip".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains("GByteArray([104, 101, 108, 108, 111])"),
+        "expected the ASCII bytes of \"hello\" round-tripped, got: {sink}"
+    );
+}
+
+/// `seek(3, "set")` moves to position 3; `tell()` reports it.
+/// Also exercises the "cur" whence: subsequent `seek(2, "cur")`
+/// should land at position 5.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_seek_and_tell_report_position() {
+    let path = temp_path("seek_tell");
+    std::fs::write(&path, b"0123456789").expect("precondition write");
+
+    let body = r#"
+        new seekRet1, tellRet1, seekRet2, tellRet2 in {
+          fileAgent!(*seekRet1, "seek", 3, "set") |
+          for (@_ <- seekRet1) {
+            fileAgent!(*tellRet1, "tell") |
+            for (@r1 <- tellRet1) {
+              @"sink"!(("after-set", r1)) |
+              fileAgent!(*seekRet2, "seek", 2, "cur") |
+              for (@_ <- seekRet2) {
+                fileAgent!(*tellRet2, "tell") |
+                for (@r2 <- tellRet2) { @"sink"!(("after-cur", r2)) }
+              }
+            }
+          }
+        }
+    "#;
+    let src = wrap(body, &path);
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-seek-tell".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    // Expected: two tuples on sink -- ("after-set", [true, 3]) and
+    // ("after-cur", [true, 5]).
+    assert!(
+        sink.contains(r#"GString("after-set")"#) && sink.contains("GInt(3)"),
+        "expected tell to report 3 after seek(3,\"set\"), got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("after-cur")"#) && sink.contains("GInt(5)"),
+        "expected tell to report 5 after seek(2,\"cur\") from 3, got: {sink}"
+    );
+}
+
+/// `truncate(3)` shrinks a 10-byte file to 3 bytes. `size()`
+/// then reports 3. Exercises write mode + truncate reaching the
+/// underlying `File::set_len`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_truncate_shrinks_file() {
+    let path = temp_path("truncate");
+    std::fs::write(&path, b"0123456789").expect("precondition write");
+
+    let body = r#"
+        new truncRet, sizeRet in {
+          fileAgent!(*truncRet, "truncate", 3) |
+          for (@truncResult <- truncRet) {
+            @"sink"!(("trunc", truncResult)) |
+            fileAgent!(*sizeRet, "size") |
+            for (@sizeResult <- sizeRet) { @"sink"!(("size", sizeResult)) }
+          }
+        }
+    "#;
+    // "r+" opens read+write on existing file (no truncate on open,
+    // unlike "w+"). Correct for a shrink test.
+    let src = wrap_with_mode(body, &path, "r+");
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-truncate".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let disk_size = std::fs::metadata(&path)
+        .map(|m| m.len())
+        .unwrap_or(u64::MAX);
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        sink.contains(r#"GString("trunc")"#) && sink.contains("GBool(true)"),
+        "expected truncate to succeed, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("size")"#) && sink.contains("GInt(3)"),
+        "expected size=3 after truncate(3), got: {sink}"
+    );
+    assert_eq!(
+        disk_size, 3,
+        "expected the file on disk to be 3 bytes after truncate"
+    );
+}
+
+/// `flush()` returns `[true]`. Sanity check that the wrapper
+/// resolves the URN and the try/catch destructures the empty
+/// success payload correctly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn file_agent_flush_returns_success() {
+    let path = temp_path("flush");
+    std::fs::write(&path, b"").expect("precondition touch");
+
+    // `"616263".hexToBytes()` = ASCII "abc" (3 bytes). Content
+    // doesn't matter here -- test only cares that flush returns
+    // a `[true]` success tuple.
+    let body = r#"
+        new writeRet, flushRet in {
+          fileAgent!(*writeRet, "write", "616263".hexToBytes()) |
+          for (@_ <- writeRet) {
+            fileAgent!(*flushRet, "flush") |
+            for (@result <- flushRet) { @"sink"!(result) }
+          }
+        }
+    "#;
+    let src = wrap_with_mode(body, &path, "w+");
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "file-agent-flush".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, file_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(&path);
+
+    // Success reply is a bare `[true]` -- a 1-element list.
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected flush success tuple on sink, got: {sink}"
     );
 }


### PR DESCRIPTION
## Summary

Continues Phase 2 by adding the next natural chunk of native-primitive-wrapping methods to the `File` agent (stacked on #139). Each new method follows the pattern established by `read`/`size`/`close` — `try @<pat> <- nX!?(args) { ok } catch @[code, msg] { err }`, backed by the ack-first native handlers.

## Methods added

| Method | Signature | Delegates to | Notes |
|--------|-----------|--------------|-------|
| `write(bytes)` | `[true, nWritten]` or `[false, code, msg]` | `nativeWrite(fd, bytes)` | Requires writeable fd; otherwise native returns `FSERR_PERM`. |
| `seek(offset, whence)` | `[true, newPos]` or error tuple | `nativeSeek(fd, offset, whence)` | `whence ∈ {"set","cur","end"}` |
| `tell()` | `[true, pos]` or error tuple | `nativeTell(fd)` | |
| `truncate(n)` | `[true]` or error tuple | `nativeTruncate(fd, n)` | Requires writeable fd. Native caps at 16 GiB per call. |
| `flush()` | `[true]` or error tuple | `nativeFlush(fd)` | Uses `sync_all` (data + metadata). |

## Not shipped this PR (deferred)

- **`readAt`/`writeAt`** — naive seek-then-read/write composition is racy; needs range-lock infrastructure (Phase 4).
- **`chmod`/`chown`** — need Rholang mode-string parser (planned alongside `Dir` agent).
- **`text` / `lines` / `mapReduceLines*`** — need multi-call streaming logic; separate follow-up.

## Test harness

`file_agent_env()` extended with the 5 new URN → Par mappings. `wrap` split into `wrap_with_mode(body, path, mode)` (for writeable-fd tests using `"w+"`/`"r+"`) plus a read-only convenience wrapper preserving the existing `"r"` default. All 4 previously-shipped tests continue to route through the read-only convenience form and pass unchanged.

## Tests

4 new integration tests, each exercising a chain of method calls to prove fd-table state persists across multiple invocations through the agent layer:

- **`file_agent_write_then_readback_roundtrip`** — opens `"w+"`, writes `.hexToBytes()` of "hello", seeks to 0, reads 5 bytes, asserts the returned `GByteArray` is the expected ASCII bytes. Four-hop chain: write → seek → read → sink.
- **`file_agent_seek_and_tell_report_position`** — `seek(3, "set")` then `tell()` → pos=3; then `seek(2, "cur")` from there, `tell()` → pos=5. Exercises both `"set"` and `"cur"` whence.
- **`file_agent_truncate_shrinks_file`** — opens `"r+"` on a 10-byte file, calls `truncate(3)`, then `size()` reports 3, and the OS-level file size on disk is also 3.
- **`file_agent_flush_returns_success`** — write + flush; asserts the flush success tuple.

## Sharp edge encountered

`"hello".toByteArray()` protobuf-serializes the string as a Rholang `Par` — correct for signing/hashing, wrong for on-disk content. The write test initially wrote 5 protobuf-encoding bytes instead of ASCII bytes. Fixed by using `"68656c6c6f".hexToBytes()` (same pattern as the crypto system-processes tests). Documented inline in the test.

## Test plan

- [x] `cargo build -p rholang` clean
- [x] `cargo test -p rholang --test fileio_file_agent_spec` — 8 pass (4 prior + 4 new)
- [x] `cargo test -p rholang --lib io::` — 37 pass (unchanged)
- [x] `cargo test -p rholang --test injection_runtime_spec` — 2 pass (unchanged)
- [x] `cargo test -p rholang --test fileio_lifecycle_spec` — 3 pass (unchanged)
- [x] `cargo test -p rholang --test fileio_replay_spec` — 3 pass (unchanged)
- [x] `cargo fmt -p rholang` clean
- [x] Pre-push hook (workspace fmt/clippy/deny + full test matrix) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787297203&installation_model_id=426883&pr_number=140&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F140&signature=3bcfdafcc2a292ed907d2e8a230e2ac096b42445000c262fe46a235ee0717e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->