### PR TITLE
fix(proposer): clarify "not bonded" error message instead of confusing "ReadOnlyMode"

### DIFF
--- a/casper/src/rust/blocks/proposer/propose_result.rs
+++ b/casper/src/rust/blocks/proposer/propose_result.rs
@@ -171,7 +171,7 @@ impl fmt::Display for ProposeStatus {
                 ProposeFailure::BugError => write!(f, "Proposal failed: BugError"),
                 ProposeFailure::CheckConstraintsFailure(check_failure) => match check_failure {
                     CheckProposeConstraintsFailure::NotBonded => {
-                        write!(f, "Proposal failed: ReadOnlyMode")
+                        write!(f, "Proposal failed: validator is not bonded")
                     }
                     CheckProposeConstraintsFailure::NotEnoughNewBlocks => {
                         write!(

--- a/node/src/rust/instances/block_processor_instance.rs
+++ b/node/src/rust/instances/block_processor_instance.rs
@@ -309,7 +309,7 @@ impl<T: TransportLayer + Send + Sync + 'static> BlockProcessorInstance<T> {
                             if trigger_propose_after_block_processing_enabled() {
                                 if let Some(trigger_propose) = trigger_propose_f {
                                     // Skip trigger if local validator is not currently bonded.
-                                    // This avoids repeated ReadOnlyMode propose attempts on
+                                    // This avoids repeated propose attempts on
                                     // non-bonded nodes.
                                     let is_bonded_validator =
                                         if let Some(validator) = casper.get_validator() {


### PR DESCRIPTION
The NotBonded variant in CheckProposeConstraintsFailure was displaying
"Proposal failed: ReadOnlyMode", which is misleading. The actual reason
is that the node is not yet bonded and therefore cannot propose.

Changed the message to "Proposal failed: validator is not bonded" and
updated the related comment in block_processor_instance.rs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787737459&installation_model_id=426883&pr_number=148&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F148&signature=9967faf3c860ccaafc4282a2b5798e513ebca2cef58482634d7edcb07bdc55a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->