### PR TITLE
fix(sync): avoid blocking cold start on mergeable snapshots

### DIFF
--- a/casper/src/rust/engine/lfs_block_requester.rs
+++ b/casper/src/rust/engine/lfs_block_requester.rs
@@ -89,10 +89,6 @@ pub struct ST<Key: Hash + Eq + Clone> {
     pub lower_bound: i64,
     pub height_map: BTreeMap<i64, HashSet<Key>>,
     pub finished: HashSet<Key>,
-    /// Per-block status of the mergeable-channels entry request. A block-side
-    /// `done()` does NOT mark the per-block work as finished — the entry must
-    /// also have landed. `is_finished()` requires both `d`/`latest` to be
-    /// empty AND `mergeable_d` to be empty.
     pub mergeable_d: HashMap<Key, ReqStatus>,
 }
 
@@ -149,9 +145,6 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
         }
     }
 
-    /// Mark `key`'s mergeable-channels entry as needing a request. Called
-    /// immediately after the BlockMessage for `key` has been stored; the
-    /// per-block work isn't `Done` until the entry has also landed.
     pub fn mergeable_pending(&self, key: Key) -> Self {
         let mut new_mergeable_d = self.mergeable_d.clone();
         new_mergeable_d.insert(key, ReqStatus::Init);
@@ -353,11 +346,7 @@ impl<Key: Hash + Eq + Clone> ST<Key> {
         }
     }
 
-    /// Returns flag if all keys are marked as finished (Done) AND every block
-    /// has had its mergeable-channels entry imported.
-    pub fn is_finished(&self) -> bool {
-        self.latest.is_empty() && self.d.is_empty() && self.mergeable_d.is_empty()
-    }
+    pub fn is_finished(&self) -> bool { self.latest.is_empty() && self.d.is_empty() }
 }
 
 struct StreamProcessor<'a, T: BlockRequesterOps> {
@@ -647,16 +636,16 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
         resp: &MergeableEntryResponse,
     ) -> Result<(), CasperError> {
         let block_hash_str = format!("{:?}", resp.block_hash);
-        let was_pending = {
-            let mut state = self.st.lock().map_err(|_| {
+        let was_pending = self
+            .st
+            .lock()
+            .map_err(|_| {
                 CasperError::StreamError(
-                    "Failed to acquire state lock for mergeable_received".to_string(),
+                    "Failed to acquire state lock for mergeable response".to_string(),
                 )
-            })?;
-            let (new_state, was_pending) = state.mergeable_received(&resp.block_hash);
-            *state = new_state;
-            was_pending
-        };
+            })?
+            .mergeable_d
+            .contains_key(&resp.block_hash);
 
         if !was_pending {
             tracing::debug!(
@@ -671,16 +660,23 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
                 "Mergeable entry response for {} is empty (peer has block, no entry); accepted as soft miss.",
                 block_hash_str
             );
-            return Ok(());
+        } else {
+            self.requester
+                .put_mergeable_entry(&resp.block_hash, resp.serialized_entry.as_ref())?;
+            tracing::debug!(
+                "Mergeable entry imported for block {} ({} bytes)",
+                block_hash_str,
+                resp.serialized_entry.len()
+            );
         }
 
-        self.requester
-            .put_mergeable_entry(&resp.block_hash, resp.serialized_entry.as_ref())?;
-        tracing::debug!(
-            "Mergeable entry imported for block {} ({} bytes)",
-            block_hash_str,
-            resp.serialized_entry.len()
-        );
+        let mut state = self.st.lock().map_err(|_| {
+            CasperError::StreamError(
+                "Failed to acquire state lock for mergeable_received".to_string(),
+            )
+        })?;
+        let (new_state, _) = state.mergeable_received(&resp.block_hash);
+        *state = new_state;
         Ok(())
     }
 
@@ -854,9 +850,6 @@ impl<'a, T: BlockRequesterOps> StreamProcessor<'a, T> {
 /// Create a stream to receive blocks needed for Last Finalized State.
 /// Uses exponential backoff: starts at request_timeout, doubles up to max_request_timeout.
 /// Resets to request_timeout when a response is received.
-///
-/// After each block lands, fires a `MergeableEntryRequest` for the same hash;
-/// per-block work isn't done until the entry has been imported.
 pub async fn stream<'a, T: BlockRequesterOps>(
     approved_block: &'a ApprovedBlock,
     initial_response_messages: &'a VecDeque<BlockMessage>,

--- a/casper/tests/engine/initializing_spec.rs
+++ b/casper/tests/engine/initializing_spec.rs
@@ -208,20 +208,8 @@ impl InitializingSpec {
             .as_ref()
             .unwrap()
             .clone();
-        // Tests must feed a MergeableEntryResponse for every block they enqueue;
-        // otherwise the stream's per-block mergeable_pending state never clears
-        // and is_finished() never returns true.
-        let mergeable_message_tx = initializing_engine
-            .mergeable_message_tx
-            .lock()
-            .unwrap()
-            .as_ref()
-            .unwrap()
-            .clone();
-
         let store_msgs_clone = store_response_messages.clone();
         let genesis_clone = genesis.clone();
-        let genesis_hash_for_mergeable = genesis.block_hash.clone();
 
         let enqueue_responses = async move {
             // Write directly to tuple space channel (equivalent to stateResponseQueue.enqueue1)
@@ -236,24 +224,6 @@ impl InitializingSpec {
                 .send(genesis_clone)
                 .await
                 .expect("Failed to enqueue block response");
-            // Brief yield so the LFS stream processes the genesis BlockMessage
-            // (running save_block → mergeable_pending(genesis)) before the
-            // mergeable response below is delivered. Without this, the select
-            // loop may consume the response first and reject it as unsolicited
-            // (was_pending=false), leaving mergeable_d non-empty forever and
-            // the stream blocked waiting for a response that already arrived.
-            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-            // Empty serialized_entry signals "peer has no entry"; this test
-            // doesn't exercise actual entry import, just the done-on-response gate.
-            mergeable_message_tx
-                .send(
-                    models::rust::casper::protocol::casper_message::MergeableEntryResponse {
-                        block_hash: genesis_hash_for_mergeable,
-                        serialized_entry: prost::bytes::Bytes::new(),
-                    },
-                )
-                .await
-                .expect("Failed to enqueue mergeable response");
         };
 
         let local_for_expected = fixture.local.clone();

--- a/casper/tests/engine/lfs_block_requester_state_spec.rs
+++ b/casper/tests/engine/lfs_block_requester_state_spec.rs
@@ -235,6 +235,17 @@ mod tests {
     }
 
     #[test]
+    fn pending_mergeable_entry_should_not_block_finished_state() {
+        let st = ST::new(HashSet::from([10]), None, None);
+        let (st, _) = st.get_next(false);
+        let (st, _) = st.received(10, 100, None);
+        let st = st.done(10).mergeable_pending(10);
+
+        assert!(!st.mergeable_d.is_empty());
+        assert!(st.is_finished());
+    }
+
+    #[test]
     fn from_start_to_finish_should_receive_one_item() {
         let st = ST::new(
             {


### PR DESCRIPTION
Addresses #65.

- lets mandatory block sync finish when optional mergeable-entry responses are absent
- falls back to deterministic mergeable-channel replay for missing entries
- keeps failed entry imports pending instead of silently completing them

Tests:
- cargo test -p casper engine::lfs_block_requester_state_spec -- --nocapture
- cargo test -p casper make_transition_to_running_once_approved_block_received -- --nocapture
- cargo fmt --all -- --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787333881&installation_model_id=426883&pr_number=143&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F143&signature=e6975494602fddf01736baac5b9d922b4a5a52d1d7455e91ca6254b9c411fa77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->