### PR TITLE
docs: use dev in place of deprecated staging branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ that conflicts defers to it.
 
 ## Branching and Commits
 
-- Branch from `staging` and open pull requests against `staging`. Maintainers promote
-  `staging` → `dev` → `master`.
+- Branch from `dev` and open pull requests against `dev`. Maintainers promote
+  `dev` → `master`.
 - Branch prefixes: `feature/`, `fix/`, `docs/`, `perf/`, `chore/`.
 - Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`,
   `perf:`, `refactor:`, `test:`, `chore:`.
@@ -76,7 +76,7 @@ New or occasional contributors should open pull requests from personal forks. Ke
 
 Known recurring contributors may be invited to work from branches in the upstream `F1R3FLY-io/f1r3node-rust` repository. Maintainers grant upstream access based on project need, contributor identity, prior review history, and expected scope of work.
 
-Upstream access does not bypass review. Protected branches such as `master`, `dev`, and `staging` still require pull requests and required checks before merge.
+Upstream access does not bypass review. Protected branches such as `master` and `dev` still require pull requests and required checks before merge.
 
 ## CI Approval for Fork Pull Requests
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,4 +31,4 @@ requiring physical access to or a compromised host.
 ## Supported Versions
 
 F1R3FLY is under active development with no released or mainnet versions yet. Report against
-the latest `staging` / `dev`.
+the latest `dev`.


### PR DESCRIPTION
- CONTRIBUTING.md: branch from and target `dev`; promotion flow is now `dev` -> `master`; drop `staging` from the protected-branch list.
- SECURITY.md: report against the latest `dev`.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787770216&installation_model_id=426883&pr_number=152&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F152&signature=f4f8d4cfce2156c323c658209314392b0c2fb814c0dac3cf8e12d72991311d5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->