### PR TITLE
feat(fileio): Dir agent (entries/stat/exists)

### DIFF
--- a/rholang/src/rust/interpreter/io/agents.rs
+++ b/rholang/src/rust/interpreter/io/agents.rs
@@ -17,9 +17,16 @@
 //!
 //! Native URNs each `.rho` file expects:
 //!
-//! - `file.rho` — `nRead`, `nSize`, `nClose` (extended as the
-//!   `File` surface grows in follow-up PRs).
+//! - `file.rho` — `nRead`, `nWrite`, `nSeek`, `nTell`, `nSize`,
+//!   `nTruncate`, `nFlush`, `nClose`.
+//! - `dir.rho`  — `nQuarantine`, `nEntries`, `nStat`, `nExists`.
 
 /// Source of the `File` agent block. Expects `File`, `nRead`,
-/// `nSize`, `nClose` to be bound in the enclosing scope.
+/// `nWrite`, `nSeek`, `nTell`, `nSize`, `nTruncate`, `nFlush`,
+/// `nClose` to be bound in the enclosing scope.
 pub const FILE_AGENT_SRC: &str = include_str!("agents/file.rho");
+
+/// Source of the `Dir` agent block. Expects `Dir`, `nQuarantine`,
+/// `nEntries`, `nStat`, `nExists` to be bound in the enclosing
+/// scope.
+pub const DIR_AGENT_SRC: &str = include_str!("agents/dir.rho");

--- a/rholang/src/rust/interpreter/io/agents.rs
+++ b/rholang/src/rust/interpreter/io/agents.rs
@@ -19,7 +19,8 @@
 //!
 //! - `file.rho` — `nRead`, `nWrite`, `nSeek`, `nTell`, `nSize`,
 //!   `nTruncate`, `nFlush`, `nClose`.
-//! - `dir.rho`  — `nQuarantine`, `nEntries`, `nStat`, `nExists`.
+//! - `dir.rho`  — `nQuarantine`, `nEntries`, `nStat`, `nExists`,
+//!   `nRemoveFile`, `nRemoveDir`, `nRename`, `nCopyFile`.
 
 /// Source of the `File` agent block. Expects `File`, `nRead`,
 /// `nWrite`, `nSeek`, `nTell`, `nSize`, `nTruncate`, `nFlush`,
@@ -27,6 +28,6 @@
 pub const FILE_AGENT_SRC: &str = include_str!("agents/file.rho");
 
 /// Source of the `Dir` agent block. Expects `Dir`, `nQuarantine`,
-/// `nEntries`, `nStat`, `nExists` to be bound in the enclosing
-/// scope.
+/// `nEntries`, `nStat`, `nExists`, `nRemoveFile`, `nRemoveDir`,
+/// `nRename`, `nCopyFile` to be bound in the enclosing scope.
 pub const DIR_AGENT_SRC: &str = include_str!("agents/dir.rho");

--- a/rholang/src/rust/interpreter/io/agents/dir.rho
+++ b/rholang/src/rust/interpreter/io/agents/dir.rho
@@ -1,17 +1,20 @@
 // Dir agent — wraps a directory root with the FIP `Dir` method surface.
 //
-// Currently ships: `entries`, `stat`, `exists`, `default`. Extended
-// in follow-up PRs with `openFile`, `openDir` (need File-agent
-// composition), `removeFile`, `removeDir`, `rename`, `copyFile`
-// (path-mutating natives), `chmod`, `chown` (need mode-string
-// parser).
+// Currently ships: `entries`, `stat`, `exists`, `removeFile`,
+// `removeDir`, `rename`, `copyFile`, `default`. Extended in
+// follow-up PRs with `openFile`, `openDir` (need File-agent
+// composition), `chmod`, `chown` (need mode-string parser).
 //
 // This file is an `agent` block that expects the enclosing scope
 // to bind:
 //   - `Dir`                — the agent's constructor channel
 //   - `nQuarantine`,
 //     `nEntries`, `nStat`,
-//     `nExists`            — fixed-channel Pars for the native
+//     `nExists`,
+//     `nRemoveFile`,
+//     `nRemoveDir`,
+//     `nRename`,
+//     `nCopyFile`          — fixed-channel Pars for the native
 //                            primitives, obtained via `NormalizerEnv`
 //                            injection at compile time (see
 //                            `interpreter::io::injections`).
@@ -87,6 +90,97 @@ agent Dir {
       try @[canonPath] <- nQuarantine!?(root, relPath) {
         try @[b] <- nExists!?(canonPath) {
           return!([true, b])
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method removeFile(relPath) {
+    // Native `removeFile` unlinks a regular file. Calling it on
+    // a directory returns FSERR_PERM (via the host's
+    // PermissionDenied); callers use `removeDir` for those.
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try <- nRemoveFile!?(canonPath) {
+          return!([true])
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method removeDir(relPath, recursive) {
+    // `recursive` is a Bool. When true, uses `remove_dir_all`
+    // (best-effort atomic per tokio docs) so non-empty trees
+    // can be dropped in one call. When false, requires the
+    // directory to be empty and returns FSERR_IO otherwise.
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try <- nRemoveDir!?(canonPath, recursive) {
+          return!([true])
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method rename(fromRelPath, toRelPath) {
+    // Atomic rename via POSIX `rename(2)`. Both source and
+    // destination are quarantined independently -- either
+    // escape attempt returns FSERR_QUARANTINE without touching
+    // the filesystem. A cross-filesystem rename returns
+    // FSERR_CROSS_DEVICE; callers who want copy-then-delete
+    // semantics use `copyFile` + `removeFile` explicitly.
+    for (@root <<- @(*this, "root")) {
+      try @[fromCanon] <- nQuarantine!?(root, fromRelPath) {
+        try @[toCanon] <- nQuarantine!?(root, toRelPath) {
+          try <- nRename!?(fromCanon, toCanon) {
+            return!([true])
+          }
+          catch @[code, msg] {
+            return!([false, code, msg])
+          }
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method copyFile(fromRelPath, toRelPath) {
+    // Copies bytes from source to destination, replacing the
+    // destination if it exists. Distinct from `rename`: produces
+    // an independent inode and is fine across filesystems.
+    // Returns `[true, nBytes]` on success.
+    for (@root <<- @(*this, "root")) {
+      try @[fromCanon] <- nQuarantine!?(root, fromRelPath) {
+        try @[toCanon] <- nQuarantine!?(root, toRelPath) {
+          try @[nBytes] <- nCopyFile!?(fromCanon, toCanon) {
+            return!([true, nBytes])
+          }
+          catch @[code, msg] {
+            return!([false, code, msg])
+          }
         }
         catch @[code, msg] {
           return!([false, code, msg])

--- a/rholang/src/rust/interpreter/io/agents/dir.rho
+++ b/rholang/src/rust/interpreter/io/agents/dir.rho
@@ -1,0 +1,112 @@
+// Dir agent — wraps a directory root with the FIP `Dir` method surface.
+//
+// Currently ships: `entries`, `stat`, `exists`, `default`. Extended
+// in follow-up PRs with `openFile`, `openDir` (need File-agent
+// composition), `removeFile`, `removeDir`, `rename`, `copyFile`
+// (path-mutating natives), `chmod`, `chown` (need mode-string
+// parser).
+//
+// This file is an `agent` block that expects the enclosing scope
+// to bind:
+//   - `Dir`                — the agent's constructor channel
+//   - `nQuarantine`,
+//     `nEntries`, `nStat`,
+//     `nExists`            — fixed-channel Pars for the native
+//                            primitives, obtained via `NormalizerEnv`
+//                            injection at compile time (see
+//                            `interpreter::io::injections`).
+//
+// Constructor calling convention: the `@rootPath` formal is a
+// process pattern receiving the pre-canonicalized absolute
+// root path as a String (the powerbox canonicalizes it at boot,
+// per `nativeQuarantine`'s documented precondition). Stashed on
+// `@(*this, "root")`.
+//
+// Path-taking methods (`stat`, `exists`) first call
+// `nativeQuarantine(root, relPath)` to canonicalize the relative
+// path and reject any escape via `..` or symlink traversal. Only
+// if quarantine succeeds does the method dispatch to the
+// underlying native with the canonical absolute path. Quarantine
+// failures surface as `[false, "FSERR_QUARANTINE", ...]` tuples
+// directly (they're already in the FSERR shape).
+//
+// `entries()` operates on the root itself and skips quarantine
+// (there's no relPath to check; the root was quarantined at
+// construction time by the powerbox).
+//
+// The genesis-installed `Fs` agent embeds this block inside its
+// own `new`-scope that provides the native URN bindings and
+// never exposes them outward. User code reaches `Dir` instances
+// through `Fs.openDir`.
+//
+// Default-arm reply idiom: same as `File.default` — `args` is in
+// scope via the outer `for(...@args <= this)`, first element is
+// the caller's return channel as a Process, destructure and
+// re-quote with `@` to reply.
+agent Dir {
+  constructor(@rootPath) {
+    // `@rootPath` binds the incoming Process (String) directly.
+    // Persist under a `*this`-keyed subchannel for methods to peek.
+    @(*this, "root")!(rootPath)
+  } |
+
+  method entries() {
+    // Lists the dir root itself. No relPath, so no quarantine
+    // step -- the root was canonicalized + escape-checked at
+    // Dir construction time.
+    for (@root <<- @(*this, "root")) {
+      try @[list] <- nEntries!?(root) {
+        return!([true, list])
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method stat(relPath) {
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try @[record] <- nStat!?(canonPath) {
+          return!([true, record])
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        // Quarantine failure -- typically FSERR_QUARANTINE for
+        // an escape attempt. Forward the tuple verbatim.
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method exists(relPath) {
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try @[b] <- nExists!?(canonPath) {
+          return!([true, b])
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  default(...@args) {
+    // Same idiom as `File.default`. `args` is bound by the outer
+    // `for(...@args <= this)` of the desugared dispatch loop;
+    // its first element is the caller's return channel as a
+    // Process. Re-quote with `@` and reply with FSERR_UNSUPPORTED.
+    match args {
+      [returnProc, ...rest] => {
+        @returnProc!([false, "FSERR_UNSUPPORTED", ("Dir agent has no method:", rest)])
+      }
+    }
+  }
+}

--- a/rholang/src/rust/interpreter/io/path.rs
+++ b/rholang/src/rust/interpreter/io/path.rs
@@ -98,6 +98,27 @@ pub fn canonicalize_and_quarantine(root: &Path, rel: &str) -> Result<PathBuf, Qu
     // paths past the join. We also strip a leading `./` for
     // hygiene.
     let stripped: &str = rel.trim_start_matches('/').trim_start_matches("./");
+
+    // Empty or `.`-only tails would resolve to `root` itself,
+    // which lets `removeDir("", true)` (or `removeDir(".", true)`,
+    // `rename("", ...)`, etc.) target the sandbox root -- a
+    // caller who legitimately holds only a `Dir` handle could
+    // wipe the entire sandbox. Reject at the quarantine layer
+    // so every path-taking native inherits the check (rather
+    // than requiring each agent method to remember). A caller
+    // that actually wants to operate on the root uses a
+    // root-scoped method (`entries()`, future `stat()`-on-self)
+    // instead.
+    if stripped.is_empty()
+        || Path::new(stripped)
+            .components()
+            .all(|c| matches!(c, Component::CurDir))
+    {
+        return Err(QuarantineError::BadArg(
+            "rel path resolves to the root itself; use root-scoped methods instead".to_string(),
+        ));
+    }
+
     let joined = root.join(stripped);
 
     // Fast path: fully-existing target.
@@ -267,5 +288,62 @@ mod tests {
         let (_g, root) = scratch_tree();
         let err = canonicalize_and_quarantine(&root, "a\0b").unwrap_err();
         assert_eq!(err.code(), FSERR_BAD_ARG);
+    }
+
+    /// Empty relpath must not resolve to the root itself, or
+    /// `removeDir("", true)` wipes the sandbox.
+    #[test]
+    fn empty_rel_is_bad_arg() {
+        let (_g, root) = scratch_tree();
+        let err = canonicalize_and_quarantine(&root, "").unwrap_err();
+        assert_eq!(err.code(), FSERR_BAD_ARG);
+    }
+
+    /// `"."`, `"./"`, and any all-`CurDir`-components tail must
+    /// also be rejected -- they'd equally resolve to the root.
+    #[test]
+    fn dot_only_rel_is_bad_arg() {
+        let (_g, root) = scratch_tree();
+        for rel in [".", "./", "./.", "././.", "././"] {
+            let err = canonicalize_and_quarantine(&root, rel).unwrap_err();
+            assert_eq!(
+                err.code(),
+                FSERR_BAD_ARG,
+                "expected FSERR_BAD_ARG for rel {rel:?}"
+            );
+        }
+    }
+
+    /// Leading-slash-only forms (`/`, `//`) are stripped to
+    /// empty and must be rejected too.
+    #[test]
+    fn slash_only_rel_is_bad_arg() {
+        let (_g, root) = scratch_tree();
+        for rel in ["/", "//", "///"] {
+            let err = canonicalize_and_quarantine(&root, rel).unwrap_err();
+            assert_eq!(
+                err.code(),
+                FSERR_BAD_ARG,
+                "expected FSERR_BAD_ARG for rel {rel:?}"
+            );
+        }
+    }
+
+    /// Leading slash on a real name still works (stripped, then
+    /// treated as relative-to-root). Regression guard so the
+    /// empty-tail fix doesn't over-reject legitimate paths.
+    #[test]
+    fn leading_slash_on_real_name_still_works() {
+        let (_g, root) = scratch_tree();
+        let out = canonicalize_and_quarantine(&root, "/a").unwrap();
+        assert_eq!(out, root.join("a"));
+    }
+
+    /// `./name` (leading `./` stripped) still works.
+    #[test]
+    fn leading_dot_slash_on_real_name_still_works() {
+        let (_g, root) = scratch_tree();
+        let out = canonicalize_and_quarantine(&root, "./a").unwrap();
+        assert_eq!(out, root.join("a"));
     }
 }

--- a/rholang/tests/fileio_dir_agent_spec.rs
+++ b/rholang/tests/fileio_dir_agent_spec.rs
@@ -669,3 +669,67 @@ async fn dir_agent_copy_file_duplicates_child() {
         "expected 12 bytes copied, got: {sink}"
     );
 }
+
+/// Regression guard for a HIGH-severity finding from the security
+/// review of PR #141's mutating-methods commit: `removeDir("", true)`
+/// (or `"."`, `"./"`, `"/"`) used to resolve through
+/// `canonicalize_and_quarantine` to the root path itself, letting
+/// a caller who legitimately holds only a `Dir` handle wipe the
+/// entire sandbox via `tokio::fs::remove_dir_all(root)`.
+///
+/// Fix landed in `path.rs`: empty and `.`-only tails now surface
+/// `FSERR_BAD_ARG` before any filesystem op. This test asserts
+/// the reply is that FSERR and the root directory still exists
+/// on disk after the call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_remove_dir_empty_relpath_is_rejected() {
+    let root = temp_dir("empty_relpath_reject");
+    // Populate the root with a child so we can prove it wasn't
+    // wiped (root existence alone would prove it, but a child
+    // makes the test intent unambiguous).
+    let canary = root.join("canary.txt");
+    std::fs::write(&canary, b"i am still here").expect("write canary");
+
+    // Exercise all four spelling variants of "the root itself":
+    // "", ".", "./", "/". Each must be rejected with the same
+    // FSERR_BAD_ARG code.
+    for rel in ["", ".", "./", "/"] {
+        let body = format!(
+            r#"
+            new rmRet in {{
+              dirAgent!(*rmRet, "removeDir", "{rel}", true) |
+              for (@result <- rmRet) {{ @"sink"!(("attempt", "{rel}", result)) }}
+            }}
+        "#
+        );
+        let src = wrap(&body, &root.to_string_lossy());
+
+        let runtime = mk_runtime().await;
+        let rand = Blake2b512Random::create_from_bytes(&[]);
+        let phlo = Cost::create(i64::MAX, "dir-agent-empty-relpath-reject".to_string());
+        let result = runtime
+            .evaluate(&src, phlo, dir_agent_env(), rand)
+            .await
+            .expect("evaluate");
+        assert!(
+            result.errors.is_empty(),
+            "eval errors for rel={rel:?}: {:?}",
+            result.errors
+        );
+
+        let sink = observe_sink(&runtime).await;
+
+        // Reply must be a false-tuple carrying FSERR_BAD_ARG.
+        assert!(
+            sink.contains("GBool(false)") && sink.contains(r#"GString("FSERR_BAD_ARG")"#),
+            "expected FSERR_BAD_ARG on rel={rel:?}, got: {sink}"
+        );
+        // Root directory and canary must still exist on disk.
+        assert!(
+            root.exists() && canary.exists(),
+            "root or canary was destroyed by removeDir({rel:?}, true)"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/rholang/tests/fileio_dir_agent_spec.rs
+++ b/rholang/tests/fileio_dir_agent_spec.rs
@@ -73,7 +73,7 @@ fn temp_dir(tag: &str) -> std::path::PathBuf {
     p.canonicalize().expect("canonicalize temp dir")
 }
 
-/// The four native URNs the `Dir` agent + test harness need.
+/// The native URNs the `Dir` agent + test harness need.
 fn dir_agent_env() -> HashMap<String, Par> {
     let mut env: HashMap<String, Par> = HashMap::new();
     env.insert(
@@ -92,6 +92,22 @@ fn dir_agent_env() -> HashMap<String, Par> {
         "rho:io:fs:native:1.0.0/exists".to_string(),
         FixedChannels::native_exists(),
     );
+    env.insert(
+        "rho:io:fs:native:1.0.0/removeFile".to_string(),
+        FixedChannels::native_remove_file(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/removeDir".to_string(),
+        FixedChannels::native_remove_dir(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/rename".to_string(),
+        FixedChannels::native_rename(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/copyFile".to_string(),
+        FixedChannels::native_copy_file(),
+    );
     env
 }
 
@@ -105,7 +121,11 @@ fn wrap(body: &str, root_path: &str) -> String {
      nQuarantine(`rho:io:fs:native:1.0.0/quarantine`),
      nEntries(`rho:io:fs:native:1.0.0/entries`),
      nStat(`rho:io:fs:native:1.0.0/stat`),
-     nExists(`rho:io:fs:native:1.0.0/exists`)
+     nExists(`rho:io:fs:native:1.0.0/exists`),
+     nRemoveFile(`rho:io:fs:native:1.0.0/removeFile`),
+     nRemoveDir(`rho:io:fs:native:1.0.0/removeDir`),
+     nRename(`rho:io:fs:native:1.0.0/rename`),
+     nCopyFile(`rho:io:fs:native:1.0.0/copyFile`)
    in {{
      {DIR_AGENT_SRC}
      |
@@ -369,5 +389,283 @@ async fn dir_agent_unknown_method_returns_unsupported() {
     assert!(
         sink.contains(r#"GString("nonexistent")"#),
         "expected the method name in the error payload, got: {sink}"
+    );
+}
+
+/// `removeFile(relPath)` unlinks the child; a follow-up
+/// `exists()` confirms it's gone.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_remove_file_deletes_child() {
+    let root = temp_dir("remove_file");
+    let target = root.join("doomed.txt");
+    std::fs::write(&target, b"bye").expect("write target");
+    assert!(target.exists(), "precondition: target must exist");
+
+    let body = r#"
+        new rmRet, existRet in {
+          dirAgent!(*rmRet, "removeFile", "doomed.txt") |
+          for (@rmResult <- rmRet) {
+            @"sink"!(("remove", rmResult)) |
+            dirAgent!(*existRet, "exists", "doomed.txt") |
+            for (@existResult <- existRet) {
+              @"sink"!(("exists", existResult))
+            }
+          }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-remove-file".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(!target.exists(), "file should be gone from disk");
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Success tuple on remove ([true]) + [true, false] on exists.
+    assert!(
+        sink.contains(r#"GString("remove")"#) && sink.contains("GBool(true)"),
+        "expected remove success, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("exists")"#) && sink.contains("GBool(false)"),
+        "expected exists=false after remove, got: {sink}"
+    );
+}
+
+/// `removeDir(relPath, true)` recursively deletes a non-empty
+/// subtree.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_remove_dir_recursive_deletes_tree() {
+    let root = temp_dir("remove_dir");
+    let subdir = root.join("sub");
+    std::fs::create_dir(&subdir).expect("mkdir sub");
+    std::fs::write(subdir.join("nested.txt"), b"x").expect("write nested");
+
+    let body = r#"
+        new rmRet in {
+          dirAgent!(*rmRet, "removeDir", "sub", true) |
+          for (@result <- rmRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-remove-dir".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(!subdir.exists(), "subdir should be gone from disk");
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected removeDir success, got: {sink}"
+    );
+}
+
+/// `removeDir(relPath, false)` on a non-empty directory returns
+/// an error (native surfaces the OS's `DirectoryNotEmpty`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_remove_dir_nonrecursive_on_nonempty_errors() {
+    let root = temp_dir("remove_dir_nonempty");
+    let subdir = root.join("sub");
+    std::fs::create_dir(&subdir).expect("mkdir sub");
+    std::fs::write(subdir.join("holds.txt"), b"x").expect("write holds");
+
+    let body = r#"
+        new rmRet in {
+          dirAgent!(*rmRet, "removeDir", "sub", false) |
+          for (@result <- rmRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-remove-dir-nonempty".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(subdir.exists(), "subdir should still be on disk");
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(false)"),
+        "expected error tuple on non-empty non-recursive remove, got: {sink}"
+    );
+}
+
+/// `rename(from, to)` moves a file within the root. Both source
+/// and destination are quarantined.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_rename_moves_child_within_root() {
+    let root = temp_dir("rename");
+    let source = root.join("old.txt");
+    std::fs::write(&source, b"payload").expect("write source");
+    let dest = root.join("new.txt");
+
+    let body = r#"
+        new renRet in {
+          dirAgent!(*renRet, "rename", "old.txt", "new.txt") |
+          for (@result <- renRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-rename".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(!source.exists(), "source should be gone");
+    assert!(dest.exists(), "dest should exist");
+    assert_eq!(
+        std::fs::read(&dest).expect("read dest"),
+        b"payload",
+        "dest contents should match source"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected rename success, got: {sink}"
+    );
+}
+
+/// `rename` where the SOURCE escapes root — quarantine catches
+/// it, no filesystem call. Escape target file exists to prove
+/// rejection is on principle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_rename_rejects_escape_in_source() {
+    let root = temp_dir("rename_escape_src");
+    let outside = root.parent().unwrap().join("outsider.txt");
+    std::fs::write(&outside, b"external").expect("write outside");
+
+    let body = r#"
+        new renRet in {
+          dirAgent!(*renRet, "rename", "../outsider.txt", "captured.txt") |
+          for (@result <- renRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-rename-escape-src".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(outside.exists(), "outside file should be untouched");
+    let _ = std::fs::remove_file(&outside);
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains(r#"GString("FSERR_QUARANTINE")"#),
+        "expected FSERR_QUARANTINE on rejected source, got: {sink}"
+    );
+}
+
+/// `rename` where the DESTINATION escapes root — same rejection
+/// via the second quarantine call, no filesystem side effect.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_rename_rejects_escape_in_destination() {
+    let root = temp_dir("rename_escape_dst");
+    let source = root.join("valid.txt");
+    std::fs::write(&source, b"stayput").expect("write source");
+    let out_of_root = root.parent().unwrap().join("escaped.txt");
+
+    let body = r#"
+        new renRet in {
+          dirAgent!(*renRet, "rename", "valid.txt", "../escaped.txt") |
+          for (@result <- renRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-rename-escape-dst".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(source.exists(), "source should be untouched");
+    assert!(!out_of_root.exists(), "escaped destination must NOT exist");
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains(r#"GString("FSERR_QUARANTINE")"#),
+        "expected FSERR_QUARANTINE on rejected destination, got: {sink}"
+    );
+}
+
+/// `copyFile(from, to)` duplicates a file within the root. The
+/// reply carries the number of bytes copied.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_copy_file_duplicates_child() {
+    let root = temp_dir("copyfile");
+    let source = root.join("orig.txt");
+    std::fs::write(&source, b"duplicate me").expect("write source");
+    let dest = root.join("copy.txt");
+
+    let body = r#"
+        new cpRet in {
+          dirAgent!(*cpRet, "copyFile", "orig.txt", "copy.txt") |
+          for (@result <- cpRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-copyfile".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(source.exists(), "source must still exist");
+    assert!(dest.exists(), "dest must exist");
+    assert_eq!(std::fs::read(&dest).expect("read dest"), b"duplicate me");
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Reply is [true, 12] (12 = len("duplicate me")).
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected copyFile success, got: {sink}"
+    );
+    assert!(
+        sink.contains("GInt(12)"),
+        "expected 12 bytes copied, got: {sink}"
     );
 }

--- a/rholang/tests/fileio_dir_agent_spec.rs
+++ b/rholang/tests/fileio_dir_agent_spec.rs
@@ -1,0 +1,373 @@
+//! End-to-end tests for the `Dir` agent (Phase 2 of the File I/O
+//! implementation).
+//!
+//! Same full-stack shape as `fileio_file_agent_spec.rs`, but for
+//! the `Dir` class: agent-block sugar → dispatch → NormalizerEnv
+//! injection → native handlers → replay guards. `Dir` differs
+//! from `File` in that it stashes a canonical absolute PATH
+//! (not an fd) in per-instance state, and each path-taking
+//! method routes through `nativeQuarantine(root, relPath)`
+//! before dispatching to the underlying native.
+//!
+//! Tests cover:
+//! - `entries()` — lists the root; no quarantine step.
+//! - `stat(relPath)` / `exists(relPath)` — quarantine + native.
+//! - Quarantine failure surfaces as `FSERR_QUARANTINE` on the
+//!   caller's ack channel (not a deploy-abort).
+//! - Default arm replies `FSERR_UNSUPPORTED` per the reply idiom
+//!   shared with `File`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crypto::rust::hash::blake2b512_random::Blake2b512Random;
+use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
+use rholang::rust::interpreter::accounting::costs::Cost;
+use rholang::rust::interpreter::external_services::ExternalServices;
+use rholang::rust::interpreter::io::agents::DIR_AGENT_SRC;
+use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
+use rholang::rust::interpreter::system_processes::FixedChannels;
+use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
+use rspace_plus_plus::rspace::history::history_repository::HistoryRepository;
+use rspace_plus_plus::rspace::shared::in_mem_store_manager::InMemoryStoreManager;
+use rspace_plus_plus::rspace::shared::key_value_store_manager::KeyValueStoreManager;
+
+#[allow(clippy::type_complexity)]
+async fn mk_runtime() -> RhoRuntimeImpl {
+    let mut kvm = InMemoryStoreManager::new();
+    let store = kvm.r_space_stores().await.unwrap();
+    let (runtime, _, _): (
+        RhoRuntimeImpl,
+        RhoRuntimeImpl,
+        Arc<
+            Box<
+                dyn HistoryRepository<Par, BindPattern, ListParWithRandom, TaggedContinuation>
+                    + Send
+                    + Sync
+                    + 'static,
+            >,
+        >,
+    ) = create_runtimes_with_services(store, false, &mut Vec::new(), ExternalServices::noop())
+        .await;
+    runtime
+}
+
+/// Create a fresh temp dir with a stable name for this test run.
+/// Returns the canonicalized absolute path (Dir's constructor
+/// requires the root to already be canonical, per
+/// `nativeQuarantine`'s precondition).
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "fileio_dir_agent_spec_{tag}_{pid}_{ts}",
+        pid = std::process::id(),
+        ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&p).expect("create temp dir");
+    // Canonicalize so macOS /tmp -> /private/tmp translation
+    // is applied; native_quarantine matches against the
+    // canonical form.
+    p.canonicalize().expect("canonicalize temp dir")
+}
+
+/// The four native URNs the `Dir` agent + test harness need.
+fn dir_agent_env() -> HashMap<String, Par> {
+    let mut env: HashMap<String, Par> = HashMap::new();
+    env.insert(
+        "rho:io:fs:native:1.0.0/quarantine".to_string(),
+        FixedChannels::native_quarantine(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/entries".to_string(),
+        FixedChannels::native_entries(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/stat".to_string(),
+        FixedChannels::native_stat(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/exists".to_string(),
+        FixedChannels::native_exists(),
+    );
+    env
+}
+
+/// Wrap `body` in the outer `new`-scope + inject the `Dir` agent
+/// block. Constructs a Dir instance rooted at `root_path` and
+/// binds `dirAgent` for the body to invoke.
+fn wrap(body: &str, root_path: &str) -> String {
+    format!(
+        r#"new
+     Dir,
+     nQuarantine(`rho:io:fs:native:1.0.0/quarantine`),
+     nEntries(`rho:io:fs:native:1.0.0/entries`),
+     nStat(`rho:io:fs:native:1.0.0/stat`),
+     nExists(`rho:io:fs:native:1.0.0/exists`)
+   in {{
+     {DIR_AGENT_SRC}
+     |
+     new dirRet in {{
+       // Dir constructor: `Dir!(replyChan_as_process, rootPath)`.
+       // rootPath is a String Process; auto-quoted on send,
+       // unquoted back via `@rootPath` in the constructor formal.
+       Dir!(*dirRet, "{root_path}") |
+       for (dirAgent <- dirRet) {{
+         {body}
+       }}
+     }}
+   }}"#
+    )
+}
+
+async fn observe_sink(runtime: &RhoRuntimeImpl) -> String {
+    let sink_channel = Par::default().with_exprs(vec![models::rhoapi::Expr {
+        expr_instance: Some(models::rhoapi::expr::ExprInstance::GString(
+            "sink".to_string(),
+        )),
+    }]);
+    let data = runtime.get_data(&sink_channel).await;
+    data.into_iter()
+        .flat_map(|d| d.a.pars)
+        .map(|p| format!("{p:?}"))
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// `entries()` on a directory with two files returns a list
+/// containing both entries. Native sorts lexicographically, so
+/// the order is deterministic.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_entries_lists_root_children() {
+    let root = temp_dir("entries");
+    std::fs::write(root.join("alpha.txt"), b"a").expect("write alpha");
+    std::fs::write(root.join("beta.txt"), b"bb").expect("write beta");
+
+    let body = r#"
+        new entRet in {
+          dirAgent!(*entRet, "entries") |
+          for (@result <- entRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-entries".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("alpha.txt")"#),
+        "expected alpha.txt in entries, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("beta.txt")"#),
+        "expected beta.txt in entries, got: {sink}"
+    );
+}
+
+/// `stat(relPath)` on a present child returns a stat record.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_stat_reports_child_metadata() {
+    let root = temp_dir("stat");
+    std::fs::write(root.join("target.txt"), b"12345").expect("write target");
+
+    let body = r#"
+        new statRet in {
+          dirAgent!(*statRet, "stat", "target.txt") |
+          for (@result <- statRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-stat".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Expected: [true, {"name": "target.txt", "size": 5, "kind": "file", ...}]
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("target.txt")"#),
+        "expected the file name in the stat record, got: {sink}"
+    );
+    assert!(
+        sink.contains("GInt(5)"),
+        "expected size=5 in the stat record, got: {sink}"
+    );
+}
+
+/// `exists(relPath)` returns `[true, true]` when the child is
+/// present.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_exists_true_for_present_child() {
+    let root = temp_dir("exists_true");
+    std::fs::write(root.join("here.txt"), b"").expect("touch here");
+
+    let body = r#"
+        new existRet in {
+          dirAgent!(*existRet, "exists", "here.txt") |
+          for (@result <- existRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-exists-true".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Expected: [true, true] -- both booleans on the sink.
+    let true_count = sink.matches("GBool(true)").count();
+    assert!(
+        true_count >= 2,
+        "expected two `true` booleans (success + exists), got: {sink}"
+    );
+}
+
+/// `exists(relPath)` returns `[true, false]` when the child is
+/// absent. Native `nativeExists` translates `NotFound` to
+/// `Ok(false)`, so the outer tuple is still `[true, ...]`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_exists_false_for_absent_child() {
+    let root = temp_dir("exists_false");
+
+    let body = r#"
+        new existRet in {
+          dirAgent!(*existRet, "exists", "nope.txt") |
+          for (@result <- existRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-exists-false".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Expected: [true, false] -- outer success (query succeeded),
+    // inner false (file doesn't exist).
+    assert!(
+        sink.contains("GBool(true)") && sink.contains("GBool(false)"),
+        "expected both true and false on sink, got: {sink}"
+    );
+}
+
+/// A `..` escape attempt is rejected by `nativeQuarantine`, which
+/// returns `FSERR_QUARANTINE`. The `Dir` agent forwards the
+/// tuple verbatim; no `nativeStat`/`nativeExists` call happens.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_stat_rejects_parent_escape() {
+    let root = temp_dir("escape");
+    // Create a sibling file OUTSIDE the root to prove the escape
+    // is denied even when the target exists.
+    std::fs::write(root.parent().unwrap().join("outside.txt"), b"secret").expect("write outside");
+
+    let body = r#"
+        new statRet in {
+          dirAgent!(*statRet, "stat", "../outside.txt") |
+          for (@result <- statRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-escape".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_file(root.parent().unwrap().join("outside.txt"));
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(false)"),
+        "expected error tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("FSERR_QUARANTINE")"#),
+        "expected FSERR_QUARANTINE code on sink, got: {sink}"
+    );
+}
+
+/// Unknown methods hit the default arm and get
+/// `FSERR_UNSUPPORTED` with the method name in the payload.
+/// Same reply idiom as `File.default`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_unknown_method_returns_unsupported() {
+    let root = temp_dir("unknown");
+
+    let body = r#"
+        new unkRet in {
+          dirAgent!(*unkRet, "nonexistent", "arg1") |
+          for (@result <- unkRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-agent-unknown".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(false)"),
+        "expected error tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("FSERR_UNSUPPORTED")"#),
+        "expected FSERR_UNSUPPORTED code on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("nonexistent")"#),
+        "expected the method name in the error payload, got: {sink}"
+    );
+}


### PR DESCRIPTION
## Summary

Continues Phase 2 with the first cut of the `Dir` agent class: three query methods (`entries`, `stat`, `exists`) plus the shared `default` reply idiom. Establishes the "quarantine-per-call" pattern for path-taking methods that later PRs will follow for the mutating methods.

## What's shipped

`rholang/src/rust/interpreter/io/agents/dir.rho` — `agent Dir { constructor / method entries / method stat / method exists / default }`. Rust plumbing: `pub const DIR_AGENT_SRC` in `agents.rs`.

### Method surface

| Method | Signature | Delegates to | Quarantine? |
|--------|-----------|--------------|-------------|
| `entries()` | `[true, entryList]` or error | `nativeEntries(root)` | No (root itself) |
| `stat(relPath)` | `[true, statRecord]` or error | `nativeStat(canonPath)` | Yes |
| `exists(relPath)` | `[true, bool]` or error | `nativeExists(canonPath)` | Yes |
| `default(...@args)` | `[false, "FSERR_UNSUPPORTED", ...]` | — | — |

### Per-instance state

Constructor takes an already-canonicalized absolute root path (String) as `@rootPath`, stashes it on `@(*this, "root")`. Methods peek non-consumingly, same pattern as `File`'s fd stash.

### Quarantine pattern

`entries()` skips quarantine because it operates on the root itself, which was canonicalized + escape-checked at Dir construction time (per `nativeQuarantine`'s documented precondition). The `Fs` agent that constructs Dir instances is responsible for that precondition.

Path-taking methods (`stat`/`exists`) route through `nativeQuarantine(root, relPath)` first. If quarantine fails (typically `FSERR_QUARANTINE` for a `..` escape or symlink traversal), the tuple is forwarded verbatim — the underlying native is not called.

## Deferred to follow-up PRs

- **Mutating methods**: `removeFile`, `removeDir`, `rename`, `copyFile` — natural extension of the quarantine pattern.
- **Agent-composition methods**: `openFile`, `openDir` — need to build `File`/`Dir` instances from the returned fd/rootpath and hand back a bundled name.
- **`chmod`/`chown`** — need the mode-string parser.

## Tests

Six integration tests in `rholang/tests/fileio_dir_agent_spec.rs`:

- **`dir_agent_entries_lists_root_children`** — `entries()` on a dir with `alpha.txt`+`beta.txt` returns both names in the sorted list.
- **`dir_agent_stat_reports_child_metadata`** — `stat("target.txt")` returns a stat record with name and size fields.
- **`dir_agent_exists_true_for_present_child`** — `exists("here.txt")` returns `[true, true]`.
- **`dir_agent_exists_false_for_absent_child`** — `exists("nope.txt")` returns `[true, false]` (outer success distinguishes "query succeeded, answer is no" from "query failed").
- **`dir_agent_stat_rejects_parent_escape`** — `stat("../outside.txt")` is caught by `nativeQuarantine`, returns `[false, "FSERR_QUARANTINE", ...]`. Also creates the target-of-escape file to prove the rejection is on principle, not because the target doesn't exist.
- **`dir_agent_unknown_method_returns_unsupported`** — same default-arm reply idiom as `File`.

Temp dirs are canonicalized via `Path::canonicalize` before constructor invocation so macOS's `/tmp` → `/private/tmp` translation doesn't cause `nativeQuarantine` to see two different absolute forms.

## Test plan

- [x] `cargo build -p rholang` clean
- [x] `cargo test -p rholang --test fileio_dir_agent_spec` — 6 pass
- [x] `cargo test -p rholang --test fileio_file_agent_spec` — 8 pass (unchanged)
- [x] `cargo test -p rholang --lib io::` — 37 pass (unchanged)
- [x] `cargo test -p rholang --test injection_runtime_spec` — 2 pass
- [x] `cargo test -p rholang --test fileio_lifecycle_spec` — 3 pass
- [x] `cargo test -p rholang --test fileio_replay_spec` — 3 pass
- [x] `cargo fmt -p rholang` clean
- [x] Pre-push hook (workspace fmt/clippy/deny + full test matrix) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787301068&installation_model_id=426883&pr_number=141&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F141&signature=e59edee04bbb9e0833dba26ee235bb19e9dd7f7c0be636629f89403eb783b6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->