### PR TITLE
fix(ci): restore the fork PR lane broken by actions/checkout's new guard

### DIFF
--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -124,6 +124,61 @@ EOF
 done
 ok "both pipeline callers pass secrets down"
 
+# 5. Fork-checkout hygiene. Every checkout of the code under test must set
+#    BOTH `persist-credentials: false` and `allow-unsafe-pr-checkout: true`.
+#
+#    The second is what makes the fork lane work at all: actions/checkout
+#    refuses fork code under pull_request_target without it, and because the
+#    action is pinned to the moving `@v4` tag, that guard arrived upstream and
+#    silently broke every fork PR at Clone Repository with no change in this
+#    repo. Asserting it means a future removal fails CI loudly instead of
+#    breaking outside contributors invisibly again.
+#
+#    The first is the control that opt-in leans on. Once we tell checkout to
+#    fetch untrusted code in a base-repo context, `persist-credentials: false`
+#    is what keeps a writable token out of a workspace that fork code will be
+#    built in. It was previously convention; opting past a security guard is
+#    exactly when convention stops being good enough.
+fork_bad_persist=""
+fork_bad_optin=""
+while read -r line_no flags; do
+    case "$flags" in
+        *P*) ;;
+        *) fork_bad_persist="$fork_bad_persist $PIPELINE:$line_no" ;;
+    esac
+    case "$flags" in
+        *A*) ;;
+        *) fork_bad_optin="$fork_bad_optin $PIPELINE:$line_no" ;;
+    esac
+done <<EOF
+$(awk '
+    function flush() {
+        if (is_fork) printf "%d %s%s\n", start, (has_persist ? "P" : "-"), (has_optin ? "A" : "-")
+        is_fork = 0; has_persist = 0; has_optin = 0
+    }
+    # Anchored to the start of the line so a YAML KEY is required, not just a
+    # mention of one. Unanchored, the comment above these settings — which
+    # names `persist-credentials: false` while explaining why it matters —
+    # satisfied the match by itself, and that half of the check could never
+    # fail. Caught by mutation testing; a guard defeated by its own
+    # documentation is worse than no guard, because it reports ok.
+    /^      - (name|uses):/ { flush(); start = NR }
+    /inputs\.checkout_repository/                       { is_fork = 1 }
+    /^[[:space:]]*persist-credentials:[[:space:]]*false/     { has_persist = 1 }
+    /^[[:space:]]*allow-unsafe-pr-checkout:[[:space:]]*true/ { has_optin = 1 }
+    END { flush() }
+' "$PIPELINE")
+EOF
+if [ -n "$fork_bad_persist" ]; then
+    err "checkout of fork-authored code without 'persist-credentials: false' at:${fork_bad_persist}; a writable token must never reach a workspace holding untrusted code"
+fi
+if [ -n "$fork_bad_optin" ]; then
+    err "checkout of fork-authored code without 'allow-unsafe-pr-checkout: true' at:${fork_bad_optin}; actions/checkout refuses fork code under pull_request_target without it, which breaks every fork PR at clone"
+fi
+if [ -z "$fork_bad_persist$fork_bad_optin" ]; then
+    ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
+fi
+
 if [ "$fail" -ne 0 ]; then
     printf '::error::%s\n' "workflow security invariants violated; see errors above"
     exit 1

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -104,6 +104,21 @@ jobs:
           repository: ${{ inputs.checkout_repository != '' && inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # Fork PRs reach this pipeline through ci-fork-pr.yml's
+          # pull_request_target, and recent actions/checkout releases refuse to
+          # check out fork code from that trigger without this opt-in. Nothing
+          # changed here — the pin is the moving `@v4` tag, so the fork lane
+          # broke upstream and every fork PR has died at Clone Repository since.
+          #
+          # The opt-in is sound only because its premises are machine-enforced,
+          # not merely conventional. check-workflow-invariants.sh asserts that
+          # this job gates on await_approval (fork code is fetched only after a
+          # maintainer reviews the diff), that credentials are confined to
+          # launch_ephemeral_runners (which never checks out the code under
+          # test), and that `persist-credentials: false` is set right here. The
+          # workflow file itself executes from the base branch, so fork code
+          # cannot alter what runs. Do not add secrets to this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -422,6 +437,21 @@ jobs:
           repository: ${{ inputs.checkout_repository != '' && inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # Fork PRs reach this pipeline through ci-fork-pr.yml's
+          # pull_request_target, and recent actions/checkout releases refuse to
+          # check out fork code from that trigger without this opt-in. Nothing
+          # changed here — the pin is the moving `@v4` tag, so the fork lane
+          # broke upstream and every fork PR has died at Clone Repository since.
+          #
+          # The opt-in is sound only because its premises are machine-enforced,
+          # not merely conventional. check-workflow-invariants.sh asserts that
+          # this job gates on await_approval (fork code is fetched only after a
+          # maintainer reviews the diff), that credentials are confined to
+          # launch_ephemeral_runners (which never checks out the code under
+          # test), and that `persist-credentials: false` is set right here. The
+          # workflow file itself executes from the base branch, so fork code
+          # cannot alter what runs. Do not add secrets to this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Clone system-integration
         uses: actions/checkout@v4
@@ -519,6 +549,21 @@ jobs:
           repository: ${{ inputs.checkout_repository != '' && inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # Fork PRs reach this pipeline through ci-fork-pr.yml's
+          # pull_request_target, and recent actions/checkout releases refuse to
+          # check out fork code from that trigger without this opt-in. Nothing
+          # changed here — the pin is the moving `@v4` tag, so the fork lane
+          # broke upstream and every fork PR has died at Clone Repository since.
+          #
+          # The opt-in is sound only because its premises are machine-enforced,
+          # not merely conventional. check-workflow-invariants.sh asserts that
+          # this job gates on await_approval (fork code is fetched only after a
+          # maintainer reviews the diff), that credentials are confined to
+          # launch_ephemeral_runners (which never checks out the code under
+          # test), and that `persist-credentials: false` is set right here. The
+          # workflow file itself executes from the base branch, so fork code
+          # cannot alter what runs. Do not add secrets to this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Load Docker Image
         uses: actions/download-artifact@v4
@@ -628,6 +673,21 @@ jobs:
           repository: ${{ inputs.checkout_repository != '' && inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # Fork PRs reach this pipeline through ci-fork-pr.yml's
+          # pull_request_target, and recent actions/checkout releases refuse to
+          # check out fork code from that trigger without this opt-in. Nothing
+          # changed here — the pin is the moving `@v4` tag, so the fork lane
+          # broke upstream and every fork PR has died at Clone Repository since.
+          #
+          # The opt-in is sound only because its premises are machine-enforced,
+          # not merely conventional. check-workflow-invariants.sh asserts that
+          # this job gates on await_approval (fork code is fetched only after a
+          # maintainer reviews the diff), that credentials are confined to
+          # launch_ephemeral_runners (which never checks out the code under
+          # test), and that `persist-credentials: false` is set right here. The
+          # workflow file itself executes from the base branch, so fork code
+          # cannot alter what runs. Do not add secrets to this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Load Docker Image
         uses: actions/download-artifact@v4
@@ -728,6 +788,21 @@ jobs:
           repository: ${{ inputs.checkout_repository != '' && inputs.checkout_repository || github.repository }}
           ref: ${{ inputs.checkout_ref != '' && inputs.checkout_ref || github.sha }}
           persist-credentials: false
+          # Fork PRs reach this pipeline through ci-fork-pr.yml's
+          # pull_request_target, and recent actions/checkout releases refuse to
+          # check out fork code from that trigger without this opt-in. Nothing
+          # changed here — the pin is the moving `@v4` tag, so the fork lane
+          # broke upstream and every fork PR has died at Clone Repository since.
+          #
+          # The opt-in is sound only because its premises are machine-enforced,
+          # not merely conventional. check-workflow-invariants.sh asserts that
+          # this job gates on await_approval (fork code is fetched only after a
+          # maintainer reviews the diff), that credentials are confined to
+          # launch_ephemeral_runners (which never checks out the code under
+          # test), and that `persist-credentials: false` is set right here. The
+          # workflow file itself executes from the base branch, so fork code
+          # cannot alter what runs. Do not add secrets to this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Install just
         shell: bash -ex {0}


### PR DESCRIPTION
## Problem

Reported by @spreston8 on [#142](https://github.com/F1R3FLY-io/f1r3node-rust/pull/142#issuecomment-5124651243). Every fork PR dies within seconds at `Clone Repository`:

> `##[error]Refusing to check out fork pull request code from a 'pull_request_target' workflow. … To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.`

Recent `actions/checkout` releases added this guard, and the pipeline pins the **moving `@v4` tag** — so the fork lane broke *upstream*, with no change in this repo and no signal that anything had happened. This is why #142's integration tests never ran even after #161 fixed the concurrency eviction, and why the reopen-from-a-branch workaround has become the de facto path for outside contributors.

I verified every load-bearing claim in the report before acting:

| Claim | Verified |
|---|---|
| Pipeline pins the moving `@v4` tag | Yes — **all seven** checkout sites |
| Five checkouts of the code under test via `inputs.checkout_repository` | Yes — lines 101, 419, 516, 625, 725 |
| Those five set `persist-credentials: false` | Yes, all five |
| The system-integration checkouts are separate | Yes — they pin a trusted ref and need no opt-in |

## Changes

**`allow-unsafe-pr-checkout: true` on the five code-under-test checkouts.** The two system-integration checkouts fetch a pinned trusted ref and are deliberately untouched.

**A new invariant (#5) requiring both `persist-credentials: false` and `allow-unsafe-pr-checkout: true`** on every checkout of the code under test.

## Why the opt-in is safe here

Its premises are **machine-enforced, not conventional** — `check-workflow-invariants.sh` already asserts three of the four:

- the job **gates on `await_approval`**, so fork code is fetched only after a maintainer has reviewed the diff;
- **credentials are confined to `launch_ephemeral_runners`**, which checks out only the pinned system-integration ref and never the code under test;
- every credential-reading job **names an environment**;
- and the workflow file itself **executes from the base branch**, so fork code cannot alter what runs.

The fourth premise — `persist-credentials: false` — was convention only. That is the control keeping a writable token out of a workspace where untrusted code gets built, and opting past a security guard is precisely when convention stops being sufficient. Hence invariant 5. It also asserts the opt-in itself, so a future removal fails CI loudly rather than silently breaking outside contributors again — which is exactly how this went unnoticed for days.

## Mutation testing caught a defect in the new guard before it landed

The `persist-credentials` half was **unfalsifiable**. The explanatory comment beside these settings contains the literal string `persist-credentials: false`, and the unanchored regex matched the *comment* rather than the setting — so that half reported `ok` no matter what. Both patterns are now anchored to the start of the line, requiring a YAML key rather than a mention of one.

A guard defeated by its own documentation is worse than no guard: it manufactures confidence.

**Verified:** baseline passes; removing the opt-in from one site fails naming that site; removing `persist-credentials` from one site fails naming that site; YAML parses.

## Open question for reviewers

**Should `actions/checkout` be pinned by SHA across all seven sites?** The moving `@v4` tag is the *root cause* — an upstream behaviour change silently broke CI with no local edit, and the next one will do the same. Pinning would fix the class rather than this instance, the way `OCI_CLI_INSTALLER_URL` is already pinned with a checksum in this repo. Left out here because it touches two sites this bug does not require; happy to add it in this PR or a follow-up.

## Credit

Diagnosis and the proposed fix are @spreston8's; this PR implements it with the invariant added. They offered to submit it separately — taken up here to keep it moving, not to duplicate their work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788045385&installation_model_id=426883&pr_number=171&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F171&signature=de9b82ef69923bb56c3bea2348e3c564cb76509efe165a698877594c5e03b11e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
