### PR TITLE
[agent] fix(soak): publish Pages dashboard, repair stakeholder alerting, protect published history

### DIFF
--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -262,10 +262,21 @@ jobs:
           DURATION_SECONDS: ${{ needs.schedule_gate.outputs.duration_seconds }}
           DASHBOARD_URL: https://f1r3fly-io.github.io/f1r3node-rust/
         run: |
-          curl -fsS --max-time 30 "${DASHBOARD_URL}data/latest-summary.json" \
-            -o /tmp/soak-baseline.json 2>/dev/null \
-            && export BASELINE_JSON=/tmp/soak-baseline.json \
-            || echo "no published baseline yet (bootstrap run)"
+          # Cache-busted so the week-over-week deltas are not computed against
+          # a stale CDN copy. Unlike the history fetch this stays soft: a 60h
+          # soak's report is worth more than its baseline comparison, so a
+          # miss degrades to "no baseline" rather than discarding the run —
+          # but a non-404 miss is warned about, since a silently absent
+          # baseline makes the verdict look clean.
+          cb="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          base_code="$(curl -sS --max-time 30 -H 'Cache-Control: no-cache' -w '%{http_code}' \
+            -o /tmp/soak-baseline.json \
+            "${DASHBOARD_URL}data/latest-summary.json?cb=${cb}")" || base_code=000
+          case "$base_code" in
+            200) export BASELINE_JSON=/tmp/soak-baseline.json ;;
+            404) echo "no published baseline yet (bootstrap run)" ;;
+            *)   echo "::warning::baseline fetch failed (HTTP ${base_code}); verdict computed without week-over-week comparison" ;;
+          esac
           ci-control/scripts/bench/aggregate-perf-report.sh
           cat "$OUT_DIR/perf-report.md" >> "$GITHUB_STEP_SUMMARY"
 
@@ -280,6 +291,16 @@ jobs:
         run: |
           # Instance-principal auth: works only on the OCI runner, no secrets.
           # Notification failure must never mask the soak result.
+          #
+          # This overlaps with the notify_failure job by design — do not
+          # "deduplicate" them. This step sends the weekly verdict with its
+          # metrics and week-over-week deltas, but only ever runs ON the soak
+          # runner and only once a report exists, so it cannot report a runner
+          # that never launched or a soak that died before writing one.
+          # notify_failure covers exactly those cases from a GitHub-hosted
+          # runner. A weekend soak that completes and then fails its verdict
+          # gate therefore sends two mails: the verdict (with numbers) and the
+          # job-level alert. That is the accepted cost of never going silent.
           ci-control/scripts/oci/publish-soak-alert.sh || \
             echo "::warning::ONS alert publish failed (non-fatal)"
 
@@ -329,9 +350,29 @@ jobs:
             echo "::error::soak artifact has no weekly-summary.json"; exit 1; }
           mkdir -p site/data
           cp -r ci-control/site/soak-dashboard/. site/
-          curl -fsS --max-time 30 "${DASHBOARD_URL}data/history.json" \
-            -o /tmp/history.json 2>/dev/null || echo '[]' > /tmp/history.json
-          jq -e 'type == "array"' /tmp/history.json > /dev/null || echo '[]' > /tmp/history.json
+          # Pages is the only durable store for the history series — soak
+          # artifacts expire after 14 days — and this is the job that appends
+          # to it. Treating a transient fetch failure as "nothing published"
+          # would permanently reset the series to this run alone, so only a
+          # 404 may start an empty history and anything else aborts. The
+          # cache-busting query string stops the CDN serving a copy older
+          # than the last publish, which would drop intervening weeks.
+          cb="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          code="$(curl -sS --max-time 30 -H 'Cache-Control: no-cache' -w '%{http_code}' \
+            -o /tmp/history.json "${DASHBOARD_URL}data/history.json?cb=${cb}")" || code=000
+          case "$code" in
+            200)
+              jq -e 'type == "array"' /tmp/history.json >/dev/null 2>&1 || {
+                echo "::error::published history.json is not a JSON array; refusing to reset the series"
+                exit 1
+              }
+              ;;
+            404) echo '[]' > /tmp/history.json ;;
+            *)
+              echo "::error::could not read published history.json (HTTP ${code}); aborting so the series is not reset to this run alone"
+              exit 1
+              ;;
+          esac
           jq -s '.[0] + [.[1]] | sort_by(.run.date)' \
             /tmp/history.json soak-results/report/weekly-summary.json \
             > site/data/history.json
@@ -426,12 +467,14 @@ jobs:
             exit 1
           fi
           if [ "$DURATION_SECONDS" = "216000" ]; then kind="weekend-60h"; else kind="daily-24h"; fi
-          # Name what actually broke. A soak that never ran and a dashboard
-          # that failed to publish after a clean soak are different pages.
+          # Name what actually broke. A soak that never ran and a report stage
+          # that failed after a clean soak are different pages. perf_report
+          # covers both the Pages deploy and the regression verdict gate, so
+          # its failure is named for the stage rather than the deploy alone.
           case "$LAUNCH_RESULT/$SOAK_RESULT" in
             failure/*|cancelled/*) what="runner launch $LAUNCH_RESULT" ;;
             */failure|*/cancelled) what="soak $SOAK_RESULT" ;;
-            *)                     what="dashboard publish $DASHBOARD_RESULT" ;;
+            *)                     what="report/verdict stage $DASHBOARD_RESULT" ;;
           esac
           title="F1R3FLY soak alert ($kind): $what — $(date -u +%F)"
           body="Merge Recovery Soak did not complete cleanly: $what.

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -364,13 +364,19 @@ jobs:
     # Runs on a GitHub-hosted runner with user-principal OCI auth so the
     # alert still goes out when the OCI runner itself failed to launch —
     # the in-soak ONS step (instance-principal) cannot cover that case.
+    # `cancelled` counts too: a 60h soak that hits its timeout, is cancelled
+    # by hand, or loses its runner to preemption produced no result either,
+    # and silence there is indistinguishable from success.
     if: >-
       always() &&
       needs.schedule_gate.outputs.should_run == 'true' &&
-      contains(needs.*.result, 'failure')
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
     environment: ephemeral-launch-internal
     timeout-minutes: 10
+    # Alerting needs OCI credentials, never the GitHub API — this job has no
+    # checkout and no reason to hold a token scope.
+    permissions: {}
     steps:
       - name: Install OCI CLI (pinned, checksum-verified)
         shell: bash -e {0}
@@ -403,7 +409,7 @@ jobs:
           EOF
           oci iam region list >/dev/null
 
-      - name: Publish failure alert
+      - name: Publish soak alert
         env:
           ONS_TOPIC_OCID: ${{ vars.SOAK_ONS_TOPIC_OCID }}
           LAUNCH_RESULT: ${{ needs.launch_runner.result }}
@@ -420,8 +426,15 @@ jobs:
             exit 1
           fi
           if [ "$DURATION_SECONDS" = "216000" ]; then kind="weekend-60h"; else kind="daily-24h"; fi
-          title="F1R3FLY soak FAILURE ($kind) $(date -u +%F)"
-          body="Merge Recovery Soak run failed.
+          # Name what actually broke. A soak that never ran and a dashboard
+          # that failed to publish after a clean soak are different pages.
+          case "$LAUNCH_RESULT/$SOAK_RESULT" in
+            failure/*|cancelled/*) what="runner launch $LAUNCH_RESULT" ;;
+            */failure|*/cancelled) what="soak $SOAK_RESULT" ;;
+            *)                     what="dashboard publish $DASHBOARD_RESULT" ;;
+          esac
+          title="F1R3FLY soak alert ($kind): $what — $(date -u +%F)"
+          body="Merge Recovery Soak did not complete cleanly: $what.
 
           Target:    $TARGET_REF
           Duration:  $kind

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -86,6 +86,15 @@ jobs:
           if [ "$duration_seconds" = "216000" ]; then
             run_benchmarks=true
           fi
+          if [ "$should_run" != "true" ]; then
+            echo "::notice::Schedule gate no-op: cron slot resolved outside the Pacific 22:00 launch window. No soak was attempted; this run's success is not a soak result."
+            {
+              echo "## Schedule gate: no-op"
+              echo ""
+              echo "This scheduled trigger resolved outside the Pacific 22:00 launch window."
+              echo "**No soak was attempted** — a green check on this run is not a soak result."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           {
             echo "should_run=$should_run"
             echo "duration_seconds=$duration_seconds"
@@ -348,3 +357,92 @@ jobs:
             jq -r '.failures[] | "FAIL: " + .' soak-results/report/verdict.json
             exit 1
           fi
+
+  notify_failure:
+    name: Email Soak Failure Alert
+    needs: [schedule_gate, launch_runner, soak, perf_report]
+    # Runs on a GitHub-hosted runner with user-principal OCI auth so the
+    # alert still goes out when the OCI runner itself failed to launch —
+    # the in-soak ONS step (instance-principal) cannot cover that case.
+    if: >-
+      always() &&
+      needs.schedule_gate.outputs.should_run == 'true' &&
+      contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    environment: ephemeral-launch-internal
+    timeout-minutes: 10
+    steps:
+      - name: Install OCI CLI (pinned, checksum-verified)
+        shell: bash -e {0}
+        run: |
+          curl -fsSL "$OCI_CLI_INSTALLER_URL" -o /tmp/oci-install.sh
+          echo "$OCI_CLI_INSTALLER_SHA256  /tmp/oci-install.sh" | sha256sum -c -
+          bash /tmp/oci-install.sh \
+            --accept-all-defaults --install-dir /opt/oci-cli --exec-dir /usr/local/bin
+          oci --version
+
+      - name: Configure OCI authentication
+        env:
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
+        shell: bash -e {0}
+        run: |
+          install -d -m 700 ~/.oci
+          umask 077
+          printf '%s\n' "$OCI_PRIVATE_KEY" > ~/.oci/oci_api_key.pem
+          cat > ~/.oci/config <<EOF
+          [DEFAULT]
+          user=$OCI_USER_OCID
+          fingerprint=$OCI_FINGERPRINT
+          tenancy=$OCI_TENANCY_OCID
+          region=$OCI_REGION
+          key_file=$HOME/.oci/oci_api_key.pem
+          EOF
+          oci iam region list >/dev/null
+
+      - name: Publish failure alert
+        env:
+          ONS_TOPIC_OCID: ${{ vars.SOAK_ONS_TOPIC_OCID }}
+          LAUNCH_RESULT: ${{ needs.launch_runner.result }}
+          SOAK_RESULT: ${{ needs.soak.result }}
+          DASHBOARD_RESULT: ${{ needs.perf_report.result }}
+          TARGET_REF: ${{ needs.schedule_gate.outputs.target_ref }}
+          DURATION_SECONDS: ${{ needs.schedule_gate.outputs.duration_seconds }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          DASHBOARD_URL: https://f1r3fly-io.github.io/f1r3node-rust/
+        shell: bash -euo pipefail {0}
+        run: |
+          if [ -z "$ONS_TOPIC_OCID" ]; then
+            echo "::error::SOAK_ONS_TOPIC_OCID is not configured; failure alert NOT sent"
+            exit 1
+          fi
+          if [ "$DURATION_SECONDS" = "216000" ]; then kind="weekend-60h"; else kind="daily-24h"; fi
+          title="F1R3FLY soak FAILURE ($kind) $(date -u +%F)"
+          body="Merge Recovery Soak run failed.
+
+          Target:    $TARGET_REF
+          Duration:  $kind
+          Job results:
+            launch runner:  $LAUNCH_RESULT
+            soak:           $SOAK_RESULT
+            dashboard:      $DASHBOARD_RESULT
+
+          Run: $RUN_URL
+          Dashboard: $DASHBOARD_URL
+
+          Manage this subscription via the unsubscribe link in this email."
+          oci ons message publish \
+            --topic-id "$ONS_TOPIC_OCID" \
+            --title "$title" \
+            --body "$body"
+          echo "published ONS failure alert: $title"
+
+      - name: Remove OCI credentials
+        if: always()
+        shell: bash -e {0}
+        run: |
+          shred -fu ~/.oci/oci_api_key.pem 2>/dev/null || true
+          rm -rf ~/.oci

--- a/.github/workflows/soak-dashboard-pages.yml
+++ b/.github/workflows/soak-dashboard-pages.yml
@@ -1,0 +1,62 @@
+name: Soak Dashboard Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - site/soak-dashboard/**
+      - .github/workflows/soak-dashboard-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Publish Soak Dashboard (bootstrap)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: soak-pages
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Assemble dashboard site
+        shell: bash -euo pipefail {0}
+        env:
+          DASHBOARD_URL: https://f1r3fly-io.github.io/f1r3node-rust/
+        run: |
+          # Bootstrap/refresh deploy: publish the dashboard shell while
+          # preserving any data already published by the weekend soak's
+          # perf_report job. First deploy ships an empty history.
+          mkdir -p site/data
+          cp -r site/soak-dashboard/. site/
+          for f in history.json latest-summary.json latest-verdict.json latest-report.md; do
+            curl -fsS --max-time 30 "${DASHBOARD_URL}data/${f}" \
+              -o "site/data/${f}" 2>/dev/null || rm -f "site/data/${f}"
+          done
+          jq -e 'type == "array"' site/data/history.json >/dev/null 2>&1 \
+            || echo '[]' > site/data/history.json
+          test -s site/data/latest-report.md \
+            || echo 'No soak report yet — the first successful weekend soak publishes one.' \
+              > site/data/latest-report.md
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/soak-dashboard-pages.yml
+++ b/.github/workflows/soak-dashboard-pages.yml
@@ -42,13 +42,18 @@ jobs:
           # perf_report job. First deploy ships an empty history.
           mkdir -p site/data
           cp -r site/soak-dashboard/. site/
+          # Pages is CDN-backed, so a plain GET can return a copy cached from
+          # before the weekend soak's last publish — and we would then
+          # republish that stale copy over the newer data. A per-run query
+          # string forces a cache miss so we always read current state.
+          cb="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           # Only a 404 proves nothing has been published yet. Every other
           # outcome (outage, timeout, rate limit, 5xx) is transient, and
           # treating it as "no data" would republish an empty dashboard
           # over real soak history — so abort instead.
           for f in history.json latest-summary.json latest-verdict.json latest-report.md; do
-            code="$(curl -sS --max-time 30 -w '%{http_code}' \
-              -o "site/data/${f}" "${DASHBOARD_URL}data/${f}")" || code=000
+            code="$(curl -sS --max-time 30 -H 'Cache-Control: no-cache' -w '%{http_code}' \
+              -o "site/data/${f}" "${DASHBOARD_URL}data/${f}?cb=${cb}")" || code=000
             case "$code" in
               200) ;;
               404) rm -f "site/data/${f}" ;;
@@ -57,6 +62,15 @@ jobs:
                 exit 1
                 ;;
             esac
+          done
+          # HTTP 200 is not proof of valid content — a CDN or proxy error page
+          # is served with 200 too. Republishing one would corrupt the data.
+          for f in history.json latest-summary.json latest-verdict.json; do
+            [ -e "site/data/${f}" ] || continue
+            jq -e . "site/data/${f}" >/dev/null 2>&1 || {
+              echo "::error::published ${f} is not valid JSON; refusing to republish it"
+              exit 1
+            }
           done
           if [ -e site/data/history.json ]; then
             jq -e 'type == "array"' site/data/history.json >/dev/null 2>&1 || {

--- a/.github/workflows/soak-dashboard-pages.yml
+++ b/.github/workflows/soak-dashboard-pages.yml
@@ -42,12 +42,30 @@ jobs:
           # perf_report job. First deploy ships an empty history.
           mkdir -p site/data
           cp -r site/soak-dashboard/. site/
+          # Only a 404 proves nothing has been published yet. Every other
+          # outcome (outage, timeout, rate limit, 5xx) is transient, and
+          # treating it as "no data" would republish an empty dashboard
+          # over real soak history — so abort instead.
           for f in history.json latest-summary.json latest-verdict.json latest-report.md; do
-            curl -fsS --max-time 30 "${DASHBOARD_URL}data/${f}" \
-              -o "site/data/${f}" 2>/dev/null || rm -f "site/data/${f}"
+            code="$(curl -sS --max-time 30 -w '%{http_code}' \
+              -o "site/data/${f}" "${DASHBOARD_URL}data/${f}")" || code=000
+            case "$code" in
+              200) ;;
+              404) rm -f "site/data/${f}" ;;
+              *)
+                echo "::error::could not read published ${f} (HTTP ${code}); aborting so live dashboard data is not overwritten"
+                exit 1
+                ;;
+            esac
           done
-          jq -e 'type == "array"' site/data/history.json >/dev/null 2>&1 \
-            || echo '[]' > site/data/history.json
+          if [ -e site/data/history.json ]; then
+            jq -e 'type == "array"' site/data/history.json >/dev/null 2>&1 || {
+              echo "::error::published history.json is not a JSON array; refusing to replace it"
+              exit 1
+            }
+          else
+            echo '[]' > site/data/history.json
+          fi
           test -s site/data/latest-report.md \
             || echo 'No soak report yet — the first successful weekend soak publishes one.' \
               > site/data/latest-report.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,11 @@ Both settings take effect at the next session start.
 - Keep commit messages clean and professional
 
 ### Branch Strategy
-- `main` — stable releases
-- `master` — current working branch
-- Feature branches for development
+- `master` — default branch and release line; maintainers promote `dev` → `master`
+- `dev` — integration branch; feature and fix PRs target this
+- Feature branches (`feature/`, `fix/`, `docs/`, `perf/`, `chore/`) branch from and target `dev`
+- `hotfix/` branches from and target `master`, then `master` is merged back into `dev`
+- There is no `main` branch, and `staging` is deprecated (fully contained in `dev`)
 
 ## Relationship to f1r3node
 This repo was extracted from `F1R3FLY-io/f1r3fly` (`rust/dev` branch). Key differences:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ that conflicts defers to it.
 
 ## Branching and Commits
 
-- Branch from `staging` and open pull requests against `staging`. Maintainers promote
-  `staging` → `dev` → `master`.
+- Branch from `dev` and open pull requests against `dev`. Maintainers promote
+  `dev` → `master`.
 - Branch prefixes: `feature/`, `fix/`, `docs/`, `perf/`, `chore/`.
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`,
   `perf:`, `refactor:`, `test:`, `chore:`.
@@ -76,7 +76,7 @@ New or occasional contributors should open pull requests from personal forks. Ke
 
 Known recurring contributors may be invited to work from branches in the upstream `F1R3FLY-io/f1r3node-rust` repository. Maintainers grant upstream access based on project need, contributor identity, prior review history, and expected scope of work.
 
-Upstream access does not bypass review. Protected branches such as `master`, `dev`, and `staging` still require pull requests and required checks before merge.
+Upstream access does not bypass review. Protected branches such as `master` and `dev` still require pull requests and required checks before merge.
 
 ## CI Approval for Fork Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,13 +16,26 @@ that conflicts defers to it.
 ## Branching and Commits
 
 - Branch from `dev` and open pull requests against `dev`. Maintainers promote
-  `dev` → `master`.
-- Branch prefixes: `feature/`, `fix/`, `docs/`, `perf/`, `chore/`.
+  `dev` → `master`. Hotfixes are the one exception — see Hotfixes below.
+- Branch prefixes: `feature/`, `fix/`, `docs/`, `perf/`, `chore/`, `hotfix/`.
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`,
   `perf:`, `refactor:`, `test:`, `chore:`.
 - Keep one concern per pull request.
 - Preserve commit history when picking up someone else's PR — don't squash unrelated commits
   without consent.
+
+### Hotfixes
+
+Urgent work that cannot wait for the next `dev` → `master` promotion — a broken release or CI
+pipeline, a security patch, a production incident — branches from `master` as
+`hotfix/<topic>` and opens its pull request against `master`.
+
+After the hotfix merges, merge `master` back into `dev` so the fix survives the next
+promotion. Skipping that step is how a hotfix silently disappears from the next release.
+
+Use this path sparingly. A hotfix reaches `master` without ever being integrated against the
+work already queued in `dev`, so it trades integration coverage for speed. Anything that can
+wait should go through `dev` like everything else.
 
 ## Local Checks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,4 +31,4 @@ requiring physical access to or a compromised host.
 ## Supported Versions
 
 F1R3FLY is under active development with no released or mainnet versions yet. Report against
-the latest `staging` / `dev`.
+the latest `dev`.

--- a/docs/neutralCloud_benchmark_review.md
+++ b/docs/neutralCloud_benchmark_review.md
@@ -1,12 +1,12 @@
-# Neutral Cloud Benchmark Review Guide — F1R3FLY Rust Node Staging
+# Neutral Cloud Benchmark Review Guide — F1R3FLY Rust Node
 
 _Date prepared: 2026-07-06_
 
 ## Purpose
 
-This document gives a partner engineering team a review and benchmark plan for the F1R3FLY Rust node `staging` branch of `F1R3FLY-io/f1r3node-rust`, using the cloud / integration-test patterns already documented in:
+This document gives a partner engineering team a review and benchmark plan for the F1R3FLY Rust node `dev` branch of `F1R3FLY-io/f1r3node-rust`, using the cloud / integration-test patterns already documented in:
 
-- `F1R3FLY-io/f1r3node-rust`, branch `staging`
+- `F1R3FLY-io/f1r3node-rust`, branch `dev`
 - `F1R3FLY-io/system-integration`, branch `main`
 - `f1r3node-rust/docs/vps-cloud-testing.md`
 - `system-integration/integration-tests/README.md`
@@ -15,9 +15,9 @@ The intended audience is a partner engineering team that wants to reproduce a di
 
 ---
 
-## 1. Current staging baseline
+## 1. Current dev baseline
 
-The `staging` branch currently exposes the Rust node workspace as a standalone Cargo/Docker setup. The repository README describes the Rust node as a pure Rust implementation of the F1R3FLY blockchain node with:
+The `dev` branch currently exposes the Rust node workspace as a standalone Cargo/Docker setup. The repository README describes the Rust node as a pure Rust implementation of the F1R3FLY blockchain node with:
 
 - Concurrent smart contract execution using Rholang and RSpace
 - Proof-of-stake consensus and finalization through the `casper` crate
@@ -50,9 +50,9 @@ Security note: the upstream README states that the codebase has not completed a 
 
 ---
 
-## 2. Benchmark baseline: the `staging` branch
+## 2. Benchmark baseline: the `dev` branch
 
-The `staging` branch is the benchmark baseline. All in-flight development work targeting `staging` is merged before handoff, so the branch represents a single consolidated baseline rather than a set of optional feature candidates — no per-change selection or separate benchmark branch is required. What matters for reproducibility is recording exactly what was benchmarked: capture the exact commit hash of `staging` and the Docker image digest for every run (see section 5.9), and record the consolidated feature set in `docs/benchmark/BRANCH_CONTENTS.md` (see section 7).
+The `dev` branch is the benchmark baseline. All in-flight development work targeting `dev` is merged before handoff, so the branch represents a single consolidated baseline rather than a set of optional feature candidates — no per-change selection or separate benchmark branch is required. What matters for reproducibility is recording exactly what was benchmarked: capture the exact commit hash of `dev` and the Docker image digest for every run (see section 5.9), and record the consolidated feature set in `docs/benchmark/BRANCH_CONTENTS.md` (see section 7).
 
 ---
 
@@ -349,7 +349,7 @@ These are placeholders until F1R3FLY and the partner team agree on targets.
 
 ## 7. Recommended repository deliverables
 
-For the benchmark effort, add only Markdown artifacts to `staging` at first:
+For the benchmark effort, add only Markdown artifacts to `dev` at first:
 
 ```text
 docs/benchmark/README.md
@@ -390,7 +390,7 @@ Suggested split:
 
 Reviewed public repository material on 2026-07-06:
 
-- `https://github.com/F1R3FLY-io/f1r3node-rust/tree/staging`
+- `https://github.com/F1R3FLY-io/f1r3node-rust/tree/dev`
 - `https://github.com/F1R3FLY-io/system-integration`
 - `https://raw.githubusercontent.com/F1R3FLY-io/system-integration/main/integration-tests/README.md`
-- `https://raw.githubusercontent.com/F1R3FLY-io/f1r3node-rust/staging/docs/vps-cloud-testing.md`
+- `https://raw.githubusercontent.com/F1R3FLY-io/f1r3node-rust/dev/docs/vps-cloud-testing.md`


### PR DESCRIPTION
## What this fixes

The 60-hour weekend soak and the daily soaks had never produced a usable result, for three stacked reasons:

1. **Before PR #138** every scheduled run was a wall-clock gate no-op that reported success. The soak never executed.
2. **After #138** every real attempt died ~41s into `test_load.py` on a missing `validator4` TLS cert — `Failed to read the X.509 certificate: Is a directory (os error 21)`. Docker turns an absent bind-mount host path into a directory. That fix lives in `F1R3FLY-io/system-integration` PR #65.
3. **GitHub Pages was never enabled**, so even a passing soak could not publish its dashboard, and the stakeholder alert chain was broken end-to-end.

The OCI runners were never the problem — they launch, build, and run within two minutes on every attempt.

## Changes

**Soak operability**
- `soak-dashboard-pages.yml` (new): publishes the dashboard on push to `master` with an empty-state history, so the page exists without waiting for a weekend soak.
- Schedule-gate no-ops now emit a `::notice::` and a step summary, so a green check on a skipped cron is not mistaken for a soak result. The gate no-ops ~9× a week by design.
- `notify_failure` (new job): emails the ONS topic when a real soak fails **or is cancelled**. Runs GitHub-hosted with user-principal auth, so it still fires when the OCI runner never launched — a case the in-soak instance-principal step structurally cannot reach. Declares `permissions: {}` (no checkout, no GitHub API).

**Protecting published history** — Pages is the only durable store for the soak series, since artifacts expire at 14 days.
- Both the bootstrap deploy and `perf_report` now treat only HTTP 404 as "nothing published". Any other outcome — 5xx, timeout, connection failure — aborts instead of republishing an empty dashboard over real history. Previously a transient failure exited 0 and reset the series to the current run alone.
- Fetches are cache-busted (`?cb=<run_id>-<attempt>` plus `Cache-Control: no-cache`). Pages is CDN-backed, so a `200` could otherwise serve a copy older than the last publish and silently roll it back.
- Every fetched JSON artifact is validated before republishing — a `200` carrying a proxy error page is not data.

**Docs** (separately scoped commits, revertable independently)
- `staging` → `dev` across `CONTRIBUTING.md`, `SECURITY.md`, and the neutral-cloud benchmark guide. `staging` holds zero commits not already in `dev` and sits 158 behind.
- Documented the hotfix path — branch from `master`, PR to `master`, then merge `master` back into `dev` — which three merged PRs already follow but nothing described.
- Corrected `CLAUDE.md`'s branch strategy, which named a `main` branch that does not exist.

## Configuration applied out-of-band

Not visible in this diff, but required for any of it to work: GitHub Pages enabled (`build_type: workflow`); the `SOAK_ONS_TOPIC_OCID` repo variable set (it was unset, so every publish silently exited 0); and `use ons-topics` granted to the `ci-runner-ephemeral` dynamic group and `ci-runner-launchers` group — no IAM policy previously permitted ONS publish at all.

## Verification

The data-preservation logic was exercised against a local fixture server rather than reasoned about: a healthy `200` preserves and appends history, `404` bootstraps an empty series, and `503`, connection failure, and a `200` carrying HTML all abort without publishing. The pre-fix behaviour was reproduced first to confirm the bug was real — the old code exits **0** under HTTP 503 and publishes only the current week.

## Review

Two review passes are addressed in the comments below. A multi-agent review found the CDN staleness; @spreston8 found that the first fix was applied to the bootstrap path while the weekly production path — the one that actually appends history — kept the original hazard. Neither review caught the other's finding. Dismissed findings are documented with evidence so the calls can be challenged.

## Known remaining work

`SYSTEM_INTEGRATION_REF` is still pinned at `a50eeb19`, which predates the `validator4` certs. Until system-integration PR #65 merges and that pin is bumped, the soak still fails — but it now emails on failure instead of reporting a silent green.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787767347&installation_model_id=426883&pr_number=151&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F151&signature=6e9bd7e32faa2f60701478a27c7248187911f35ea750b0a3414f60ff4d4732ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
