### PR TITLE
feat(soak): let an operator ask a running soak to publish

### DIFF
--- a/.github/actions/soak-segment/action.yml
+++ b/.github/actions/soak-segment/action.yml
@@ -69,8 +69,72 @@ inputs:
 runs:
   using: composite
   steps:
+    # Turns an operator signal into something the soak loop can see.
+    #
+    # The channel is this instance's own OCI freeform tags, read with
+    # instance-principal auth and the OCID from IMDSv2 -- the same mechanism
+    # the soak already uses to exempt itself from the reaper, so it grants no
+    # new credential and trusts nothing new. .github/workflows/soak-signal.yml
+    # is the sender.
+    #
+    # Backgrounded because the soak is a single long-running `run:`: there is
+    # no other point at which this job could notice anything. It writes a file
+    # rather than signalling the process, because the loop must choose the
+    # moment -- stopping mid-iteration leaves a partial result the aggregator
+    # would count as real.
+    #
+    # Entirely optional. If IMDS or OCI is unreachable it warns and exits, and
+    # the segment behaves exactly as before: a soak must never fail because a
+    # convenience channel is unavailable.
+    - name: Start signal poller (${{ inputs.label }})
+      shell: bash -e {0}
+      env:
+        SIGNAL_FILE: /tmp/merge-recovery-soak/signal
+        SUPPRESS_LABEL_WARNING: "True"
+      run: |
+        mkdir -p /tmp/merge-recovery-soak
+        # A signal left over from the previous segment would fire the instant
+        # this one starts.
+        rm -f "$SIGNAL_FILE"
+        iid="$(curl -sS --max-time 10 -H 'Authorization: Bearer Oracle' \
+          http://169.254.169.254/opc/v2/instance/id 2>/dev/null)" || iid=""
+        case "$iid" in
+          ocid1.instance.*) ;;
+          *)
+            echo "::warning::signal poller: could not read this instance OCID from IMDS; on-demand checkpoint/finalize is unavailable for this segment"
+            exit 0
+            ;;
+        esac
+        # Only a signal newer than this segment counts. Without the floor, a
+        # tag from an earlier segment ends every later one the moment it opens.
+        started="$(date +%s)"
+        printf '%s' "$iid" > /tmp/merge-recovery-soak/.signal-iid
+        printf '%s' "$started" > /tmp/merge-recovery-soak/.signal-since
+        nohup bash -c '
+          iid="$(cat /tmp/merge-recovery-soak/.signal-iid)"
+          since="$(cat /tmp/merge-recovery-soak/.signal-since)"
+          while :; do
+            sleep 30
+            raw="$(oci --auth instance_principal compute instance get \
+              --instance-id "$iid" \
+              --query "data.\"freeform-tags\".\"soak-signal\"" --raw-output 2>/dev/null || true)"
+            case "$raw" in ""|null) continue ;; esac
+            action="${raw%%:*}"; at="${raw##*:}"
+            case "$at" in ""|*[!0-9]*) continue ;; esac
+            [ "$at" -le "$since" ] && continue
+            case "$action" in
+              checkpoint|finalize)
+                printf "%s" "$action" > /tmp/merge-recovery-soak/signal
+                exit 0
+                ;;
+            esac
+          done
+        ' >/dev/null 2>&1 &
+        echo "signal poller watching soak-signal on $iid; signals after ${started} count"
+
     - name: Soak (${{ inputs.label }})
       env:
+        SOAK_SIGNAL_FILE: /tmp/merge-recovery-soak/signal
         F1R3FLY_NODE_IMAGE: ${{ inputs.node_image }}
         F1R3FLY_NODE_BINARY: /tmp/rnode
         F1R3FLY_NODE_DEFAULTS_CONF: ${{ inputs.node_repo_dir }}/node/src/main/resources/defaults.conf

--- a/.github/workflows/soak-signal.yml
+++ b/.github/workflows/soak-signal.yml
@@ -1,0 +1,173 @@
+name: Soak Signal
+
+# Asks a RUNNING soak to publish now.
+#
+# A soak publishes only at a segment boundary, and those boundaries are fixed
+# Pacific instants (07:30 / 13:00). A run that starts off that grid can go
+# hours with nothing on the dashboard, and a 60h weekend run is dark for its
+# first twelve. This makes a boundary reachable on demand.
+#
+# The signal is a freeform tag on the soak's own VM. The soak reads it with
+# instance-principal auth using the OCID it takes from IMDSv2 -- the same
+# mechanism it already uses to exempt itself from the reaper -- so nothing new
+# is trusted and no new credential is granted.
+#
+# Two limits worth knowing before relying on this:
+#
+#   1. It only affects a run that is ALREADY EXECUTING, and only one whose
+#      checkout contains the poller. A soak runs the script it checked out at
+#      launch, so this cannot help a run that started before this merged.
+#
+#   2. `checkpoint` needs a segment boundary to publish from. The final segment
+#      has none -- the soak refuses the request there rather than ending the
+#      run and publishing nothing. A run with no scheduled checkpoints is all
+#      final segment, so use `finalize` for those.
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: >-
+          checkpoint = publish now and keep running (needs a non-final segment).
+          finalize = stop and publish a full verdict + history entry.
+        required: true
+        type: choice
+        options:
+          - checkpoint
+          - finalize
+      run_id:
+        description: >-
+          Soak run to signal. Empty = the newest soak with a RUNNING tagged VM,
+          which is almost always what you want.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  # Same compartment literal as ci-runner-reaper.yml and merge-recovery-soak.yml.
+  # check-workflow-invariants.sh asserts every literal names the same one.
+  CI_RUNNER_COMPARTMENT_OCID: "ocid1.compartment.oc1..aaaaaaaalq6bh2a6dmq4h6i3nrripxlcevv7fa3goaf7wxve52qiuocmehia"
+  OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"
+  OCI_CLI_INSTALLER_SHA256: "079dcc9a3e2a61ec692400e30169c9996b2998ac8c4e205198ed5863283fcb76"
+  OCI_CLI_VERSION: "3.89.1"
+
+jobs:
+  signal:
+    name: Signal running soak
+    runs-on: ubuntu-latest
+    environment: oci-credentials
+    timeout-minutes: 10
+    steps:
+      - name: Install OCI CLI (pinned, checksum-verified)
+        shell: bash -e {0}
+        run: |
+          curl -fsSL --retry 5 --retry-delay 10 "$OCI_CLI_INSTALLER_URL" -o /tmp/oci-install.sh
+          echo "$OCI_CLI_INSTALLER_SHA256  /tmp/oci-install.sh" | sha256sum -c -
+          bash /tmp/oci-install.sh \
+            --accept-all-defaults --install-dir /opt/oci-cli --exec-dir /usr/local/bin \
+            --oci-cli-version "$OCI_CLI_VERSION"
+
+      - name: Configure OCI auth from secrets
+        shell: bash -e {0} # no -x: never trace the multi-line private key
+        env:
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_PRIVATE_KEY: ${{ secrets.OCI_PRIVATE_KEY }}
+        run: |
+          install -d -m 700 ~/.oci
+          umask 077
+          printf '%s\n' "$OCI_PRIVATE_KEY" > ~/.oci/key.pem
+          cat > ~/.oci/config <<CFG
+          [DEFAULT]
+          user=$OCI_USER_OCID
+          fingerprint=$OCI_FINGERPRINT
+          tenancy=$OCI_TENANCY_OCID
+          region=$OCI_REGION
+          key_file=$HOME/.oci/key.pem
+          CFG
+
+      - name: Tag the soak VM
+        shell: bash -e {0}
+        env:
+          # Environment, never interpolated into the script body: `${{ }}` is
+          # substituted before bash sees it, so a value with shell
+          # metacharacters would execute rather than be quoted.
+          ACTION: ${{ inputs.action }}
+          WANT_RUN: ${{ inputs.run_id }}
+          SUPPRESS_LABEL_WARNING: "True"
+        run: |
+          case "$ACTION" in
+            checkpoint|finalize) ;;
+            *) echo "::error::unrecognised action: $ACTION"; exit 1 ;;
+          esac
+          case "$WANT_RUN" in
+            ''|*[0-9]*) ;;
+          esac
+          if [ -n "$WANT_RUN" ] && ! [[ "$WANT_RUN" =~ ^[0-9]+$ ]]; then
+            echo "::error::run_id must be numeric"; exit 1
+          fi
+          # List and filter separated: piping the CLI into jq under 2>/dev/null
+          # makes a credentials fault, an outage and "no soak is running" the
+          # same empty answer -- and this one ends with "nothing to signal".
+          if ! listing="$(oci compute instance list \
+               --compartment-id "$CI_RUNNER_COMPARTMENT_OCID" --all --output json 2>&1)"; then
+            printf '%s\n' "$listing" | tail -20
+            echo "::error::could not list instances; cannot tell a missing soak from an unreadable compartment"
+            exit 1
+          fi
+          # Newest RUNNING soak-tagged VM, optionally pinned to one run. The
+          # github-run-key tag is "<run_id>-<attempt>", so match the prefix.
+          if ! iid="$(printf '%s' "$listing" | jq -r --arg want "$WANT_RUN" '
+               [ .data[]
+                 | select(."lifecycle-state" == "RUNNING")
+                 | select(."freeform-tags".purpose == "soak")
+                 | select($want == "" or ((."freeform-tags"["github-run-key"] // "") | startswith($want + "-")))
+               ]
+               | sort_by(."time-created") | last | .id // empty' 2>&1)"; then
+            printf '%s\n' "$iid" | tail -10
+            echo "::error::could not parse the instance listing"
+            exit 1
+          fi
+          if [ -z "$iid" ]; then
+            echo "::error::no RUNNING soak-tagged instance${WANT_RUN:+ for run $WANT_RUN}; nothing to signal"
+            exit 1
+          fi
+          name="$(printf '%s' "$listing" | jq -r --arg i "$iid" '.data[]|select(.id==$i)|."display-name"')"
+          echo "signalling $ACTION to $name"
+          # Read-modify-write. --freeform-tags REPLACES the whole map, so a
+          # blind write erases purpose/series/soak-deadline-epoch and hands the
+          # reaper a VM with no exemption -- it would be terminated at the 2h
+          # age bound mid-soak. Same care as the soak's own self-tag step.
+          if ! existing="$(oci compute instance get --instance-id "$iid" \
+               --query 'data."freeform-tags"' --raw-output 2>&1)"; then
+            printf '%s\n' "$existing" | tail -10
+            echo "::error::could not read current tags; refusing to write a tag map built from a failed read"
+            exit 1
+          fi
+          case "$existing" in ''|null) existing='{}' ;; esac
+          if ! jq -e 'type == "object"' <<<"$existing" >/dev/null 2>&1; then
+            echo "::error::current tags did not parse as a JSON object; refusing to overwrite them"
+            exit 1
+          fi
+          merged="$(jq -cn --argjson cur "$existing" --arg v "${ACTION}:$(date +%s)" \
+            '$cur + {"soak-signal": $v}')"
+          oci compute instance update --instance-id "$iid" --force \
+            --freeform-tags "$merged" >/dev/null
+          echo "tagged soak-signal=${ACTION}; picked up within ~30s, acted on at the next iteration boundary"
+          if [ "$ACTION" = "finalize" ]; then
+            echo "::warning::finalize ends the run early -- remaining segments exit immediately and the run publishes a full verdict"
+          fi
+
+      - name: Remove OCI credentials
+        if: always()
+        shell: bash -e {0}
+        run: |
+          if [ -d ~/.oci ]; then
+            find ~/.oci -type f -exec shred -u {} + 2>/dev/null || rm -rf ~/.oci
+            rm -rf ~/.oci
+          fi

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -38,11 +38,16 @@ fi
 # (a Pacific checkpoint) rather than after a fixed span. Without one, the
 # deadline is the full requested duration measured from the original start, so
 # a final segment needs no deadline of its own.
+# Whether this segment ends on a checkpoint boundary. The caller publishes a
+# checkpoint only when it passed a deadline, so this also decides whether an
+# on-demand checkpoint is possible here at all — see the signal handling below.
+HAS_CHECKPOINT_BOUNDARY=0
 if [ -n "${SOAK_DEADLINE_EPOCH:-}" ]; then
   if ! [[ "$SOAK_DEADLINE_EPOCH" =~ ^[1-9][0-9]*$ ]]; then
     printf 'SOAK_DEADLINE_EPOCH must be a positive integer\n' >&2
     exit 2
   fi
+  HAS_CHECKPOINT_BOUNDARY=1
   DEADLINE="$SOAK_DEADLINE_EPOCH"
   # Never run past the overall budget, whatever the caller asked for.
   if [ "$DEADLINE" -gt "$((STARTED_AT + DURATION_SECONDS))" ]; then
@@ -349,7 +354,73 @@ if [ "$RUN_BENCHMARKS" = "true" ] && [ "$SEGMENT" -eq 1 ]; then
   run_bench_segment
 fi
 
+# Operator signal, polled between iterations.
+#
+# A soak publishes only at a segment boundary, and those boundaries are fixed
+# Pacific instants (07:30 / 13:00). A run starting off that grid — a short
+# restart window, an afternoon dispatch — can run for hours with nothing on the
+# dashboard, and a 60h weekend run is dark for its first twelve. This makes a
+# boundary reachable on demand. The signal file is written by the poller in the
+# soak-segment action, which reads it from this instance's own OCI freeform
+# tags; see .github/workflows/soak-signal.yml for the sender.
+#
+# Checked here rather than in the poller because only this loop knows where an
+# iteration boundary is. Stopping mid-iteration would leave a half-finished
+# iteration that the aggregator counts as a real one, skewing the very numbers
+# the checkpoint exists to report.
+#
+#   checkpoint  End THIS segment now, so the caller's aggregate/upload/publish
+#               steps run exactly as at a scheduled checkpoint. The next
+#               segment resumes from the state file with counters, start time
+#               and iteration numbering intact, and the run continues.
+#
+#               Only possible where a segment boundary exists. The caller gates
+#               those publish steps on having passed a deadline, so in the
+#               final segment the request is refused rather than silently
+#               ending the run and publishing nothing -- which is what it would
+#               do if this simply broke the loop. Zero-checkpoint runs are all
+#               final segment, so that is the common case, not a corner.
+#
+#   finalize    End the run. The marker survives into the remaining segments,
+#               which exit immediately, so the run drains to the normal
+#               end-of-run publish and produces a real verdict and history
+#               entry rather than a latest-* refresh.
+SIGNAL_FILE="${SOAK_SIGNAL_FILE:-$OUTPUT_DIR/signal}"
+FINALIZE_MARKER="$OUTPUT_DIR/finalize-requested"
+if [ -e "$FINALIZE_MARKER" ]; then
+  printf 'finalize requested in an earlier segment; segment %s does no work\n' "$SEGMENT"
+  DEADLINE=0
+fi
+
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  if [ -e "$SIGNAL_FILE" ]; then
+    SIGNAL="$(tr -d '[:space:]' < "$SIGNAL_FILE" 2>/dev/null || true)"
+    # Consumed either way: an unread signal re-fires on every later iteration
+    # and every later segment.
+    rm -f "$SIGNAL_FILE"
+    case "$SIGNAL" in
+      checkpoint)
+        if [ "$HAS_CHECKPOINT_BOUNDARY" -eq 1 ]; then
+          printf 'checkpoint signalled after iteration %s; ending segment %s\n' "$ITERATIONS" "$SEGMENT"
+          printf '%s\n' "checkpoint signalled after iteration $ITERATIONS" \
+            > "$OUTPUT_DIR/signalled-checkpoint.txt"
+          break
+        fi
+        printf 'checkpoint signalled, but segment %s is the final segment and publishes no checkpoint; ignoring. Use finalize to end the run and publish a full verdict.\n' \
+          "$SEGMENT" >&2
+        ;;
+      finalize)
+        printf 'finalize signalled after iteration %s; ending the run\n' "$ITERATIONS"
+        printf '%s\n' "finalize signalled after iteration $ITERATIONS" > "$FINALIZE_MARKER"
+        break
+        ;;
+      '')
+        ;;
+      *)
+        printf 'ignoring unrecognised soak signal: %s\n' "$SIGNAL" >&2
+        ;;
+    esac
+  fi
   PROVIDER="${PROVIDERS[$((ITERATIONS % ${#PROVIDERS[@]}))]}"
   ITERATIONS="$((ITERATIONS + 1))"
   ITERATION_DIR="$OUTPUT_DIR/iteration-$(printf '%05d' "$ITERATIONS")-$PROVIDER"


### PR DESCRIPTION
A soak publishes only at a segment boundary, and those boundaries are fixed Pacific instants (07:30 and 13:00). A run that starts off that grid can go hours with nothing on the dashboard: a short restart window or an afternoon dispatch lands entirely between two instants and gets zero checkpoints, and a 60h weekend run is dark for its first twelve hours. Nothing could shorten that wait, so the dashboard could be empty for a day with a healthy soak running.

Two modes, deliberately distinct rather than one overloaded signal:

  checkpoint  End this segment now, so the aggregate/upload/publish steps run
              exactly as at a scheduled checkpoint. The next segment resumes
              from the state file with counters, original start time and
              iteration numbering intact, and the run continues.

  finalize    End the run. The marker survives into the remaining segments,
              which exit immediately, so the run drains to the normal
              end-of-run publish and produces a real verdict and history entry
              rather than a latest-* refresh.

checkpoint is refused in the final segment rather than honoured. The caller gates its publish steps on having been given a deadline, and the final segment has none, so breaking the loop there would end the run and publish nothing -- the request would appear to work and silently do the opposite of what it says. That is not a corner case: a run with no scheduled checkpoints is ALL final segment, which is exactly the situation this feature exists for. The refusal names finalize as the tool for it.

Signalling rides on the VM's own OCI freeform tags, read with instance- principal auth and the OCID from IMDSv2 -- the same mechanism the soak already uses to exempt itself from the reaper, so no new credential is granted and nothing new is trusted. soak-signal.yml is the sender; it read-modify-writes the tag map, because --freeform-tags REPLACES it and a blind write would erase soak-deadline-epoch and hand the reaper an unexempted VM to terminate at the 2h mark, mid-run.

The signal is checked between iterations, not in the poller. Only the loop knows where an iteration boundary is; stopping mid-iteration would leave a half-finished iteration that the aggregator counts as real, skewing the very numbers the checkpoint exists to report.

The poller is fail-soft: if IMDS or OCI is unreachable it warns and exits, and the segment behaves exactly as before. A soak must never fail because a convenience channel is unavailable.

Behaviour-tested across six paths: no signal, checkpoint with a boundary, checkpoint in the final segment (refused, run continues), finalize with a boundary, finalize in the final segment, and an unrecognised signal.

Two limits, recorded in soak-signal.yml's header because they would otherwise be discovered at 3am. This affects only a run that is ALREADY EXECUTING and whose checkout contains the poller -- a soak runs the script it checked out at launch, so it cannot help a run that started before this merged. And checkpoint needs a non-final segment, per the refusal above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788130953&installation_model_id=426883&pr_number=179&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F179&signature=8c88f915b608137381429ddc8869517389cc0ca80c926ef2248ed1805209f103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->