### PR TITLE
feat(fileio): Dir.openFile + Dir.openDir (agent composition)

### DIFF
--- a/rholang/src/rust/interpreter/io/agents.rs
+++ b/rholang/src/rust/interpreter/io/agents.rs
@@ -20,14 +20,23 @@
 //! - `file.rho` — `nRead`, `nWrite`, `nSeek`, `nTell`, `nSize`,
 //!   `nTruncate`, `nFlush`, `nClose`.
 //! - `dir.rho`  — `nQuarantine`, `nEntries`, `nStat`, `nExists`,
-//!   `nRemoveFile`, `nRemoveDir`, `nRename`, `nCopyFile`.
+//!   `nRemoveFile`, `nRemoveDir`, `nRename`, `nCopyFile`, `nOpen`,
+//!   plus the `File` constructor channel (`openFile` composes
+//!   with the File agent).
 
 /// Source of the `File` agent block. Expects `File`, `nRead`,
 /// `nWrite`, `nSeek`, `nTell`, `nSize`, `nTruncate`, `nFlush`,
 /// `nClose` to be bound in the enclosing scope.
 pub const FILE_AGENT_SRC: &str = include_str!("agents/file.rho");
 
-/// Source of the `Dir` agent block. Expects `Dir`, `nQuarantine`,
-/// `nEntries`, `nStat`, `nExists`, `nRemoveFile`, `nRemoveDir`,
-/// `nRename`, `nCopyFile` to be bound in the enclosing scope.
+/// Source of the `Dir` agent block. Expects `Dir`, `File`,
+/// `nQuarantine`, `nEntries`, `nStat`, `nExists`, `nRemoveFile`,
+/// `nRemoveDir`, `nRename`, `nCopyFile`, `nOpen` to be bound in
+/// the enclosing scope.
+///
+/// The `File` binding is required because `Dir.openFile`
+/// constructs a `File` instance around the fd returned by
+/// `nativeOpen`. In practice this means the genesis-installed
+/// `Fs` agent's outer `new`-scope must bind BOTH agent
+/// classes and their combined native URN set.
 pub const DIR_AGENT_SRC: &str = include_str!("agents/dir.rho");

--- a/rholang/src/rust/interpreter/io/agents/dir.rho
+++ b/rholang/src/rust/interpreter/io/agents/dir.rho
@@ -273,7 +273,7 @@ agent Dir {
               }
             }
             _ => {
-              return!([false, "FSERR_BAD_ARG", ("path is not a directory:", relPath)])
+              return!([false, "FSERR_BAD_ARG", "path is not a directory: " ++ relPath])
             }
           }
         }

--- a/rholang/src/rust/interpreter/io/agents/dir.rho
+++ b/rholang/src/rust/interpreter/io/agents/dir.rho
@@ -1,20 +1,23 @@
 // Dir agent — wraps a directory root with the FIP `Dir` method surface.
 //
 // Currently ships: `entries`, `stat`, `exists`, `removeFile`,
-// `removeDir`, `rename`, `copyFile`, `default`. Extended in
-// follow-up PRs with `openFile`, `openDir` (need File-agent
-// composition), `chmod`, `chown` (need mode-string parser).
+// `removeDir`, `rename`, `copyFile`, `openFile`, `openDir`,
+// `default`. Extended in follow-up PRs with `chmod`, `chown`
+// (need mode-string parser).
 //
 // This file is an `agent` block that expects the enclosing scope
 // to bind:
 //   - `Dir`                — the agent's constructor channel
+//   - `File`               — the `File` agent's constructor
+//                            channel (`openFile` composes with it)
 //   - `nQuarantine`,
 //     `nEntries`, `nStat`,
 //     `nExists`,
 //     `nRemoveFile`,
 //     `nRemoveDir`,
 //     `nRename`,
-//     `nCopyFile`          — fixed-channel Pars for the native
+//     `nCopyFile`,
+//     `nOpen`              — fixed-channel Pars for the native
 //                            primitives, obtained via `NormalizerEnv`
 //                            injection at compile time (see
 //                            `interpreter::io::injections`).
@@ -180,6 +183,98 @@ agent Dir {
           }
           catch @[code, msg] {
             return!([false, code, msg])
+          }
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method openFile(relPath, mode) {
+    // Quarantine the caller-supplied path, open an fd through
+    // `nativeOpen`, then construct a `File` agent around the
+    // fd. Returns `[true, fileBundle]` on success -- `fileBundle`
+    // is the `bundle+{*this}` value from `File`'s constructor,
+    // usable by the caller as a send target for File methods:
+    //
+    //     try @[file] <- dir!openFile("notes.txt", "r") {
+    //       try @[bytes] <- file!?("read", 100) { ... }
+    //       catch @[code, msg] { ... }
+    //     }
+    //     catch @[code, msg] { ... }
+    //
+    // This is the first agent-composition in the fileio stack;
+    // the `Fs` agent's `openFile` will follow the same shape but
+    // operate on the absolute-path level rather than
+    // relative-to-a-Dir-root.
+    //
+    // `mode` is a String from the fopen-style set the native
+    // handler accepts (`"r"`, `"w"`, `"a"`, `"r+"`, `"w+"`,
+    // `"a+"`, `"wx"`, `"w+x"`). Options-map form
+    // (`{"mode": "r+", "create": true}`) deferred to a
+    // follow-up alongside `openDir`'s options.
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try @[fd] <- nOpen!?(canonPath, mode) {
+          new fileRet in {
+            File!(*fileRet, fd) |
+            for (@fileBundle <- fileRet) {
+              // fileBundle is the bundle process from File's
+              // constructor -- forward as a Process in the
+              // reply tuple. Caller's `try @[file] <- ...`
+              // binds `file` as a Process; `file!method(...)`
+              // uses it as a channel via Rholang's implicit
+              // process->name quoting.
+              return!([true, fileBundle])
+            }
+          }
+        }
+        catch @[code, msg] {
+          return!([false, code, msg])
+        }
+      }
+      catch @[code, msg] {
+        return!([false, code, msg])
+      }
+    }
+  } |
+
+  method openDir(relPath) {
+    // Quarantine the caller-supplied path, verify it names a
+    // directory via `nativeStat`, then construct a nested `Dir`
+    // agent rooted at the canonical path. Returns
+    // `[true, dirBundle]` on success. Unlike `openFile`, no fd
+    // is opened -- Dir agents hold a path, not an fd.
+    //
+    // `mode` and `path: true` options from the FIP deferred to
+    // a follow-up. Currently returns a fully-privileged Dir
+    // (equivalent to the FIP's `mode: "rw"` default for the
+    // flag form); mode restriction on the returned agent needs
+    // a mode-parameterized Dir constructor.
+    for (@root <<- @(*this, "root")) {
+      try @[canonPath] <- nQuarantine!?(root, relPath) {
+        try @[statRecord] <- nStat!?(canonPath) {
+          // The stat record is a Map; `kind` field is one of
+          // "file"/"dir"/"symlink"/"other". Only "dir" is
+          // acceptable here -- a "file" (or anything else)
+          // means the caller pointed at the wrong thing.
+          match statRecord.get("kind") {
+            "dir" => {
+              new dirRet in {
+                Dir!(*dirRet, canonPath) |
+                for (@dirBundle <- dirRet) {
+                  return!([true, dirBundle])
+                }
+              }
+            }
+            _ => {
+              return!([false, "FSERR_BAD_ARG", ("path is not a directory:", relPath)])
+            }
           }
         }
         catch @[code, msg] {

--- a/rholang/tests/fileio_dir_agent_spec.rs
+++ b/rholang/tests/fileio_dir_agent_spec.rs
@@ -24,7 +24,7 @@ use crypto::rust::hash::blake2b512_random::Blake2b512Random;
 use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
 use rholang::rust::interpreter::accounting::costs::Cost;
 use rholang::rust::interpreter::external_services::ExternalServices;
-use rholang::rust::interpreter::io::agents::DIR_AGENT_SRC;
+use rholang::rust::interpreter::io::agents::{DIR_AGENT_SRC, FILE_AGENT_SRC};
 use rholang::rust::interpreter::rho_runtime::{RhoRuntime, RhoRuntimeImpl};
 use rholang::rust::interpreter::system_processes::FixedChannels;
 use rholang::rust::interpreter::test_utils::resources::create_runtimes_with_services;
@@ -74,8 +74,16 @@ fn temp_dir(tag: &str) -> std::path::PathBuf {
 }
 
 /// The native URNs the `Dir` agent + test harness need.
+///
+/// Includes all URNs referenced by both `Dir` and (transitively)
+/// `File`, since `Dir.openFile` composes with `File` and Dir's
+/// agent block references `nOpen` + the `File` constructor
+/// channel. The normalizer catches unbound names regardless of
+/// whether the referring method is invoked, so every test's
+/// enclosing scope must supply the full set.
 fn dir_agent_env() -> HashMap<String, Par> {
     let mut env: HashMap<String, Par> = HashMap::new();
+    // Dir's own natives.
     env.insert(
         "rho:io:fs:native:1.0.0/quarantine".to_string(),
         FixedChannels::native_quarantine(),
@@ -108,16 +116,56 @@ fn dir_agent_env() -> HashMap<String, Par> {
         "rho:io:fs:native:1.0.0/copyFile".to_string(),
         FixedChannels::native_copy_file(),
     );
+    // `openFile` needs the open primitive + the File agent's
+    // full native set (since embedding File also requires
+    // resolving its own URN references at normalization time).
+    env.insert(
+        "rho:io:fs:native:1.0.0/open".to_string(),
+        FixedChannels::native_open(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/read".to_string(),
+        FixedChannels::native_read(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/write".to_string(),
+        FixedChannels::native_write(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/seek".to_string(),
+        FixedChannels::native_seek(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/tell".to_string(),
+        FixedChannels::native_tell(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/size".to_string(),
+        FixedChannels::native_size(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/truncate".to_string(),
+        FixedChannels::native_truncate(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/flush".to_string(),
+        FixedChannels::native_flush(),
+    );
+    env.insert(
+        "rho:io:fs:native:1.0.0/close".to_string(),
+        FixedChannels::native_close(),
+    );
     env
 }
 
-/// Wrap `body` in the outer `new`-scope + inject the `Dir` agent
-/// block. Constructs a Dir instance rooted at `root_path` and
-/// binds `dirAgent` for the body to invoke.
+/// Wrap `body` in the outer `new`-scope + inject BOTH the `Dir`
+/// and `File` agent blocks (Dir.openFile constructs File
+/// instances). Constructs a Dir instance rooted at `root_path`
+/// and binds `dirAgent` for the body to invoke.
 fn wrap(body: &str, root_path: &str) -> String {
     format!(
         r#"new
-     Dir,
+     Dir, File,
      nQuarantine(`rho:io:fs:native:1.0.0/quarantine`),
      nEntries(`rho:io:fs:native:1.0.0/entries`),
      nStat(`rho:io:fs:native:1.0.0/stat`),
@@ -125,9 +173,20 @@ fn wrap(body: &str, root_path: &str) -> String {
      nRemoveFile(`rho:io:fs:native:1.0.0/removeFile`),
      nRemoveDir(`rho:io:fs:native:1.0.0/removeDir`),
      nRename(`rho:io:fs:native:1.0.0/rename`),
-     nCopyFile(`rho:io:fs:native:1.0.0/copyFile`)
+     nCopyFile(`rho:io:fs:native:1.0.0/copyFile`),
+     nOpen(`rho:io:fs:native:1.0.0/open`),
+     nRead(`rho:io:fs:native:1.0.0/read`),
+     nWrite(`rho:io:fs:native:1.0.0/write`),
+     nSeek(`rho:io:fs:native:1.0.0/seek`),
+     nTell(`rho:io:fs:native:1.0.0/tell`),
+     nSize(`rho:io:fs:native:1.0.0/size`),
+     nTruncate(`rho:io:fs:native:1.0.0/truncate`),
+     nFlush(`rho:io:fs:native:1.0.0/flush`),
+     nClose(`rho:io:fs:native:1.0.0/close`)
    in {{
      {DIR_AGENT_SRC}
+     |
+     {FILE_AGENT_SRC}
      |
      new dirRet in {{
        // Dir constructor: `Dir!(replyChan_as_process, rootPath)`.
@@ -732,4 +791,269 @@ async fn dir_agent_remove_dir_empty_relpath_is_rejected() {
     }
 
     let _ = std::fs::remove_dir_all(&root);
+}
+
+// --- openFile / openDir: agent-composition tests ------------------
+//
+// `Dir.openFile(relPath, mode)` and `Dir.openDir(relPath)` are the
+// first agent-composing methods in the fileio stack. They quarantine
+// the caller-supplied path, then construct a `File` (or nested `Dir`)
+// instance around the resolved handle/path and hand back the bundle
+// via the reply tuple. Downstream callers use the returned agent as
+// a plain send channel via Rholang's implicit process->name η.
+//
+// These tests exercise the full composition: `Dir.openFile` -> get a
+// File bundle -> call `File.read` on it -> assert content. Any bug in
+// the composition (wrong reply shape, missing agent binding,
+// mis-bundled `*this`) surfaces here.
+
+/// `openFile` composes correctly: caller receives a File bundle
+/// and uses it to `read` the file's bytes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_file_returns_functional_file() {
+    let root = temp_dir("open_file_ok");
+    std::fs::write(root.join("hello.txt"), b"hello").expect("write hello");
+
+    // openFile -> get file bundle -> file!?("read", 5) via raw send
+    // (return-first shape, as in fileio_file_agent_spec.rs). We
+    // bind `file` as a Process via `@[true, file]`; using it as a
+    // send channel relies on Rholang's implicit process->name
+    // quoting.
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openFile", "hello.txt", "r") |
+          for (@openResult <- openRet) {
+            match openResult {
+              [true, file] => {
+                new readRet in {
+                  @file!(*readRet, "read", 5) |
+                  for (@readResult <- readRet) { @"sink"!(readResult) }
+                }
+              }
+              _ => @"sink"!(("openFile-failed", openResult))
+            }
+          }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-file-ok".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Expected: [true, GByteArray([104, 101, 108, 108, 111])]
+    // = "hello" ASCII.
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected read success tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains("GByteArray([104, 101, 108, 108, 111])"),
+        "expected ASCII bytes of \"hello\", got: {sink}"
+    );
+}
+
+/// `openFile` on a `..` escape is caught by quarantine before
+/// any `nativeOpen` fires. Escape target file exists on disk to
+/// prove the rejection is on principle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_file_rejects_escape() {
+    let root = temp_dir("open_file_escape");
+    let outside = root.parent().unwrap().join("secret.txt");
+    std::fs::write(&outside, b"secret").expect("write outside");
+
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openFile", "../secret.txt", "r") |
+          for (@result <- openRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-file-escape".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(outside.exists(), "outside file must be untouched");
+    let _ = std::fs::remove_file(&outside);
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains(r#"GString("FSERR_QUARANTINE")"#),
+        "expected FSERR_QUARANTINE on escape, got: {sink}"
+    );
+}
+
+/// `openFile` on a missing file with mode "r" surfaces the
+/// native's `NotFound` error (mapped to FSERR_NOT_FOUND). Proves
+/// native errors bubble through the openFile composition without
+/// being masked by the agent-composition layer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_file_missing_returns_not_found() {
+    let root = temp_dir("open_file_missing");
+
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openFile", "nope.txt", "r") |
+          for (@result <- openRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-file-missing".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // FSERR_NOT_FOUND (not FSERR_QUARANTINE — path resolves inside
+    // root but doesn't exist).
+    assert!(
+        sink.contains(r#"GString("FSERR_NOT_FOUND")"#),
+        "expected FSERR_NOT_FOUND for missing file, got: {sink}"
+    );
+}
+
+/// `openDir` composes correctly: returned nested Dir handles
+/// `entries()` on the subdirectory.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_dir_returns_functional_dir() {
+    let root = temp_dir("open_dir_ok");
+    let sub = root.join("sub");
+    std::fs::create_dir(&sub).expect("mkdir sub");
+    std::fs::write(sub.join("child.txt"), b"c").expect("write child");
+
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openDir", "sub") |
+          for (@openResult <- openRet) {
+            match openResult {
+              [true, subDir] => {
+                new entRet in {
+                  @subDir!(*entRet, "entries") |
+                  for (@entResult <- entRet) { @"sink"!(entResult) }
+                }
+              }
+              _ => @"sink"!(("openDir-failed", openResult))
+            }
+          }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-dir-ok".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Expected: entries() on `sub` returns a list containing
+    // child.txt.
+    assert!(
+        sink.contains("GBool(true)"),
+        "expected entries success, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("child.txt")"#),
+        "expected child.txt in subdir entries, got: {sink}"
+    );
+}
+
+/// `openDir` on a regular file returns `[false, "FSERR_BAD_ARG", ...]`.
+/// Proves the kind-check fires before constructing a bogus Dir.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_dir_on_regular_file_returns_bad_arg() {
+    let root = temp_dir("open_dir_notdir");
+    std::fs::write(root.join("file.txt"), b"not a dir").expect("write file");
+
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openDir", "file.txt") |
+          for (@result <- openRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-dir-notdir".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains("GBool(false)"),
+        "expected error tuple on sink, got: {sink}"
+    );
+    assert!(
+        sink.contains(r#"GString("FSERR_BAD_ARG")"#),
+        "expected FSERR_BAD_ARG code on sink, got: {sink}"
+    );
+}
+
+/// `openDir` on a `..` escape is caught by quarantine.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dir_agent_open_dir_rejects_escape() {
+    let root = temp_dir("open_dir_escape");
+    // Create an outside dir so the escape target exists.
+    let outside_dir = root.parent().unwrap().join("outside_dir");
+    std::fs::create_dir_all(&outside_dir).expect("mkdir outside");
+
+    let body = r#"
+        new openRet in {
+          dirAgent!(*openRet, "openDir", "../outside_dir") |
+          for (@result <- openRet) { @"sink"!(result) }
+        }
+    "#;
+    let src = wrap(body, &root.to_string_lossy());
+
+    let runtime = mk_runtime().await;
+    let rand = Blake2b512Random::create_from_bytes(&[]);
+    let phlo = Cost::create(i64::MAX, "dir-open-dir-escape".to_string());
+    let result = runtime
+        .evaluate(&src, phlo, dir_agent_env(), rand)
+        .await
+        .expect("evaluate");
+    assert!(result.errors.is_empty(), "eval errors: {:?}", result.errors);
+
+    let sink = observe_sink(&runtime).await;
+    assert!(outside_dir.exists(), "outside dir must be untouched");
+    let _ = std::fs::remove_dir_all(&outside_dir);
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        sink.contains(r#"GString("FSERR_QUARANTINE")"#),
+        "expected FSERR_QUARANTINE on escape, got: {sink}"
+    );
 }


### PR DESCRIPTION
## Summary

Extends the `Dir` agent with the two remaining Phase-2 methods that compose one agent-class instance out of another:

- **`Dir.openFile(relPath, mode)`** — quarantines the relPath, opens a fd via `nativeOpen`, constructs a `File` agent around the fd, and returns `[true, fileBundle]`.
- **`Dir.openDir(relPath)`** — quarantines the relPath, verifies it names a directory via `nativeStat`, and constructs a nested `Dir` agent rooted at the canonical path. Returns `[true, dirBundle]`.

This is the first agent-composition point in the fileio stack. `Fs.openFile` in Phase 3 will follow the same shape but operate on absolute paths.

## The composition pattern

```rholang
try @[file] <- dir!openFile("notes.txt", "r") {
  try @[bytes] <- file!?("read", 100) { ... }
  catch @[code, msg] { ... }
}
catch @[code, msg] { ... }
```

`@[file] <- ...` binds `file` as a Process; `file!method(...)` uses it as a channel via Rholang's implicit Process→Name η-quoting.

## Test wrapper unification

`dir_agent_env()` and `wrap()` now bind BOTH the `Dir` and `File` constructor channels plus the union of their native URN sets, and inject `DIR_AGENT_SRC | FILE_AGENT_SRC` in parallel. The normalizer catches unbound `File` references in `Dir.openFile` at compile time, so both agent blocks need to be in scope regardless of whether `openFile` is actually invoked.

The extra bindings are inert for the 14 existing Dir tests — all still pass.

## Test plan

- [x] `cargo test -p rholang --test fileio_dir_agent_spec` — 20 pass (14 prior + 6 new)
- [x] `cargo test -p rholang --test fileio_file_agent_spec` — 8 pass
- [x] `cargo test -p rholang --lib io::` — 42 pass
- [x] `cargo test -p rholang --test fileio_lifecycle_spec` — 3 pass
- [x] `cargo test -p rholang --test fileio_replay_spec` — 3 pass
- [x] `cargo test -p rholang --test injection_runtime_spec` — 2 pass
- [x] `cargo fmt -p rholang --check` — clean
- [x] Pre-push (11 slices) — clean

## New tests (6)

Success cases exercise the returned bundle end-to-end (openFile→read, openDir→entries). Escape cases (`../secret.txt`, `../outside_dir`) return `FSERR_QUARANTINE`. Edge cases: `openFile` on a missing file returns `FSERR_NOT_FOUND` from the underlying `nativeOpen`; `openDir` on a regular file returns `FSERR_BAD_ARG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787334625&installation_model_id=426883&pr_number=144&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F144&signature=6b7633afa5a3671df5c008ab5220ce382eb8322627108907d8f8e7db03dc1e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->