### PR TITLE
fix(dashboard): seed grey badges so the README stops showing 'resourc…

### DIFF
--- a/.github/workflows/soak-dashboard-pages.yml
+++ b/.github/workflows/soak-dashboard-pages.yml
@@ -119,6 +119,37 @@ jobs:
               }
             done
           done
+          # Seed a grey "no data" badge for any series that has not published
+          # one, exactly as the reports below are seeded.
+          #
+          # README.md renders four shields.io endpoint badges from these files
+          # and documents "any badge grey | ... no data published for that
+          # series yet". That state did not exist: shields renders a missing
+          # endpoint as "resource not found", so the four badges at the top of
+          # the README have read as errors since badge generation was added in
+          # db530ec5 (2026-07-29) — no soak has completed since, so no
+          # badge-*.json was ever produced, and the publisher's copy is
+          # existence-guarded so it skipped silently. The documented graceful
+          # degradation was never implemented.
+          #
+          # These are placeholders, not fallbacks: the soak publisher overwrites
+          # them the moment a run produces real ones, and the carry-forward loop
+          # above then preserves the real values. Message and colour are copied
+          # from the aggregator's own no-data branches so the badge does not
+          # change shape when data arrives.
+          for spec in badge-soak.json:'soak · master' \
+                      badge-soak-daily.json:'soak · dev' \
+                      badge-stability.json:stability \
+                      badge-stability-daily.json:stability \
+                      badge-perf.json:perf \
+                      badge-perf-daily.json:perf; do
+            f="${spec%%:*}"
+            [ -e "site/data/${f}" ] && continue
+            jq -cn --arg label "${spec#*:}" \
+              '{schemaVersion: 1, label: $label, message: "no data", color: "lightgrey"}' \
+              > "site/data/${f}"
+            echo "seeded placeholder ${f}"
+          done
           test -s site/data/latest-report.md \
             || echo 'No soak report yet — the first successful weekend soak publishes one.' \
               > site/data/latest-report.md


### PR DESCRIPTION
…e not found'

The four shields.io badges at the top of README.md have rendered as errors since 2026-07-29. They are endpoint badges reading badge-soak.json, badge-soak-daily.json, badge-stability.json and badge-perf.json from the published dashboard, and none of those files has ever existed.

Badge generation was added to aggregate-perf-report.sh in db530ec5 that day. No soak has completed since, so the aggregator has never produced them, and the publisher copies each badge under [ -e ] -- deliberately, so a missing badge can never block the dashboard deploy -- which meant the absence was silent. shields renders a missing endpoint as 'resource not found'.

README.md line 40 already documents the intended behaviour:

    any badge grey | mid-run, or no data published for that series yet

That state was never implemented. This adds it, alongside the existing seeding of latest-report.md and latest-report-daily.md a few lines below, which solves the same problem for the report panes.

These are placeholders, not fallbacks. They are written only where nothing was carried forward, so a series that has published a real badge is untouched; the soak publisher overwrites them as soon as a run produces real ones, and the carry-forward loop then preserves those. message and color are copied from the aggregator's own no-data branches ('no data' / lightgrey, already present for stability and perf) so a badge does not change shape when data arrives.

Verified against a scratch site/data with one series pre-populated: five placeholders written, the pre-existing real badge left byte-identical, and all six files carrying the schemaVersion/label/message/color keys shields requires.

Hotfix against master because that is where the broken badges are visible -- routing through dev would leave the repository front page reading as an error until the next promotion. master merges back into dev afterwards.

Worth recording separately: history.json is [] and the single history-daily.json entry has every field null, as do latest-summary-daily.json and latest-verdict-daily.json. The dashboard has never held a real soak result. The badges were the visible symptom, not the disease.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788108245&installation_model_id=426883&pr_number=176&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F176&signature=5a278fc4fd8c581706a915870a6afddb78d96a51bb9bf2ed44030c66d1bc2846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->