### PR TITLE
fix(ci): move smoke-test host ports out of the ephemeral range

### DIFF
--- a/.github/scripts/check-node-ports.sh
+++ b/.github/scripts/check-node-ports.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify a host port range is free before starting anything that binds it.
+#
+# Usage: check-node-ports.sh <first-port> <last-port>
+#
+# CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the kernel
+# ephemeral floor of 32768, so nothing can be auto-assigned into it and no
+# reservation is needed. This is a precondition check, not a drain wait.
+#
+# It used to reserve and wait on 40400-40455, inside the ephemeral range, and
+# that is the whole reason the heavy pipeline had to be re-run so often. The
+# Actions agent opens its control connections to GitHub before the job exists
+# and can source them from that range:
+#
+#   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
+#   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
+#
+# Those are ESTAB for the life of the job. They never drain, so the old 90s
+# wait could not have helped -- it only delayed the failure. A re-run passed
+# because a fresh runner's agent picked different source ports, which is
+# exactly why this read as an intermittent flake for months.
+#
+# TIME_WAIT is still worth waiting out: it genuinely clears in ~60s, and a
+# previous job on the same runner can leave some behind. So the two cases are
+# separated -- wait for what drains, fail immediately and name the holder for
+# what does not.
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <first-port> <last-port>" >&2
+  exit 2
+fi
+first="$1"
+last="$2"
+for p in "$first" "$last"; do
+  case "$p" in
+    ''|*[!0-9]*)
+      echo "::error::port arguments must be numeric; got '$first' '$last'" >&2
+      exit 2
+      ;;
+  esac
+done
+if [ "$first" -gt "$last" ]; then
+  echo "::error::first port ($first) is above last port ($last)" >&2
+  exit 2
+fi
+# Refuse a range the kernel can auto-assign into. The whole point of the move
+# was to get below the ephemeral floor; a caller that passes an overlapping
+# range has reintroduced the original bug, and silently checking it would let
+# that pass as a green step.
+floor="$(sysctl -n net.ipv4.ip_local_port_range 2>/dev/null | awk '{print $1}')"
+case "$floor" in
+  ''|*[!0-9]*) floor=32768 ;;
+esac
+if [ "$last" -ge "$floor" ]; then
+  echo "::error::range ${first}-${last} reaches into the ephemeral range (starts at ${floor}); the Actions agent can already hold ports there before this job exists"
+  exit 1
+fi
+
+range="sport >= :${first} and sport <= :${last}"
+# 13 samples at t=0,5,...,60 -- the last sample IS the decision, so the loop
+# never sleeps past a check it does not then act on.
+for i in $(seq 1 13); do
+  snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
+  busy="$(printf '%s' "$snapshot" | grep -c . || true)"
+  [ "$busy" -eq 0 ] && exit 0
+  stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
+  if [ -n "$stuck" ]; then
+    echo "FAIL: port(s) in ${first}-${last} held by a socket that will not drain:"
+    printf '%s\n' "$stuck"
+    echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
+    echo "Actions agent, the CI range now overlaps the ephemeral range again --"
+    echo "check net.ipv4.ip_local_port_range on this runner."
+    exit 1
+  fi
+  [ "$i" -eq 13 ] && break
+  echo "  [${i}] ${busy} TIME_WAIT socket(s) in ${first}-${last}; waiting for drain..."
+  sleep 5
+done
+echo "FAIL: ${busy} TIME_WAIT socket(s) still holding ${first}-${last} after 60s:"
+printf '%s\n' "$snapshot"
+exit 1

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -589,43 +589,78 @@ jobs:
         # the reservation already in place). Wait for the range to drain
         # (TIME_WAIT <= 60s) before starting anything that binds.
         run: |
-          sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
-          for i in $(seq 1 18); do
-            busy=$(ss -Htan 'sport >= :40400 and sport <= :40455' | wc -l)
+          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
+          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
+          # into it and no reservation is needed. This step is now a fast
+          # precondition check, not a drain wait.
+          #
+          # It used to reserve and wait on 40400-40455, inside the ephemeral
+          # range, and that is the whole reason the heavy pipeline had to be
+          # re-run so often. The Actions agent opens its control connections to
+          # GitHub before the job exists and can source them from that range:
+          #
+          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
+          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
+          #
+          # Those are ESTAB for the life of the job. They never drain, so the
+          # 90s wait could not have helped -- it only delayed the failure. A
+          # re-run passed because a fresh runner's agent picked different source
+          # ports, which is exactly why this read as an intermittent flake.
+          #
+          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
+          # and a previous job on the same runner can leave some behind. So the
+          # two cases are separated -- wait for what drains, fail immediately
+          # and name the holder for what does not.
+          range='sport >= :14400 and sport <= :14455'
+          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
+          # the loop never sleeps past a check it does not then act on.
+          for i in $(seq 1 13); do
+            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
+            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
             [ "$busy" -eq 0 ] && exit 0
-            echo "  [${i}] ${busy} pre-existing socket(s) in 40400-40455; waiting for drain..."
+            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
+            if [ -n "$stuck" ]; then
+              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
+              printf '%s\n' "$stuck"
+              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
+              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
+              echo "check net.ipv4.ip_local_port_range on this runner."
+              exit 1
+            fi
+            [ "$i" -eq 13 ] && break
+            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
             sleep 5
           done
-          echo "FAIL: sockets still holding node ports after 90s:"
-          sudo ss -tanp 'sport >= :40400 and sport <= :40455' || true
+          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
+          printf '%s\n' "$snapshot"
           exit 1
 
       - name: Start standalone node
         shell: bash -ex {0}
-        run: docker compose -f docker/standalone.yml up -d
+        run: docker compose -f docker/standalone.yml -f docker/ci-ports.standalone.yml up -d
 
       - name: Wait for Running state
         shell: bash -ex {0}
         run: |
           for i in $(seq 1 60); do
-            if docker compose -f docker/standalone.yml logs 2>&1 | grep -q "Making a transition to Running state"; then
+            if docker compose -f docker/standalone.yml -f docker/ci-ports.standalone.yml logs 2>&1 | grep -q "Making a transition to Running state"; then
               echo "Node reached Running state"
               break
             fi
             echo "  [${i}] Waiting for Running state..."
             sleep 5
           done
-          docker compose -f docker/standalone.yml logs 2>&1 | grep "Making a transition to Running state" || (echo "FAIL: Node did not reach Running state" && exit 1)
+          docker compose -f docker/standalone.yml -f docker/ci-ports.standalone.yml logs 2>&1 | grep "Making a transition to Running state" || (echo "FAIL: Node did not reach Running state" && exit 1)
 
       - name: Verify HTTP API
         shell: bash -ex {0}
-        run: curl -sf http://localhost:40403/api/status
+        run: curl -sf http://localhost:14403/api/status
 
       - name: Wait for 10 finalized blocks
         shell: bash -ex {0}
         run: |
           for i in $(seq 1 60); do
-            LFB=$(curl -sf http://localhost:40403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
+            LFB=$(curl -sf http://localhost:14403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
             echo "  [$((i*5))s] LFB: #$LFB"
             if [ "$LFB" -ge 10 ] 2>/dev/null; then
               echo "Reached LFB #$LFB"
@@ -656,7 +691,7 @@ jobs:
       - name: Cleanup
         if: always()
         shell: bash {0}
-        run: docker compose -f docker/standalone.yml down -v
+        run: docker compose -f docker/standalone.yml -f docker/ci-ports.standalone.yml down -v
 
   # Smoke test: full docker-compose shard (bootstrap + validators + observer).
   smoke_docker_shard:
@@ -708,20 +743,55 @@ jobs:
         # and again in run 29629049175 with the reservation alone in place —
         # a pre-existing socket survives the sysctl, so also drain the range).
         run: |
-          sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
-          for i in $(seq 1 18); do
-            busy=$(ss -Htan 'sport >= :40400 and sport <= :40455' | wc -l)
+          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
+          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
+          # into it and no reservation is needed. This step is now a fast
+          # precondition check, not a drain wait.
+          #
+          # It used to reserve and wait on 40400-40455, inside the ephemeral
+          # range, and that is the whole reason the heavy pipeline had to be
+          # re-run so often. The Actions agent opens its control connections to
+          # GitHub before the job exists and can source them from that range:
+          #
+          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
+          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
+          #
+          # Those are ESTAB for the life of the job. They never drain, so the
+          # 90s wait could not have helped -- it only delayed the failure. A
+          # re-run passed because a fresh runner's agent picked different source
+          # ports, which is exactly why this read as an intermittent flake.
+          #
+          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
+          # and a previous job on the same runner can leave some behind. So the
+          # two cases are separated -- wait for what drains, fail immediately
+          # and name the holder for what does not.
+          range='sport >= :14400 and sport <= :14455'
+          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
+          # the loop never sleeps past a check it does not then act on.
+          for i in $(seq 1 13); do
+            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
+            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
             [ "$busy" -eq 0 ] && exit 0
-            echo "  [${i}] ${busy} pre-existing socket(s) in 40400-40455; waiting for drain..."
+            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
+            if [ -n "$stuck" ]; then
+              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
+              printf '%s\n' "$stuck"
+              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
+              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
+              echo "check net.ipv4.ip_local_port_range on this runner."
+              exit 1
+            fi
+            [ "$i" -eq 13 ] && break
+            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
             sleep 5
           done
-          echo "FAIL: sockets still holding node ports after 90s:"
-          sudo ss -tanp 'sport >= :40400 and sport <= :40455' || true
+          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
+          printf '%s\n' "$snapshot"
           exit 1
 
       - name: Start shard
         shell: bash -ex {0}
-        run: docker compose -f docker/shard.yml up -d
+        run: docker compose -f docker/shard.yml -f docker/ci-ports.shard.yml up -d
 
       - name: Wait for bootstrap Running state
         shell: bash -ex {0}
@@ -740,7 +810,7 @@ jobs:
         shell: bash -ex {0}
         run: |
           for i in $(seq 1 60); do
-            LFB=$(curl -sf http://localhost:40403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
+            LFB=$(curl -sf http://localhost:14403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
             echo "  [$((i*5))s] LFB: #$LFB"
             if [ "$LFB" -ge 10 ] 2>/dev/null; then
               echo "Reached LFB #$LFB"
@@ -771,7 +841,7 @@ jobs:
       - name: Cleanup
         if: always()
         shell: bash {0}
-        run: docker compose -f docker/shard.yml down -v
+        run: docker compose -f docker/shard.yml -f docker/ci-ports.shard.yml down -v
 
   # Smoke test: extract binary from docker image, run locally without docker.
   smoke_local_standalone:
@@ -845,24 +915,69 @@ jobs:
         # binds 40400-40405 directly on the host. Reservation + drain, same
         # rationale as the docker smoke steps above.
         run: |
-          sudo sysctl -w net.ipv4.ip_local_reserved_ports=40400-40455
-          for i in $(seq 1 18); do
-            busy=$(ss -Htan 'sport >= :40400 and sport <= :40455' | wc -l)
+          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
+          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
+          # into it and no reservation is needed. This step is now a fast
+          # precondition check, not a drain wait.
+          #
+          # It used to reserve and wait on 40400-40455, inside the ephemeral
+          # range, and that is the whole reason the heavy pipeline had to be
+          # re-run so often. The Actions agent opens its control connections to
+          # GitHub before the job exists and can source them from that range:
+          #
+          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
+          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
+          #
+          # Those are ESTAB for the life of the job. They never drain, so the
+          # 90s wait could not have helped -- it only delayed the failure. A
+          # re-run passed because a fresh runner's agent picked different source
+          # ports, which is exactly why this read as an intermittent flake.
+          #
+          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
+          # and a previous job on the same runner can leave some behind. So the
+          # two cases are separated -- wait for what drains, fail immediately
+          # and name the holder for what does not.
+          range='sport >= :14400 and sport <= :14455'
+          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
+          # the loop never sleeps past a check it does not then act on.
+          for i in $(seq 1 13); do
+            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
+            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
             [ "$busy" -eq 0 ] && exit 0
-            echo "  [${i}] ${busy} pre-existing socket(s) in 40400-40455; waiting for drain..."
+            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
+            if [ -n "$stuck" ]; then
+              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
+              printf '%s\n' "$stuck"
+              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
+              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
+              echo "check net.ipv4.ip_local_port_range on this runner."
+              exit 1
+            fi
+            [ "$i" -eq 13 ] && break
+            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
             sleep 5
           done
-          echo "FAIL: sockets still holding node ports after 90s:"
-          sudo ss -tanp 'sport >= :40400 and sport <= :40455' || true
+          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
+          printf '%s\n' "$snapshot"
           exit 1
 
       - name: Start standalone node
         shell: bash -ex {0}
         run: |
+          # Same reason as docker/ci-ports.*.yml: the defaults (40400-40405) sit
+          # inside the ephemeral range the Actions agent draws from. This job
+          # binds on the host directly, so the ports move via CLI flags rather
+          # than a compose mapping.
           ./target/release/node run -s \
             --config-file=run-local/conf/standalone.conf \
             --validator-private-key=5f668a7ee96d944a4494cc947e4005e172d7ab3461ee5538f1f2a45a835e9657 \
             --host=localhost \
+            --protocol-port=14400 \
+            --api-port-grpc-external=14401 \
+            --api-port-grpc-internal=14402 \
+            --api-port-http=14403 \
+            --discovery-port=14404 \
+            --api-port-admin-http=14405 \
             --no-upnp \
             > /tmp/node-stdout.log 2>&1 &
           echo $! > /tmp/node.pid
@@ -883,13 +998,13 @@ jobs:
 
       - name: Verify HTTP API
         shell: bash -ex {0}
-        run: curl -sf http://localhost:40403/api/status
+        run: curl -sf http://localhost:14403/api/status
 
       - name: Wait for 10 finalized blocks
         shell: bash -ex {0}
         run: |
           for i in $(seq 1 60); do
-            LFB=$(curl -sf http://localhost:40403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
+            LFB=$(curl -sf http://localhost:14403/api/last-finalized-block 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('blockInfo',{}).get('blockNumber',0))" 2>/dev/null || echo 0)
             echo "  [$((i*5))s] LFB: #$LFB"
             if [ "$LFB" -ge 10 ] 2>/dev/null; then
               echo "Reached LFB #$LFB"

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -577,22 +577,15 @@ jobs:
           zcat /tmp/rust-node-docker.tar.gz | docker image load
           docker tag ${{ env.DOCKER_IMAGE_NAME }}:amd64 ${{ env.DOCKER_IMAGE_NAME }}
 
-      - name: Reserve node host ports
+      - name: Check node host ports
         shell: bash -e {0}
-        # 40400-40455 sit inside the kernel ephemeral range (32768-60999); a
-        # transient outbound connection can grab one as its source port and
-        # fail the bind with "address already in use". Reserving them excludes
-        # them from ephemeral allocation. Reservation only stops NEW
-        # allocations — a socket that grabbed a port in the range before this
-        # step ran (runner provisioning, artifact download) still holds it
-        # (observed: run 29629049175, validator2 bind on 40420 failing with
-        # the reservation already in place). Wait for the range to drain
-        # (TIME_WAIT <= 60s) before starting anything that binds.
+        # Docker smoke tests bind 14400-14455 below the kernel ephemeral range.
+        # Fail for active holders; allow TIME_WAIT sockets up to 60s to clear.
         run: |
-          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
+          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is below the
           # kernel ephemeral floor of 32768, so nothing can be auto-assigned
-          # into it and no reservation is needed. This step is now a fast
-          # precondition check, not a drain wait.
+          # into it and no reservation is needed. Verify the range is available
+          # before starting containers, waiting only for TIME_WAIT sockets.
           #
           # It used to reserve and wait on 40400-40455, inside the ephemeral
           # range, and that is the whole reason the heavy pipeline had to be
@@ -736,17 +729,15 @@ jobs:
           zcat /tmp/rust-node-docker.tar.gz | docker image load
           docker tag ${{ env.DOCKER_IMAGE_NAME }}:amd64 ${{ env.DOCKER_IMAGE_NAME }}
 
-      - name: Reserve node host ports
+      - name: Check node host ports
         shell: bash -e {0}
-        # Same ephemeral-port hazard as the standalone smoke; observed as
-        # rnode.validator2 failing to bind 0.0.0.0:40420 (run 28917696069,
-        # and again in run 29629049175 with the reservation alone in place —
-        # a pre-existing socket survives the sysctl, so also drain the range).
+        # Docker smoke tests bind 14400-14455 below the kernel ephemeral range.
+        # Fail for active holders; allow TIME_WAIT sockets up to 60s to clear.
         run: |
-          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
+          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is below the
           # kernel ephemeral floor of 32768, so nothing can be auto-assigned
-          # into it and no reservation is needed. This step is now a fast
-          # precondition check, not a drain wait.
+          # into it and no reservation is needed. Verify the range is available
+          # before starting containers, waiting only for TIME_WAIT sockets.
           #
           # It used to reserve and wait on 40400-40455, inside the ephemeral
           # range, and that is the whole reason the heavy pipeline had to be
@@ -909,16 +900,16 @@ jobs:
         shell: bash -ex {0}
         run: just setup-standalone
 
-      - name: Reserve node host ports
+      - name: Check node host ports
         shell: bash -e {0}
-        # Same ephemeral-port hazard as the docker smokes: the node binary
-        # binds 40400-40405 directly on the host. Reservation + drain, same
-        # rationale as the docker smoke steps above.
+        # The local smoke binds 14400-14455 through node CLI flags, below the
+        # kernel ephemeral range. Fail for active holders; allow TIME_WAIT
+        # sockets up to 60s to clear.
         run: |
-          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is BELOW the
-          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
-          # into it and no reservation is needed. This step is now a fast
-          # precondition check, not a drain wait.
+          # The local smoke binds 14400-14455 below the kernel ephemeral floor
+          # of 32768, so nothing can be auto-assigned into it and no reservation
+          # is needed. Verify the range is available before starting the node,
+          # waiting only for TIME_WAIT sockets.
           #
           # It used to reserve and wait on 40400-40455, inside the ephemeral
           # range, and that is the whole reason the heavy pipeline had to be

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -579,54 +579,10 @@ jobs:
 
       - name: Check node host ports
         shell: bash -e {0}
-        # Docker smoke tests bind 14400-14455 below the kernel ephemeral range.
-        # Fail for active holders; allow TIME_WAIT sockets up to 60s to clear.
-        run: |
-          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is below the
-          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
-          # into it and no reservation is needed. Verify the range is available
-          # before starting containers, waiting only for TIME_WAIT sockets.
-          #
-          # It used to reserve and wait on 40400-40455, inside the ephemeral
-          # range, and that is the whole reason the heavy pipeline had to be
-          # re-run so often. The Actions agent opens its control connections to
-          # GitHub before the job exists and can source them from that range:
-          #
-          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
-          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
-          #
-          # Those are ESTAB for the life of the job. They never drain, so the
-          # 90s wait could not have helped -- it only delayed the failure. A
-          # re-run passed because a fresh runner's agent picked different source
-          # ports, which is exactly why this read as an intermittent flake.
-          #
-          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
-          # and a previous job on the same runner can leave some behind. So the
-          # two cases are separated -- wait for what drains, fail immediately
-          # and name the holder for what does not.
-          range='sport >= :14400 and sport <= :14455'
-          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
-          # the loop never sleeps past a check it does not then act on.
-          for i in $(seq 1 13); do
-            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
-            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
-            [ "$busy" -eq 0 ] && exit 0
-            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
-            if [ -n "$stuck" ]; then
-              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
-              printf '%s\n' "$stuck"
-              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
-              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
-              echo "check net.ipv4.ip_local_port_range on this runner."
-              exit 1
-            fi
-            [ "$i" -eq 13 ] && break
-            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
-            sleep 5
-          done
-          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
-          printf '%s\n' "$snapshot"
-          exit 1
+        # Extracted to .github/scripts/check-node-ports.sh: this ran
+        # verbatim in all three smoke jobs, so a fix had to be applied
+        # three times or the copies silently diverged.
+        run: .github/scripts/check-node-ports.sh 14400 14455
 
       - name: Start standalone node
         shell: bash -ex {0}
@@ -731,54 +687,10 @@ jobs:
 
       - name: Check node host ports
         shell: bash -e {0}
-        # Docker smoke tests bind 14400-14455 below the kernel ephemeral range.
-        # Fail for active holders; allow TIME_WAIT sockets up to 60s to clear.
-        run: |
-          # CI binds 14400-14455 (see docker/ci-ports.*.yml), which is below the
-          # kernel ephemeral floor of 32768, so nothing can be auto-assigned
-          # into it and no reservation is needed. Verify the range is available
-          # before starting containers, waiting only for TIME_WAIT sockets.
-          #
-          # It used to reserve and wait on 40400-40455, inside the ephemeral
-          # range, and that is the whole reason the heavy pipeline had to be
-          # re-run so often. The Actions agent opens its control connections to
-          # GitHub before the job exists and can source them from that range:
-          #
-          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
-          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
-          #
-          # Those are ESTAB for the life of the job. They never drain, so the
-          # 90s wait could not have helped -- it only delayed the failure. A
-          # re-run passed because a fresh runner's agent picked different source
-          # ports, which is exactly why this read as an intermittent flake.
-          #
-          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
-          # and a previous job on the same runner can leave some behind. So the
-          # two cases are separated -- wait for what drains, fail immediately
-          # and name the holder for what does not.
-          range='sport >= :14400 and sport <= :14455'
-          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
-          # the loop never sleeps past a check it does not then act on.
-          for i in $(seq 1 13); do
-            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
-            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
-            [ "$busy" -eq 0 ] && exit 0
-            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
-            if [ -n "$stuck" ]; then
-              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
-              printf '%s\n' "$stuck"
-              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
-              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
-              echo "check net.ipv4.ip_local_port_range on this runner."
-              exit 1
-            fi
-            [ "$i" -eq 13 ] && break
-            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
-            sleep 5
-          done
-          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
-          printf '%s\n' "$snapshot"
-          exit 1
+        # Extracted to .github/scripts/check-node-ports.sh: this ran
+        # verbatim in all three smoke jobs, so a fix had to be applied
+        # three times or the copies silently diverged.
+        run: .github/scripts/check-node-ports.sh 14400 14455
 
       - name: Start shard
         shell: bash -ex {0}
@@ -902,55 +814,10 @@ jobs:
 
       - name: Check node host ports
         shell: bash -e {0}
-        # The local smoke binds 14400-14455 through node CLI flags, below the
-        # kernel ephemeral range. Fail for active holders; allow TIME_WAIT
-        # sockets up to 60s to clear.
-        run: |
-          # The local smoke binds 14400-14455 below the kernel ephemeral floor
-          # of 32768, so nothing can be auto-assigned into it and no reservation
-          # is needed. Verify the range is available before starting the node,
-          # waiting only for TIME_WAIT sockets.
-          #
-          # It used to reserve and wait on 40400-40455, inside the ephemeral
-          # range, and that is the whole reason the heavy pipeline had to be
-          # re-run so often. The Actions agent opens its control connections to
-          # GitHub before the job exists and can source them from that range:
-          #
-          #   ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  (("Runner.Listener",pid=2060))
-          #   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  (("hosted-compute-",pid=2034))
-          #
-          # Those are ESTAB for the life of the job. They never drain, so the
-          # 90s wait could not have helped -- it only delayed the failure. A
-          # re-run passed because a fresh runner's agent picked different source
-          # ports, which is exactly why this read as an intermittent flake.
-          #
-          # TIME_WAIT is still worth waiting out: it genuinely clears in ~60s,
-          # and a previous job on the same runner can leave some behind. So the
-          # two cases are separated -- wait for what drains, fail immediately
-          # and name the holder for what does not.
-          range='sport >= :14400 and sport <= :14455'
-          # 13 samples at t=0,5,...,60 -- the last sample IS the decision, so
-          # the loop never sleeps past a check it does not then act on.
-          for i in $(seq 1 13); do
-            snapshot="$(sudo ss -Htanp "$range" 2>/dev/null || true)"
-            busy="$(printf '%s' "$snapshot" | grep -c . || true)"
-            [ "$busy" -eq 0 ] && exit 0
-            stuck="$(printf '%s\n' "$snapshot" | grep -v '^TIME-WAIT' || true)"
-            if [ -n "$stuck" ]; then
-              echo "FAIL: port(s) in 14400-14455 held by a socket that will not drain:"
-              printf '%s\n' "$stuck"
-              echo "Not TIME_WAIT, so waiting cannot clear these. If the holder is the"
-              echo "Actions agent, the CI range now overlaps the ephemeral range again --"
-              echo "check net.ipv4.ip_local_port_range on this runner."
-              exit 1
-            fi
-            [ "$i" -eq 13 ] && break
-            echo "  [${i}] ${busy} TIME_WAIT socket(s) in 14400-14455; waiting for drain..."
-            sleep 5
-          done
-          echo "FAIL: ${busy} TIME_WAIT socket(s) still holding 14400-14455 after 60s:"
-          printf '%s\n' "$snapshot"
-          exit 1
+        # Extracted to .github/scripts/check-node-ports.sh: this ran
+        # verbatim in all three smoke jobs, so a fix had to be applied
+        # three times or the copies silently diverged.
+        run: .github/scripts/check-node-ports.sh 14400 14455
 
       - name: Start standalone node
         shell: bash -ex {0}

--- a/docker/ci-ports.shard.yml
+++ b/docker/ci-ports.shard.yml
@@ -1,0 +1,61 @@
+# CI-only host port remap for docker/shard.yml. See ci-ports.standalone.yml
+# for why: 40400-40455 overlaps the kernel ephemeral range and the GitHub
+# runner agent can already hold ports in it before the job starts.
+#
+# Uniform -26000 offset, so the per-node grouping is preserved and a host port
+# still maps to its node by the same arithmetic (boot 144xx, validator1 1441x,
+# validator2 1442x, validator3 1443x, readonly 1445x). Container ports are
+# unchanged.
+#
+# chroma-db (8000), prometheus (9090) and grafana (3000) are deliberately NOT
+# listed: they are already outside the ephemeral range, and because of the
+# !override below, naming one here would replace its ports list entirely
+# rather than leave it alone.
+#
+# `ports: !override` is load-bearing. Compose MERGES list-valued keys, so a
+# plain `ports:` here would ADD 14400-1445x while leaving 40400-4045x bound --
+# the ephemeral-range collision this file exists to avoid would still happen,
+# silently, and the smoke tests would still fail intermittently. Verified with
+# `docker compose config`: without !override the merged service lists both
+# ranges; with it, only ours. Requires Compose v2.24+ (runner has v5.1.1).
+services:
+  boot:
+    ports: !override
+      - "14400:40400"
+      - "14401:40401"
+      - "14402:40402"
+      - "14403:40403"
+      - "14404:40404"
+      - "14405:40405"
+  validator1:
+    ports: !override
+      - "14410:40400"
+      - "14411:40401"
+      - "14412:40402"
+      - "14413:40403"
+      - "14414:40404"
+      - "14415:40405"
+  validator2:
+    ports: !override
+      - "14420:40400"
+      - "14421:40401"
+      - "14422:40402"
+      - "14423:40403"
+      - "14424:40404"
+      - "14425:40405"
+  validator3:
+    ports: !override
+      - "14430:40400"
+      - "14431:40401"
+      - "14432:40402"
+      - "14433:40403"
+      - "14434:40404"
+      - "14435:40405"
+  readonly:
+    ports: !override
+      - "14450:40400"
+      - "14451:40401"
+      - "14452:40402"
+      - "14453:40403"
+      - "14454:40404"
+      - "14455:40405"

--- a/docker/ci-ports.standalone.yml
+++ b/docker/ci-ports.standalone.yml
@@ -1,0 +1,35 @@
+# CI-only host port remap for docker/standalone.yml.
+#
+# 40400-40405 sit inside the kernel ephemeral range (32768-60999). On a
+# GitHub-hosted runner the Actions agent opens its control connections to
+# GitHub before the job exists and can source them from that range, e.g.
+#
+#   ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  users:(("hosted-compute-",pid=2034))
+#
+# Those sockets are ESTAB for the life of the job, so they never drain and the
+# bind fails. sysctl ip_local_reserved_ports cannot help: it only blocks new
+# allocations and cannot reclaim a socket that already exists. Re-running the
+# job "fixes" it only because a fresh runner's agent picked different source
+# ports -- which is why this presented as an intermittent flake for so long.
+#
+# 14400-14405 is below the ephemeral floor, so the kernel will never assign it
+# to anything automatically. Container ports are unchanged, so nothing inside
+# the node or on the compose network moves; this is purely the host side.
+#
+# Used only by _integration-pipeline.yml. Local development keeps 40400-40405
+# via docker/standalone.yml on its own, where no runner agent competes.
+# `ports: !override` is load-bearing. Compose MERGES list-valued keys, so a
+# plain `ports:` here would ADD 14400-1445x while leaving 40400-4045x bound --
+# the ephemeral-range collision this file exists to avoid would still happen,
+# silently, and the smoke tests would still fail intermittently. Verified with
+# `docker compose config`: without !override the merged service lists both
+# ranges; with it, only ours. Requires Compose v2.24+ (runner has v5.1.1).
+services:
+  standalone:
+    ports: !override
+      - "14400:40400"
+      - "14401:40401"
+      - "14402:40402"
+      - "14403:40403"
+      - "14404:40404"
+      - "14405:40405"

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -9,6 +9,42 @@ mr_status:
 
 # Tasks and Epics
 
+## CLOSED: extraction complete, root cause found, evidence VMs released (2026-08-01T02:05Z)
+
+<!-- claude-session-9f68c6fa — supersedes the 01:35Z orchestrator status below -->
+
+- **Extraction COMPLETE**: 79 files (runner `_diag` incl. 1MB Worker log,
+  syslog family, 4h06m of `/tmp/merge-recovery-soak` results) in the secure
+  session vault, SHA256 `7141929f...c3354` verified both ends. Raw logs stay
+  out of git per owner directive.
+- **Root cause of run 30661821085 (and the whole "runner lost, VM healthy"
+  class): a 52-minute OCI host stall froze the VM's userspace** — job-lock
+  renewals stopped 00:08:34, lock expired 00:18:31 (= exact job death),
+  listener woke 01:00:03. The staged runner self-update was a red herring.
+  On-box mitigations cannot address this class; lock expiry is the detector,
+  restart-in-window is the recovery, Oracle ticket / placement diversity are
+  the fixes. Full analysis: `../system-integration/docs/ToDos.md` (01:50Z).
+- **`c7fd9f` and `evidence-helper-c7fd9f` terminated on the repo owner's
+  explicit instruction** after completeness was confirmed — the 01:35Z
+  "do not terminate" below is superseded. Durable copies remain: boot-volume
+  backup `evidence-run-30661821085-...T013353Z` and clone
+  `evidence-c7fd9f-clone`, both AVAILABLE in OCI.
+- The weekend 60h soak (02:30Z) proceeds with known exposure to the same
+  stall class; failed VMs survive by construction and the clone-and-extract
+  playbook is proven.
+
+---
+
+## ORCHESTRATOR STATUS (superseded): evidence extraction is active, not yet complete (2026-08-01T01:35Z)
+
+- The recovered `~/.ssh/oci-ci-runner` key matches the runner public key, but direct SSH to the original VM still stalls before the SSH banner. Do not reboot or terminate it.
+- The evidence hold is extended to 2026-08-02T04:30Z.
+- A live, crash-consistent boot-volume clone is available and a helper VM is SSH-reachable.
+- The cloned volume is now `ATTACHED` read-only and mounted at `/mnt/evidence` on the helper. Disk evidence is available for extraction; never remount it read-write.
+- Raw logs and diagnostics belong only in the secure temporary vault; commit sanitized findings, hashes, and paths—not credentials, addresses, or raw runner output.
+
+The clone is mounted and ready for selected evidence to be copied into the secure temporary vault with hashes. Volatile state on the original VM remains unavailable while its SSH service fails before the banner.
+
 This document tracks implementation work through **epics** (logical groupings of related tasks).
 
 **Document Structure**


### PR DESCRIPTION
The heavy pipeline's recurring 'just re-run it and it passes' failures are not flaky. They are deterministic, and the reason they looked random is that the condition is decided before the job starts.

Host ports 40400-40455 sit inside the kernel ephemeral range (32768-60999). The GitHub Actions agent opens its control connections to GitHub before the job exists and can source them from that range:

  ESTAB 10.1.0.54:40418 -> 20.85.130.105:443  users:(("Runner.Listener",pid=2060))
  ESTAB 10.1.0.32:40422 -> 140.82.112.24:443  users:(("hosted-compute-",pid=2034))

Those sockets are ESTAB for the life of the job. They never drain, so the step's 90-second wait could not have helped -- it only delayed the failure by a minute and a half. sysctl ip_local_reserved_ports cannot help either: it blocks new allocations and cannot reclaim a socket that already exists, which the step's own comment says. Re-running passed because a fresh runner's agent picked different source ports.

CI now binds 14400-14455, below the ephemeral floor, where nothing is ever auto-assigned. Container ports are unchanged, so nothing inside the node or on the compose network moves; docker/ci-ports.*.yml remap only the host side and are used only by this pipeline, so local development keeps 40400-40405. smoke_local_standalone binds on the host directly rather than through compose, so it moves via the node's own --*-port flags.

ports: !override is load-bearing and is called out in both files. Compose MERGES list-valued keys, so the first version of this change ADDED 14400-1445x while leaving 40400-4045x bound -- the collision would have survived, silently, and the smoke tests would have kept failing at the same rate. Caught by running docker compose config rather than by reading the spec.

The reserve step is now a precondition check rather than a drain wait, and it separates the two cases it previously conflated: a non-TIME_WAIT holder fails immediately and names it, because waiting cannot clear it; TIME_WAIT still gets its drain window, sampled through t=60 inclusive so the last sample is the decision. Behaviour-tested against both real signatures plus a clear range and a never-clearing TIME_WAIT.

Evidence, for anyone auditing this later: three re-run events across the last 60 CI runs, two of them this step. The six 'Check matrix slots' failures in the same window are the aggregator gate reporting those, not independent faults. Note that a naive search finds nothing -- a re-run flips the run conclusion to success and the jobs API serves only the latest attempt, so prior failures are visible only via /runs/{id}/attempts/{n}/jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788121164&installation_model_id=426883&pr_number=178&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F178&signature=64d34f0d4ade18e3aa0ea33754f912b3b6ef1d1d6bf4da5041b71c68ea9c7054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->