### PR TITLE
Fix CI Runners, canceling queues, approval, and better parallelism

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -28,6 +28,17 @@ NC='\033[0m'
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# git exports GIT_INDEX_FILE=<repo>/.git/index.lock into this hook's
+# environment. cargo shells out to git for its own repositories (the RustSec
+# advisory database fetched by `cargo deny`, git dependencies resolved by
+# `cargo fmt`/`cargo clippy`), and those child git processes inherit the
+# variable — writing their index entries into this repo's pending lock index.
+# git then builds the commit tree from the poisoned lock and aborts with
+# "invalid object <sha> for '<path>' / Error building trees", naming a path
+# that belongs to the other repository. Drop the inherited git environment
+# before running any cargo command.
+unset GIT_INDEX_FILE GIT_DIR GIT_WORK_TREE
+
 SKIP_FMT="${SKIP_FMT:-0}"
 SKIP_CLIPPY="${SKIP_CLIPPY:-0}"
 SKIP_DENY="${SKIP_DENY:-0}"

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -181,7 +181,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.gated && 'ephemeral-launch' || 'ephemeral-launch-internal' }}
     permissions: {}
-    timeout-minutes: 5
+    # No timeout-minutes. This job's entire purpose is to wait, and the wait is
+    # human-paced: GitHub lets a pending environment approval sit for up to 30
+    # days. A tight timeout here would cancel the whole pipeline whenever a
+    # maintainer did not click Approve promptly — a worse failure than the lane
+    # blockage this split was introduced to fix, and one that would only surface
+    # the first time someone stepped away. The single step below is an echo, so
+    # there is no runaway-execution risk to bound; do not add one.
     steps:
       - name: Approval recorded
         shell: bash -e {0}

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -67,8 +67,22 @@ env:
 
 jobs:
   # Build Docker image natively on each arch using Oracle Cloud self-hosted runners.
+  #
+  # Gated on await_approval so that NOTHING in this pipeline runs for an
+  # unapproved fork PR. This job compiles fork-authored code on the permanent
+  # self-hosted runners, and the smoke_* jobs that depend on it burn
+  # GitHub-hosted minutes; without the gate an untrusted contributor could spend
+  # both simply by pushing, which is the abuse the ephemeral-launch approval
+  # exists to prevent. Approval — not the concurrency group — is what holds
+  # untrusted work back, so this must stay even if the grouping changes again.
+  #
+  # Internal runs are unaffected in substance: ephemeral-launch-internal has no
+  # protection rules, so the gate resolves in seconds. The build still overlaps
+  # the ~1-minute runner launch, since build and launch gate on the same node
+  # rather than on each other.
   build_docker_image:
     name: Build Docker Image (${{ matrix.arch }})
+    needs: await_approval
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -141,6 +141,38 @@ jobs:
           name: artifacts-docker-${{ matrix.arch }}
           path: /tmp/rust-node-docker.tar.gz
 
+  # Approval gate, deliberately separated from the launch job below.
+  #
+  # This job exists solely to hold the environment's required-reviewer wait. It
+  # runs no steps, touches no secrets, and carries NO concurrency group — so a
+  # fork run parked here awaiting a maintainer costs nothing but a queue slot.
+  #
+  # Why the split: a job sitting in `waiting` holds any concurrency group it
+  # names, for as long as the approval takes (GitHub expires pending approvals
+  # after 30 days). When the OCI serialization group lived on the same job as
+  # the environment, one unapproved fork PR blocked every other heavy run
+  # indefinitely — observed 2026-07-29, where a run waiting since 04:21 held the
+  # lane for twelve hours. Keeping the wait outside the serialized section
+  # bounds the lock to actual VM creation.
+  #
+  # gated=true (fork path) uses ephemeral-launch, whose required_reviewers rule
+  # is what a maintainer clears after reviewing the fork diff. gated=false
+  # (internal path) uses ephemeral-launch-internal, which has NO protection
+  # rules, so internal events pass straight through unattended. Both branches
+  # must name a real environment: an empty-string environment name fails
+  # workflow startup (the value is validated when the run graph is built), so
+  # the ungated path cannot fall back to ''.
+  await_approval:
+    name: Await Launch Approval
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.gated && 'ephemeral-launch' || 'ephemeral-launch-internal' }}
+    permissions: {}
+    timeout-minutes: 5
+    steps:
+      - name: Approval recorded
+        shell: bash -e {0}
+        run: echo "Ephemeral launch approved for this run; proceeding to OCI launch."
+
   # Launch ephemeral OCI VMs that will pick up the integration-tests matrix
   # jobs. Runs in parallel with build_docker_image so the ~1-minute launch
   # overhead overlaps with the ~7-minute Docker build. Each VM boots from a
@@ -150,17 +182,33 @@ jobs:
   #
   # This is the only job that handles secrets. It checks out ONLY the trusted
   # system-integration repo and runs only its scripts — never the code-under-test.
+  #
+  # `needs: await_approval` is the gate: this job cannot start until the
+  # environment's reviewers have cleared the run, exactly as before. The
+  # difference is that the waiting happens in a job that holds no lock.
+  # SECURITY: do not remove that `needs:` — it is the only thing sequencing the
+  # OCI credentials behind maintainer approval now that the environment is
+  # declared one job upstream.
   launch_ephemeral_runners:
     name: Launch Ephemeral Runners
+    needs: await_approval
     runs-on: ubuntu-latest
-    # gated=true (fork path) routes through the ephemeral-launch environment so
-    # the required-reviewer approval releases OCI_* + RELEASE_PAT to the job.
-    # gated=false (internal path) uses ephemeral-launch-internal, an environment
-    # with NO protection rules, so internal events get secrets and run unattended.
-    # Both branches must name a real environment: an empty-string environment
-    # name fails workflow startup (the value is validated when the run graph is
-    # built), so the ungated path cannot fall back to ''.
-    environment: ${{ inputs.gated && 'ephemeral-launch' || 'ephemeral-launch-internal' }}
+    # Serializes real OCI VM creation across every heavy run in the repository:
+    # the tenancy's daily instance-creation quota is shared, so two pipelines
+    # launching at once both risk LimitExceeded. cancel-in-progress: false makes
+    # a second launcher queue rather than cancel the in-flight one. The lock is
+    # now held only for the ~1 minute of actual launching, not across an
+    # unbounded approval wait.
+    #
+    # Residual risk, accepted: GitHub keeps only ONE pending entry per group, so
+    # if three launchers contend within that ~1-minute window, the middle one is
+    # cancelled. Recovery is a manual re-run of the affected job — there is no
+    # silent data loss, but the PR shows a cancelled Heavy Pipeline rather than
+    # a failure, so check for cancelled runs before assuming a pipeline was
+    # never triggered.
+    concurrency:
+      group: oci-ephemeral-launch
+      cancel-in-progress: false
     # Runner registration uses RELEASE_PAT (admin scope); the default GITHUB_TOKEN
     # mints nothing here, so this job needs only read access for the checkout.
     permissions:

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -44,9 +44,23 @@ permissions:
 # _integration-pipeline.yml's launch job, held only for the ~1 minute of actual
 # launching rather than across an unbounded approval wait. See that file for the
 # residual-contention note and its manual-re-run recovery.
+#
+# cancel-in-progress: true, matching ci.yml's PR path. Without it, a re-push
+# leaves the previous run parked in await_approval, and a maintainer clicking
+# Approve then spends real OCI VMs validating a commit that is no longer the PR
+# head — while the current head still needs its own approval and run. Approving
+# stale work is worse than losing it, because the resulting green checks are
+# commit-scoped and cannot satisfy the new head anyway.
+#
+# BEHAVIOUR TO EXPECT: superseding a run that is already waiting also withdraws
+# its pending environment approval request. A maintainer part-way through
+# reviewing a fork diff will see the approval prompt disappear when the
+# contributor pushes again. That is correct — the diff they were approving is no
+# longer what would run — but it is surprising the first time. The replacement
+# run raises a fresh approval request for the new head.
 concurrency:
   group: ci-fork-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Run the shared heavy pipeline against the FORK's head commit, gated behind

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -27,19 +27,25 @@ permissions:
   contents: read
   actions: read
 
-# One group across all FORK PRs: fork heavy runs (real OCI VMs) never run in
-# parallel — a second fork run queues rather than cancelling the in-flight one.
+# Per-PR groups, never a shared one. GitHub keeps only ONE pending run per
+# concurrency group, so any group spanning multiple PRs silently cancels queued
+# runs: each new arrival evicts the previously pending one, and the evicted PR
+# shows no failed check — its heavy pipeline simply never happened.
 #
-# Internal PRs must not share that group. pull_request_target also fires for
-# same-repo PRs (their jobs skip via the `fork == true` guards below), but the
-# run itself still joins whatever group is named here. GitHub keeps only ONE
-# pending run per concurrency group, so each new arrival cancels the previously
-# pending one: a burst of internal pushes evicts a fork run that is queued
-# behind an in-flight or awaiting-approval fork run, and that fork PR silently
-# loses its heavy pipeline with no failed check to show for it. Internal PRs
-# therefore get their own per-PR groups, where their skipped jobs are harmless.
+# This bit repeatedly on 2026-07-29. A fork run parked awaiting environment
+# approval since 04:21 held the single shared lane all day; internal PRs (which
+# also fire pull_request_target and then skip via the `fork == true` guards
+# below) kept joining that same lane and evicting whatever was queued. PR #143
+# lost its integration tests to an internal push at 14:02 with nothing on the
+# PR to show for it.
+#
+# Serializing real OCI VM creation — the reason a shared group existed — is now
+# enforced where it belongs: a job-level `oci-ephemeral-launch` group on
+# _integration-pipeline.yml's launch job, held only for the ~1 minute of actual
+# launching rather than across an unbounded approval wait. See that file for the
+# residual-contention note and its manual-re-run recovery.
 concurrency:
-  group: ${{ github.event.pull_request.head.repo.fork == true && 'ci-fork-pr' || format('ci-fork-pr-internal-{0}', github.event.pull_request.number) }}
+  group: ci-fork-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ci-fork-pr.yml
+++ b/.github/workflows/ci-fork-pr.yml
@@ -27,10 +27,19 @@ permissions:
   contents: read
   actions: read
 
-# One group across ALL fork PRs: fork heavy runs (real OCI VMs) never run in
+# One group across all FORK PRs: fork heavy runs (real OCI VMs) never run in
 # parallel — a second fork run queues rather than cancelling the in-flight one.
+#
+# Internal PRs must not share that group. pull_request_target also fires for
+# same-repo PRs (their jobs skip via the `fork == true` guards below), but the
+# run itself still joins whatever group is named here. GitHub keeps only ONE
+# pending run per concurrency group, so each new arrival cancels the previously
+# pending one: a burst of internal pushes evicts a fork run that is queued
+# behind an in-flight or awaiting-approval fork run, and that fork PR silently
+# loses its heavy pipeline with no failed check to show for it. Internal PRs
+# therefore get their own per-PR groups, where their skipped jobs are harmless.
 concurrency:
-  group: ci-fork-pr
+  group: ${{ github.event.pull_request.head.repo.fork == true && 'ci-fork-pr' || format('ci-fork-pr-internal-{0}', github.event.pull_request.number) }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,26 @@ on:
 
 # Concurrency: PRs run in parallel (one group per ref) for fast feedback; pushes
 # (dev/master/staging/trying/tags) share a single group so merge and release runs
-# serialize rather than piling up independent 4-VM OCI matrices. Nothing is
-# cancelled mid-flight — a re-push queues behind its own in-flight run, so release
+# serialize rather than piling up independent 4-VM OCI matrices.
+#
+# Pushes never cancel: a re-push queues behind its own in-flight run, so release
 # jobs and long integration runs always reach completion.
+#
+# PRs DO cancel their own older runs, and must. GitHub keeps only one *pending*
+# run per group, so queueing instead of superseding means a third event evicts
+# the queued one — and an evicted run reports nothing, leaving every required
+# check on the current head permanently "Expected — waiting for status to be
+# reported". PR #158 hit exactly that on 2026-07-29: the run for head 1d3d79b1
+# was cancelled while queued behind a 14-hour predecessor, all 12 required
+# checks never reported, and the PR sat BLOCKED with no failure to point at.
+#
+# Superseding is also what you actually want per PR: once a newer head exists,
+# the older head's results cannot satisfy branch protection anyway, because
+# required checks are commit-scoped. Cancelling them deliberately frees the lane
+# for the head that matters instead of starving it.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || 'push' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## What this fixes

CI runs were being silently cancelled, and PRs were losing checks with nothing to
point at. On 2026-07-29 this happened twice, in two different workflows, from the
same underlying GitHub behaviour: **only one run may be *pending* per concurrency
group, so each new arrival cancels the previously pending one** — and a cancelled
run reports no status at all.

- PR #143's `CI (fork PRs)` run (`30457308520`) was cancelled with **zero jobs
  started**. Its integration tests simply never happened; the PR showed no failure.
- PR #158's `CI` run for head `1d3d79b1` was cancelled while queued. All **12
  required checks never reported**, so the PR sat `BLOCKED` showing
  *"Expected — waiting for status to be reported"* forever.

Four fixes here.

### 1. Every fork run shared one concurrency lane

`ci-fork-pr.yml` used a single `ci-fork-pr` group for all PRs. `pull_request_target`
also fires for same-repo PRs — their jobs skip via the `fork == true` guards, but the
*run* still joined the lane. Six internal pushes between 13:41 and 15:07 each evicted
whatever was queued, including #143.

Now every run gets `ci-fork-pr-<PR number>`.

### 2. Approval waits held the serialization lock

The OCI serialization group and the `ephemeral-launch` reviewer gate were on the same
job. A job sitting in `waiting` holds any concurrency group it names, and GitHub lets
approvals pend for up to 30 days. Run `30422042122` (PR #142) waited from 04:21 and
held the lane for twelve hours.

Split into a lock-free `await_approval` job that holds only the wait, and a
`launch_ephemeral_runners` job that holds `oci-ephemeral-launch` for the ~1 minute of
actual VM creation. `await_approval` carries **no** `timeout-minutes` — a bound on a
job whose purpose is waiting on a human would cancel the pipeline whenever a
maintainer didn't click Approve promptly.

### 3. The approval gate did not cover most of the pipeline

`build_docker_image` had no dependencies, so an **unapproved** fork PR already compiled
fork-authored code on the permanent self-hosted runners, and the three `smoke_*` jobs
spent GitHub-hosted minutes. The gate only ever covered OCI VM creation.

`build_docker_image` now depends on `await_approval`, so every job is transitively
behind the gate. An unapproved fork PR consumes nothing. Approval — not the
concurrency grouping — is what holds untrusted work back, which matters now that fork
runs no longer share a single lane.

### 4. PR runs queued instead of superseding

`ci.yml` used `cancel-in-progress: false` for everything. For **pushes** that is
correct and unchanged — a re-push queues behind its own in-flight run so release and
long integration runs always finish. For **PRs** it was backwards: queueing means a
third event evicts the queued run, and the current head ends up with required checks
that never report.

Now `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. The group key is
untouched; pushes still share `CI-push` and still queue.

Once a newer head exists, the older head's results cannot satisfy branch protection
anyway — required checks are commit-scoped. Cancelling them deliberately frees the
lane for the head that matters instead of starving it.

**Behaviour change:** pushing twice in quick succession now cancels the first run
mid-flight, including a heavy pipeline that may have already launched OCI VMs. Those
VMs self-terminate, so nothing leaks, but the launch is wasted. That trade is
deliberate — a wasted launch beats a permanently blocked PR.

## Secrets: read this before reviewing the diff

`launch_ephemeral_runners` no longer declares `environment:`. From the diff alone this
looks like the job loses its credentials, or like gating regressed. Neither is the case:

- `OCI_*` and `RELEASE_PAT` existed in **two** places — repo-level and scoped to
  `ephemeral-launch` — with confirmed identical values.
- The environment-scoped copies have since been **deleted**. Repo-level is now the
  single source of truth, so partial rotation is impossible rather than merely
  detectable. Verified: `environments/ephemeral-launch/secrets` → `[]`.
- `ephemeral-launch` keeps its `required_reviewers` rule and is now purely a gate —
  the same shape `ephemeral-launch-internal` already had.
- Bad credentials still fail loudly: the launch job ends its setup with
  `oci iam region list`.

**Pre-existing, not introduced here:** repo-level secrets are readable by any job in
any workflow, so `needs: await_approval` sequences the launch behind approval but does
not *bind* secret access. That was already true — `ci-runner-reaper.yml` and
`merge-recovery-soak.yml` consume the same secrets repo-level today. Narrowing it is
worth doing as a separate change.

## Behaviour change for fork contributors

Fork PRs now show the Heavy Pipeline sitting in `waiting` until a maintainer approves,
instead of watching the Docker build start and only integration tests pend. Cheap
`pull_request` checks — lint, per-crate tests, proptest/Loom/Rocq suites — still run
unapproved via `ci.yml`, so forks keep useful feedback.

## Also included

`.githooks/pre-commit` unsets `GIT_INDEX_FILE`, `GIT_DIR`, `GIT_WORK_TREE` before
invoking cargo. git exports `GIT_INDEX_FILE=<repo>/.git/index.lock` into the hook, and
`cargo deny`'s fetch of the RustSec advisory database inherited it, writing that repo's
index entries into this repo's pending lock. Commits then died with
`invalid object <sha> for '.github/actions/install-rustsec-admin/action.yml'` — a path
from another repository entirely. Six consecutive commits failed before the fix; the
first commit after it succeeded with all gates running.

It rides along here because commits on branches without it are impossible.

## Known residual risk

Three launchers contending inside the ~1-minute `oci-ephemeral-launch` window can still
evict the middle one. Recovery is a manual re-run. The symptom is a **cancelled** Heavy
Pipeline rather than a failed one, so check for cancelled runs before assuming a
pipeline was never triggered. Documented inline at the concurrency block.

More generally: a cancelled run renders as a neutral grey icon, not a failure. Both of
today's incidents presented as "waiting" and were actually "cancelled, will never
report." Worth confirming branch protection does not treat a cancelled required check
as success.

## Merge plan

1. **This PR → `dev`**, immediately.
2. After **#158** passes CI, **`master` → `dev`**.
3. Then **`dev` → `master`**.

Step 3 is what actually activates the fork-path fixes: `pull_request_target` executes
the workflow from the **base** branch, so fork PRs targeting `master` keep the old
behaviour until it lands there. Fork PRs targeting `dev` pick it up at step 1.

## Operational follow-ups (not fixed by merging)

1. Run `30422042122` (PR #142) is still `waiting` — approve or cancel it.
2. PR #143's cancelled run needs a manual re-run afterward.


<!-- codesmith:footer -->
---
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
