### PR TITLE
fix(ci): repair the reaper syntax error and gate the whole class

### DIFF
--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -241,6 +241,77 @@ if [ -z "$fork_bad_persist$fork_bad_optin" ]; then
     ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
 fi
 
+# 8. Every `run:` block in every workflow must be parseable by its shell.
+#
+# A workflow is not compiled, so a `run:` block with a syntax error is a
+# runtime failure on a schedule nobody is watching. 4330a24f shipped exactly
+# that: two apostrophes inside a single-quoted jq program in
+# ci-runner-reaper.yml closed the quote, the step died with "syntax error near
+# unexpected token |" on every 30-minute run, and the reaper — the guard
+# against the June 2026 leak of ~209 instances, ~$6k — silently terminated
+# nothing. It was found by reading a run log, not by CI.
+#
+# `bash -n` parses without executing, so this is safe and fast. It catches the
+# whole quoting/heredoc/unbalanced-block class. It does NOT catch semantic
+# faults (unset variables, wrong OCIDs) — for that this would need actionlint.
+#
+# Only default-shell and bash blocks are checked. A `shell: python` or
+# `shell: pwsh` block is skipped rather than mis-parsed as bash; that skip is
+# reported so a silent gap cannot masquerade as coverage.
+bad_syntax=""
+skipped_shells=""
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+while IFS= read -r wf; do
+    # Extract every run: block with its job/step identity. Ruby is already a
+    # hard dependency of this repo's tooling and ships with a YAML parser, so
+    # the blocks come from a real parse rather than an indentation heuristic
+    # that block scalars would defeat.
+    ruby -ryaml -e '
+      wf = ARGV[0]; out = ARGV[1]
+      doc = YAML.load_file(wf) rescue nil
+      exit 0 unless doc.is_a?(Hash) && doc["jobs"].is_a?(Hash)
+      doc["jobs"].each do |job_id, job|
+        next unless job.is_a?(Hash) && job["steps"].is_a?(Array)
+        job["steps"].each_with_index do |step, i|
+          next unless step.is_a?(Hash) && step["run"].is_a?(String)
+          shell = (step["shell"] || job.dig("defaults", "run", "shell") ||
+                   doc.dig("defaults", "run", "shell") || "bash").to_s
+          label = "#{job_id} / #{step["name"] || "step #{i + 1}"}"
+          # bash -e {0}, bash -euo pipefail {0} etc. are all bash.
+          kind = shell.split(/\s/).first
+          File.write(File.join(out, "block-#{job_id}-#{i}.sh"), step["run"])
+          File.open(File.join(out, "index.txt"), "a") { |f|
+            f.puts("block-#{job_id}-#{i}.sh\t#{kind}\t#{label}")
+          }
+        end
+      end' "$wf" "$scratch" 2>/dev/null || continue
+
+    [ -f "$scratch/index.txt" ] || continue
+    while IFS=$'\t' read -r blockfile kind label; do
+        case "$kind" in
+            bash | sh | "") ;;
+            *) skipped_shells="${skipped_shells}
+  ${wf}: ${label} (shell: ${kind})"; continue ;;
+        esac
+        if ! errout="$(bash -n "$scratch/$blockfile" 2>&1)"; then
+            bad_syntax="${bad_syntax}
+  ${wf}: ${label}
+    ${errout}"
+        fi
+    done < "$scratch/index.txt"
+    rm -f "$scratch"/index.txt "$scratch"/block-*.sh
+done < <(find .github/workflows -name '*.yml' -o -name '*.yaml' | sort)
+
+if [ -n "$bad_syntax" ]; then
+    err "workflow run: block(s) fail 'bash -n' and will die at runtime:${bad_syntax}"
+else
+    ok "every workflow run: block parses under bash -n"
+fi
+if [ -n "$skipped_shells" ]; then
+    printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
+fi
+
 if [ "$fail" -ne 0 ]; then
     printf '::error::%s\n' "workflow security invariants violated; see errors above"
     exit 1

--- a/.github/workflows/ci-runner-reaper.yml
+++ b/.github/workflows/ci-runner-reaper.yml
@@ -131,12 +131,23 @@ jobs:
                 # untagged soak runner never starts, and any untagged instance
                 # that does exist gets cleaned up. Do not harmonise them.
                 #
-                # isinfinite/isnan are load-bearing, not defensive noise: jq's
-                # `tonumber` accepts "Infinity", "inf" and overflowing literals
-                # like "1e309", each of which yields a value no `< $now` can
-                # ever be true for — a permanent exemption from one typo.
-                # Verified empirically; the equivalent hole was found in
-                # system-integration's reaper by its own review (PR #70).
+                # isinfinite/isnan are load-bearing, not defensive noise. The
+                # jq tonumber builtin accepts "Infinity", "inf" and overflowing
+                # literals like "1e309", each of which yields a value no
+                # "< $now" can ever be true for — a permanent exemption from one
+                # typo. Verified empirically; the equivalent hole was found in
+                # the system-integration reaper by its own review (PR #70).
+                #
+                # NOTE: this whole jq program is a single-quoted shell string.
+                # An apostrophe anywhere in it — including in these comments —
+                # closes that quote and turns the rest into shell code. Two
+                # possessive forms did exactly that in 4330a24f: the step died
+                # with "syntax error near unexpected token |" on every run and
+                # reaped nothing for hours, silently removing the guard against
+                # the June 2026 leak. Invariant 8 in
+                # check-workflow-invariants.sh now runs bash -n over every
+                # run: block, so this cannot merge again. Use no apostrophes
+                # below this line.
                 # The horizon cap catches the finite-but-absurd case the same
                 # way: the longest legitimate deadline is a 60h weekend plus a
                 # 2h grace, so anything past 7 days is not a soak.


### PR DESCRIPTION
The CI Runner Reaper has been dead in production since `4330a24f`. It is
currently failing on every scheduled run and reaping nothing.

## Impact right now

Live leaked instances the reaper listed and failed to terminate on its
04:00Z run, all 16-OCPU / 32 GB Ampere, all past the 2h age bound:

```
ci-eph-…-amd64-20260731-004847-06cb86   RUNNING   00:48:49Z
ci-eph-…-arm64-20260730-235344-54fc50   RUNNING   23:53:46Z
ci-eph-…-arm64-20260730-235344-5ae0d1   RUNNING   23:53:46Z
```

Nothing has been reaped since 22:37Z. This is the same guard that was
missing during the June 2026 leak (~209 zombies, ~$6k).

## Cause

The jq program is a single-quoted shell string. Two possessive apostrophes
inside its *comments* (`jq's`, `system-integration's`) closed that quote and
turned the remainder into shell code:

```
/home/runner/work/_temp/….sh: line 40: syntax error near unexpected token `|'
```

The step exited 2 before terminating anything. After repeated failures
GitHub also throttled the `*/30` schedule — it fired 10 times in the last
20 hours instead of ~40.

## Fix

Reworded the comments to avoid apostrophes, plus a warning that the block
is single-quoted. That warning is not the fix; it is the same kind of
comment that failed to prevent this the first time.

The fix is **invariant 8** in `check-workflow-invariants.sh`: extract every
`run:` block from every workflow via a real YAML parse and run `bash -n`
over it. Nothing in the required-check set looked at workflow files — Lint
is Rust-only — so this class was invisible to the gate by construction.
Invariant 8 runs inside Lint, which is required on both rulesets and pinned
to GitHub Actions, so it gates without a ruleset change.

Non-bash `run:` blocks (`shell: python`, `pwsh`) are skipped rather than
mis-parsed, and the skip is reported so a gap cannot pass as coverage.
`bash -n` catches syntax only; semantic faults would need actionlint.

## Verification

- **Mutation-verified:** reinjecting the apostrophe makes invariant 8 fail and
  name the file, job, step and line; removing it passes. The sweep found no
  other unparseable block in the repo.
- **Reproduces production:** extracting the `run:` block from `origin/dev` and
  running `bash -n` yields the identical error, same line and token, as the
  04:00Z run log. The same extraction on this branch passes.
- **Semantics unchanged** (`bash -n` cannot see inside jq, so the program was
  behavior-tested separately against synthetic instances):

  | instance | tag | expected | result |
  |---|---|---|---|
  | old, untagged | — | reap | reaped |
  | within age bound | — | spare | spared |
  | soak, live deadline | future epoch | spare | spared |
  | soak, expired | past epoch | reap | reaped |
  | soak, `1e309` | →Infinity | reap | reaped |
  | soak, `tomorrow` | unparseable | reap | reaped |
  | soak, past horizon | now+7d | reap | reaped |
  | wrong name prefix | — | spare | spared |
  | TERMINATED | — | spare | spared |

  Confirms the `isinfinite`/`isnan`/horizon guards still close the
  permanent-exemption hole, and that a bad tag never buys immunity.

Found by reading a run log, not by CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788066287&installation_model_id=426883&pr_number=173&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F173&signature=7bb55a4b3067b904079f6ec60a414f4c0f5ae4bbc0f81a285165da2a33b88936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->