### PR TITLE
hotfix(soak): stop OOM livelock before runner loss

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=79262d8b5cfb8d80b2c94815aeff6b62bcf6127d
+SYSTEM_INTEGRATION_REF=369d49df2f97e65b3d0ad869aa668a7383b11179

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: 79262d8b5cfb8d80b2c94815aeff6b62bcf6127d
+  SYSTEM_INTEGRATION_REF: 369d49df2f97e65b3d0ad869aa668a7383b11179
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -53,6 +53,8 @@ permissions:
 
 env:
   DOCKER_IMAGE_NAME: f1r3flyindustries/f1r3fly-rust
+  SOAK_RSS_CEILING_MB: "14336"
+  SOAK_HOST_FREE_FLOOR_MB: "12288"
   # THIRD pin site. The other two — .github/oci-validation.env and
   # _integration-pipeline.yml — are held identical by build_base's drift check;
   # this one is outside that check and rotted unnoticed as a result. It sat at
@@ -103,7 +105,7 @@ env:
   # by grep: main already contained the string __RUNNER_LABELS__, the cloud-init
   # template placeholder, long before the override existed. Grepping would have
   # said yes against a launcher that ignores the variable.
-  SYSTEM_INTEGRATION_REF: 79262d8b5cfb8d80b2c94815aeff6b62bcf6127d
+  SYSTEM_INTEGRATION_REF: 369d49df2f97e65b3d0ad869aa668a7383b11179
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -145,6 +145,9 @@ else
   fi
 fi
 
+printf 'Soak host protection: node RSS ceiling=%sMB; host free floor=%sMB\n' \
+  "$RSS_CEILING_MB" "$HOST_FREE_FLOOR_MB"
+
 if [ "$RUN_BENCHMARKS" = "true" ] && [ -z "$NODE_REPO_DIR" ]; then
   printf 'SOAK_NODE_REPO_DIR is required when SOAK_RUN_BENCHMARKS=true\n' >&2
   exit 2


### PR DESCRIPTION
## Diagnosis

The scheduled weekend run `30686305430` and its automatic retry `30687262967` both launched successfully, entered soak segment 1, then lost communication with their dedicated self-hosted runners after 24 and 21 minutes. Both OCI instances remain `RUNNING`, but SSH stalls during banner exchange or resets during key exchange.

OCI Compute Agent data shows the same ramp-then-gap signature on both machines:

- first run: memory 4.1% → 35.9% and CPU 1.5% → 58.8% before metrics stop
- retry: memory 4.1% → 18.2% and CPU 1.5% → 32.4% before metrics stop

That repeats the previously extracted OOM-livelock failure class rather than a flat host stall. The existing 20GB node-RSS allowance and 6GB host-free floor do not trip early enough to keep the runner responsive.

## Hotfix

- cap total node RSS at 14GB, retaining about 3.5GB above the observed healthy 10.8GB peak
- raise the host-free floor to 12GB so the out-of-process guardian kills nodes before reclaim livelock starves the runner
- normalize all three system-integration pins to `369d49df2f97e65b3d0ad869aa668a7383b11179`, adding the merged heartbeat, post-mortem dump, and listener-wedge escape to the next runner

## Validation

- edited workflows parse as YAML
- LSP diagnostics clean
- all three immutable pins are equal and match system-integration `main`
- verified PR #79 is an ancestor of the target and all three durability mechanisms exist there
- `git diff --check` clean
- pre-commit formatting, Clippy, and cargo-deny checks passed

## Operational follow-up

The two failed soak instances are still running and require an explicit teardown decision after any desired evidence extraction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788170812&installation_model_id=426883&pr_number=185&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F185&signature=b077f46282e58fef091464eeeb919f305268d17af4ff108a38fa74742bc2a0cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->