### PR TITLE
feat(ci): dispatch merge recovery soaks from OCI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,5 @@
 self-hosted-runner:
   labels:
     - f1r3fly-rust-ci-ephemeral
+    - f1r3fly-rust-soak
     - oracle-cloud

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -18,12 +18,12 @@ PIPELINE=.github/workflows/_integration-pipeline.yml
 fail=0
 
 err() {
-    printf '::error::%s\n' "$1"
-    fail=1
+	printf '::error::%s\n' "$1"
+	fail=1
 }
 
 ok() {
-    printf 'ok: %s\n' "$1"
+	printf 'ok: %s\n' "$1"
 }
 
 # Emit one line of facts per job in a workflow file:
@@ -35,7 +35,7 @@ ok() {
 # and counting those would let the guard pass on a workflow whose real `needs:`
 # had been deleted.
 scan_jobs() {
-    awk '
+	awk '
         /^[[:space:]]*#/ { next }
         /^  [A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ {
             job = $1
@@ -71,11 +71,11 @@ scan_jobs() {
 #    Removing either `needs:` is the abuse path the ephemeral-launch approval
 #    exists to close.
 for job in launch_ephemeral_runners build_docker_image; do
-    if scan_jobs "$PIPELINE" | awk -v j="$job" '$1 == j && $5 == 1 { found = 1 } END { exit !found }'; then
-        ok "$job gates on await_approval"
-    else
-        err "$job in $PIPELINE no longer depends on await_approval; unapproved fork PRs could spend CI resources"
-    fi
+	if scan_jobs "$PIPELINE" | awk -v j="$job" '$1 == j && $5 == 1 { found = 1 } END { exit !found }'; then
+		ok "$job gates on await_approval"
+	else
+		err "$job in $PIPELINE no longer depends on await_approval; unapproved fork PRs could spend CI resources"
+	fi
 done
 
 # 2. Credential concentration. Exactly one job in the reusable pipeline may hold
@@ -84,24 +84,24 @@ done
 cred_jobs="$(scan_jobs "$PIPELINE" | awk '$3 == 1 || $4 == 1 { print $1 }')"
 cred_count="$(printf '%s' "$cred_jobs" | grep -c . || true)"
 if [ "$cred_count" = "1" ] && [ "$cred_jobs" = "launch_ephemeral_runners" ]; then
-    ok "credentials confined to launch_ephemeral_runners"
+	ok "credentials confined to launch_ephemeral_runners"
 else
-    # Flattened to one line: a GitHub error annotation captures only its first
-    # line, so a multi-line job list would hide every name after the first.
-    cred_list="$(printf '%s' "$cred_jobs" | tr '\n' ' ')"
-    err "expected exactly one credential-bearing job (launch_ephemeral_runners) in $PIPELINE, found: ${cred_list:-none}"
+	# Flattened to one line: a GitHub error annotation captures only its first
+	# line, so a multi-line job list would hide every name after the first.
+	cred_list="$(printf '%s' "$cred_jobs" | tr '\n' ' ')"
+	err "expected exactly one credential-bearing job (launch_ephemeral_runners) in $PIPELINE, found: ${cred_list:-none}"
 fi
 
 # 3. Environment scoping. Any job anywhere that reads OCI or GitHub App
 #    credentials must name an environment, so access is a property of the
 #    environment rather than of the repository secret store.
 for workflow in .github/workflows/*.yml; do
-    while read -r job has_env reads_oci reads_app _gated _calls _inherits; do
-        [ -n "${job:-}" ] || continue
-        if [ "$reads_oci$reads_app" != "00" ] && [ "$has_env" = "0" ]; then
-            err "$workflow job '$job' reads privileged credentials without naming an environment"
-        fi
-    done <<EOF
+	while read -r job has_env reads_oci reads_app _gated _calls _inherits; do
+		[ -n "${job:-}" ] || continue
+		if [ "$reads_oci$reads_app" != "00" ] && [ "$has_env" = "0" ]; then
+			err "$workflow job '$job' reads privileged credentials without naming an environment"
+		fi
+	done <<EOF
 $(scan_jobs "$workflow")
 EOF
 done
@@ -113,12 +113,12 @@ ok "every credential-reading job names an environment"
 #    config as malformed (runs 30495007422 and 30498890544). Guarded because the
 #    line reads like redundant over-sharing and invites deletion.
 for caller in .github/workflows/ci.yml .github/workflows/ci-fork-pr.yml; do
-    while read -r job _has_env _reads_oci _reads_app _gated calls inherits; do
-        [ -n "${job:-}" ] || continue
-        if [ "$calls" = "1" ] && [ "$inherits" = "0" ]; then
-            err "$caller job '$job' calls the integration pipeline without 'secrets: inherit'; the launch job would see empty credentials"
-        fi
-    done <<EOF
+	while read -r job _has_env _reads_oci _reads_app _gated calls inherits; do
+		[ -n "${job:-}" ] || continue
+		if [ "$calls" = "1" ] && [ "$inherits" = "0" ]; then
+			err "$caller job '$job' calls the integration pipeline without 'secrets: inherit'; the launch job would see empty credentials"
+		fi
+	done <<EOF
 $(scan_jobs "$caller")
 EOF
 done
@@ -160,30 +160,30 @@ ocid_required=".github/workflows/ci-runner-reaper.yml"
 ocid_optional=".github/workflows/merge-recovery-soak.yml"
 ocid_values=""
 for ocid_file in $ocid_optional; do
-    ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
-        "$ocid_file" 2>/dev/null \
-        | sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
-    [ -n "$ocid_found" ] && ocid_values="${ocid_values}${ocid_found}
+	ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
+		"$ocid_file" 2>/dev/null |
+		sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
+	[ -n "$ocid_found" ] && ocid_values="${ocid_values}${ocid_found}
 "
 done
 for ocid_file in $ocid_required; do
-    ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
-        "$ocid_file" 2>/dev/null \
-        | sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
-    ocid_count="$(printf '%s' "$ocid_found" | grep -c . || true)"
-    if [ "$ocid_count" -ne 1 ]; then
-        err "$ocid_file must pin exactly one literal CI_RUNNER_COMPARTMENT_OCID, found $ocid_count (an Actions variable trades a compile-time guarantee for an admin-mutable one — see the note in ci-runner-reaper.yml)"
-    else
-        ocid_values="${ocid_values}${ocid_found}
+	ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
+		"$ocid_file" 2>/dev/null |
+		sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
+	ocid_count="$(printf '%s' "$ocid_found" | grep -c . || true)"
+	if [ "$ocid_count" -ne 1 ]; then
+		err "$ocid_file must pin exactly one literal CI_RUNNER_COMPARTMENT_OCID, found $ocid_count (an Actions variable trades a compile-time guarantee for an admin-mutable one — see the note in ci-runner-reaper.yml)"
+	else
+		ocid_values="${ocid_values}${ocid_found}
 "
-    fi
+	fi
 done
 if [ "$fail" -eq 0 ]; then
-    if [ "$(printf '%s' "$ocid_values" | sort -u | grep -c .)" -ne 1 ]; then
-        err "CI_RUNNER_COMPARTMENT_OCID differs across the workflows that pin it ($ocid_required $ocid_optional); every literal must name the same compartment"
-    else
-        ok "CI_RUNNER_COMPARTMENT_OCID pinned as a literal in $ocid_required, and consistent wherever else it appears"
-    fi
+	if [ "$(printf '%s' "$ocid_values" | sort -u | grep -c .)" -ne 1 ]; then
+		err "CI_RUNNER_COMPARTMENT_OCID differs across the workflows that pin it ($ocid_required $ocid_optional); every literal must name the same compartment"
+	else
+		ok "CI_RUNNER_COMPARTMENT_OCID pinned as a literal in $ocid_required, and consistent wherever else it appears"
+	fi
 fi
 
 # 6. Fork-checkout hygiene. Every checkout of the code under test must set
@@ -204,14 +204,14 @@ fi
 fork_bad_persist=""
 fork_bad_optin=""
 while read -r line_no flags; do
-    case "$flags" in
-        *P*) ;;
-        *) fork_bad_persist="$fork_bad_persist $PIPELINE:$line_no" ;;
-    esac
-    case "$flags" in
-        *A*) ;;
-        *) fork_bad_optin="$fork_bad_optin $PIPELINE:$line_no" ;;
-    esac
+	case "$flags" in
+	*P*) ;;
+	*) fork_bad_persist="$fork_bad_persist $PIPELINE:$line_no" ;;
+	esac
+	case "$flags" in
+	*A*) ;;
+	*) fork_bad_optin="$fork_bad_optin $PIPELINE:$line_no" ;;
+	esac
 done <<EOF
 $(awk '
     function flush() {
@@ -232,13 +232,35 @@ $(awk '
 ' "$PIPELINE")
 EOF
 if [ -n "$fork_bad_persist" ]; then
-    err "checkout of fork-authored code without 'persist-credentials: false' at:${fork_bad_persist}; a writable token must never reach a workspace holding untrusted code"
+	err "checkout of fork-authored code without 'persist-credentials: false' at:${fork_bad_persist}; a writable token must never reach a workspace holding untrusted code"
 fi
 if [ -n "$fork_bad_optin" ]; then
-    err "checkout of fork-authored code without 'allow-unsafe-pr-checkout: true' at:${fork_bad_optin}; actions/checkout refuses fork code under pull_request_target without it, which breaks every fork PR at clone"
+	err "checkout of fork-authored code without 'allow-unsafe-pr-checkout: true' at:${fork_bad_optin}; actions/checkout refuses fork code under pull_request_target without it, which breaks every fork PR at clone"
 fi
 if [ -z "$fork_bad_persist$fork_bad_optin" ]; then
-    ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
+	ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
+fi
+
+SOAK_WORKFLOW=.github/workflows/merge-recovery-soak.yml
+if grep -qE '^  schedule:' "$SOAK_WORKFLOW"; then
+	err "$SOAK_WORKFLOW must not use GitHub's delayed schedule trigger"
+else
+	ok "merge recovery soak has no GitHub schedule trigger"
+fi
+if grep -qE '^      scheduled_slot_epoch:' "$SOAK_WORKFLOW" &&
+	grep -q 'source=oci-resource-scheduler' "$SOAK_WORKFLOW"; then
+	ok "merge recovery soak accepts an OCI scheduled slot"
+else
+	err "$SOAK_WORKFLOW must accept and resolve scheduled_slot_epoch from OCI"
+fi
+if grep -Fq "[ \"\$pacific_weekday\" -eq 5 ]" "$SOAK_WORKFLOW" &&
+	grep -q 'target_ref=master' "$SOAK_WORKFLOW" &&
+	grep -q 'duration_seconds=216000' "$SOAK_WORKFLOW" &&
+	grep -q 'target_ref=dev' "$SOAK_WORKFLOW" &&
+	grep -q 'duration_seconds=79200' "$SOAK_WORKFLOW"; then
+	ok "OCI schedule gate covers daily and weekend soak series"
+else
+	err "$SOAK_WORKFLOW must route Mon-Thu to the daily dev soak and Friday to the weekend master soak"
 fi
 
 # 8. Every `run:` block in every workflow must be parseable by its shell.
@@ -263,11 +285,11 @@ skipped_shells=""
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 while IFS= read -r wf; do
-    # Extract every run: block with its job/step identity. Ruby is already a
-    # hard dependency of this repo's tooling and ships with a YAML parser, so
-    # the blocks come from a real parse rather than an indentation heuristic
-    # that block scalars would defeat.
-    ruby -ryaml -e '
+	# Extract every run: block with its job/step identity. Ruby is already a
+	# hard dependency of this repo's tooling and ships with a YAML parser, so
+	# the blocks come from a real parse rather than an indentation heuristic
+	# that block scalars would defeat.
+	ruby -ryaml -e '
       wf = ARGV[0]; out = ARGV[1]
       doc = YAML.load_file(wf) rescue nil
       exit 0 unless doc.is_a?(Hash) && doc["jobs"].is_a?(Hash)
@@ -287,34 +309,37 @@ while IFS= read -r wf; do
         end
       end' "$wf" "$scratch" 2>/dev/null || continue
 
-    [ -f "$scratch/index.txt" ] || continue
-    while IFS=$'\t' read -r blockfile kind label; do
-        case "$kind" in
-            bash | sh | "") ;;
-            *) skipped_shells="${skipped_shells}
-  ${wf}: ${label} (shell: ${kind})"; continue ;;
-        esac
-        if ! errout="$(bash -n "$scratch/$blockfile" 2>&1)"; then
-            bad_syntax="${bad_syntax}
+	[ -f "$scratch/index.txt" ] || continue
+	while IFS=$'\t' read -r blockfile kind label; do
+		case "$kind" in
+		bash | sh | "") ;;
+		*)
+			skipped_shells="${skipped_shells}
+  ${wf}: ${label} (shell: ${kind})"
+			continue
+			;;
+		esac
+		if ! errout="$(bash -n "$scratch/$blockfile" 2>&1)"; then
+			bad_syntax="${bad_syntax}
   ${wf}: ${label}
     ${errout}"
-        fi
-    done < "$scratch/index.txt"
-    rm -f "$scratch"/index.txt "$scratch"/block-*.sh
+		fi
+	done <"$scratch/index.txt"
+	rm -f "$scratch"/index.txt "$scratch"/block-*.sh
 done < <(find .github/workflows -name '*.yml' -o -name '*.yaml' | sort)
 
 if [ -n "$bad_syntax" ]; then
-    err "workflow run: block(s) fail 'bash -n' and will die at runtime:${bad_syntax}"
+	err "workflow run: block(s) fail 'bash -n' and will die at runtime:${bad_syntax}"
 else
-    ok "every workflow run: block parses under bash -n"
+	ok "every workflow run: block parses under bash -n"
 fi
 if [ -n "$skipped_shells" ]; then
-    printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
+	printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
 fi
 
 if [ "$fail" -ne 0 ]; then
-    printf '::error::%s\n' "workflow security invariants violated; see errors above"
-    exit 1
+	printf '::error::%s\n' "workflow security invariants violated; see errors above"
+	exit 1
 fi
 
 echo "All workflow security invariants hold."

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -253,6 +253,12 @@ if grep -qE '^      scheduled_slot_epoch:' "$SOAK_WORKFLOW" &&
 else
 	err "$SOAK_WORKFLOW must accept and resolve scheduled_slot_epoch from OCI"
 fi
+if grep -Fq -- "[ \"\$trigger_delay\" -gt 900 ]" "$SOAK_WORKFLOW" &&
+	grep -q 'merge-recovery-soak-slot-' "$SOAK_WORKFLOW"; then
+	ok "OCI slot delay and duplicate serialization fail closed"
+else
+	err "$SOAK_WORKFLOW must enforce the 15-minute OCI delay and serialize duplicate slots"
+fi
 if grep -Fq "[ \"\$pacific_weekday\" -eq 5 ]" "$SOAK_WORKFLOW" &&
 	grep -q 'target_ref=master' "$SOAK_WORKFLOW" &&
 	grep -q 'duration_seconds=216000' "$SOAK_WORKFLOW" &&

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -126,6 +126,9 @@ jobs:
     name: Resolve Pacific Schedule
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: merge-recovery-soak-slot-${{ inputs.scheduled_slot_epoch != '' && inputs.scheduled_slot_epoch || github.run_id }}
+      cancel-in-progress: false
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
       duration_seconds: ${{ steps.resolve.outputs.duration_seconds }}
@@ -222,8 +225,8 @@ jobs:
             now_epoch="$(date -u +%s)"
             slot_epoch="$INPUT_SCHEDULED_SLOT"
             trigger_delay=$((now_epoch - slot_epoch))
-            if [ "$trigger_delay" -lt 0 ] || [ "$trigger_delay" -gt 3600 ]; then
-              echo "::error::scheduled_slot_epoch delay ${trigger_delay}s is outside the accepted 0..3600s range"
+            if [ "$trigger_delay" -lt 0 ] || [ "$trigger_delay" -gt 900 ]; then
+              echo "::error::scheduled_slot_epoch delay ${trigger_delay}s is outside the accepted 0..900s range"
               exit 1
             fi
             pacific_hm="$(TZ=America/Los_Angeles date -d "@${slot_epoch}" +%H%M)"

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -1,16 +1,16 @@
 name: Merge Recovery Soak
 
+run-name: >-
+  ${{ inputs.scheduled_slot_epoch != '' && format('Merge Recovery Soak [scheduled:{0}]', inputs.scheduled_slot_epoch) || 'Merge Recovery Soak' }}
+
 on:
-  schedule:
-    # Both slots target Pacific 19:30; one matches PDT (UTC-7), the other PST
-    # (UTC-8), and the schedule gate no-ops whichever is currently wrong.
-    # 19:30 Pacific is chosen so the Friday weekend-60h soak finishes at
-    # exactly 07:30 Pacific on Monday (19:30 + 60h), in both DST regimes.
-    # Pacific 19:30 falls on the *next* UTC day, hence 02:30/03:30 UTC.
-    - cron: "30 2 * * *"
-    - cron: "30 3 * * *"
   workflow_dispatch:
     inputs:
+      scheduled_slot_epoch:
+        description: Intended OCI Resource Scheduler slot in epoch seconds; empty means manual mode
+        required: false
+        default: ""
+        type: string
       target_ref:
         description: Branch, tag, or SHA to validate
         required: true
@@ -49,6 +49,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -149,8 +150,7 @@ jobs:
       - name: Resolve schedule
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_SCHEDULE: ${{ github.event.schedule }}
+          INPUT_SCHEDULED_SLOT: ${{ inputs.scheduled_slot_epoch }}
           INPUT_DURATION: ${{ inputs.duration }}
           INPUT_TARGET_REF: ${{ inputs.target_ref }}
           INPUT_WINDOW_END: ${{ inputs.window_end_epoch }}
@@ -160,7 +160,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash -euo pipefail {0}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ -z "$INPUT_SCHEDULED_SLOT" ]; then
             if [ "$INPUT_DURATION" = "weekend-60h" ]; then
               duration_seconds=216000
             else
@@ -216,77 +216,60 @@ jobs:
               fi
             fi
           else
-            # GitHub delivers cron triggers minutes-to-hours late, so gate on
-            # the cron's intended slot (most recent occurrence at or before
-            # now), not the wall clock at execution time.
-            # The window is on a half hour, so the minute field matters as
-            # much as the hour — compare %H%M, not %H.
-            cron_min="$(awk '{print $1}' <<<"$EVENT_SCHEDULE")"
-            cron_hour="$(awk '{print $2}' <<<"$EVENT_SCHEDULE")"
+            case "$INPUT_SCHEDULED_SLOT" in
+              ''|*[!0-9]*) echo "::error::scheduled_slot_epoch must be epoch seconds"; exit 1 ;;
+            esac
             now_epoch="$(date -u +%s)"
-            slot_epoch="$(date -u -d "$(date -u +%F) ${cron_hour}:${cron_min}:00" +%s)"
-            if [ "$slot_epoch" -gt "$now_epoch" ]; then
-              slot_epoch=$((slot_epoch - 86400))
+            slot_epoch="$INPUT_SCHEDULED_SLOT"
+            trigger_delay=$((now_epoch - slot_epoch))
+            if [ "$trigger_delay" -lt 0 ] || [ "$trigger_delay" -gt 3600 ]; then
+              echo "::error::scheduled_slot_epoch delay ${trigger_delay}s is outside the accepted 0..3600s range"
+              exit 1
             fi
             pacific_hm="$(TZ=America/Los_Angeles date -d "@${slot_epoch}" +%H%M)"
             pacific_weekday="$(TZ=America/Los_Angeles date -d "@${slot_epoch}" +%u)"
-            echo "cron=$EVENT_SCHEDULE slot=$(date -u -d "@${slot_epoch}" +%FT%TZ) pacific_hm=$pacific_hm pacific_weekday=$pacific_weekday"
-            target_ref=dev
-            should_run=false
+            if [ "$pacific_hm" != "1930" ] || [ "$pacific_weekday" -lt 1 ] || [ "$pacific_weekday" -gt 5 ]; then
+              echo "::error::OCI slot $(date -u -d "@${slot_epoch}" +%FT%TZ) does not resolve to an eligible Pacific 19:30 weekday"
+              exit 1
+            fi
+            echo "source=oci-resource-scheduler slot=$(date -u -d "@${slot_epoch}" +%FT%TZ) pacific_hm=$pacific_hm pacific_weekday=$pacific_weekday trigger_delay=${trigger_delay}s"
+            should_run=true
             idle_skip=false
-            duration_seconds=79200
-            if [ "$pacific_hm" = "1930" ] && [ "$pacific_weekday" -ge 1 ] && [ "$pacific_weekday" -le 4 ]; then
-              # 22h, not 24h. The soak job shares a concurrency group with
-              # cancel-in-progress, so a 24h soak on a 24h cadence is cancelled
-              # by the next night's launch ~10min before it finishes — losing
-              # its final iteration and its entire artifact upload. 22h leaves
-              # the run time to report before the next one starts.
-              should_run=true
-              duration_seconds=79200
-              # Don't re-soak code that has already been soaked. If nothing
-              # landed on the branch since the previous window there is nothing
-              # new to learn, and an OCI runner is not worth spending on it.
-              #
-              # Fails OPEN: any API error, empty response or unparseable count
-              # runs the soak. A silently skipped soak is the exact failure this
-              # workflow exists to avoid, so "unsure" must mean "soak".
-              #
-              # The window is anchored to the previous eligible slot, not to a
-              # fixed 24h, because daily windows are not 24h apart: dailies run
-              # Mon-Thu, so Monday's window is four days after Thursday's. A 24h
-              # lookback on a Monday cannot see anything that landed over the
-              # weekend, and would skip the soak on code that has never been
-              # soaked at all — `dev` gets no weekend coverage either, since the
-              # 60h weekend soak targets `master`.
-              if [ "$pacific_weekday" -eq 1 ]; then
-                prev_slot_epoch=$((slot_epoch - 4 * 86400))
-              else
-                prev_slot_epoch=$((slot_epoch - 86400))
-              fi
-              # Two hours of overlap, for two reasons. Slot-aligned windows tile
-              # exactly, so a commit landing on a boundary could fall between
-              # two of them and never be seen. And the arithmetic above is in
-              # epoch seconds, so a window spanning a Pacific DST change lands
-              # an hour off — on the November change, Monday's window would
-              # otherwise start at Thursday 20:30 PT and miss the hour before
-              # it. The margin absorbs both without needing DST-aware date
-              # maths. Erring wide costs at most one redundant soak; erring
-              # narrow is the bug this whole check is meant to avoid.
-              since="$(date -u -d "@$((prev_slot_epoch - 7200))" +%Y-%m-%dT%H:%M:%SZ)"
-              new_commits="$(gh api \
-                "repos/${GITHUB_REPOSITORY}/commits?sha=${target_ref}&since=${since}" \
-                --jq 'length' 2>/dev/null || echo "")"
-              if [ "$new_commits" = "0" ]; then
-                should_run=false
-                idle_skip=true
-                echo "no commits on $target_ref since $since; skipping tonight's soak"
-              else
-                echo "commits on $target_ref since $since: ${new_commits:-unknown (check failed; soaking anyway)}"
-              fi
-            elif [ "$pacific_hm" = "1930" ] && [ "$pacific_weekday" -eq 5 ]; then
-              # Friday 19:30 + 60h = Monday 07:30 Pacific.
-              should_run=true
+            duplicate_skip=false
+            expected_title="Merge Recovery Soak [scheduled:${slot_epoch}]"
+            canonical_run="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null \
+              | jq -r --arg title "$expected_title" '[.workflow_runs[] | select(.display_title == $title) | .id] | min // empty' \
+              || true)"
+            if [ -n "$canonical_run" ] && [ "$canonical_run" != "$GITHUB_RUN_ID" ]; then
+              should_run=false
+              duplicate_skip=true
+              echo "scheduled slot already belongs to run $canonical_run; suppressing duplicate run $GITHUB_RUN_ID"
+            fi
+            if [ "$pacific_weekday" -eq 5 ]; then
+              target_ref=master
               duration_seconds=216000
+            else
+              target_ref=dev
+              duration_seconds=79200
+              if [ "$should_run" = "true" ]; then
+                if [ "$pacific_weekday" -eq 1 ]; then
+                  prev_slot_epoch=$((slot_epoch - 4 * 86400))
+                else
+                  prev_slot_epoch=$((slot_epoch - 86400))
+                fi
+                since="$(date -u -d "@$((prev_slot_epoch - 7200))" +%Y-%m-%dT%H:%M:%SZ)"
+                new_commits="$(gh api \
+                  "repos/${GITHUB_REPOSITORY}/commits?sha=${target_ref}&since=${since}" \
+                  --jq 'length' 2>/dev/null || echo "")"
+                if [ "$new_commits" = "0" ]; then
+                  should_run=false
+                  idle_skip=true
+                  echo "no commits on $target_ref since $since; skipping tonight's soak"
+                else
+                  echo "commits on $target_ref since $since: ${new_commits:-unknown (check failed; soaking anyway)}"
+                fi
+              fi
             fi
           fi
           kind=daily
@@ -366,6 +349,14 @@ jobs:
               echo "The original window ends too soon for a restart to be worth an OCI runner."
               echo "**No soak was attempted** — a green check on this run is not a soak result."
             } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$should_run" != "true" ] && [ "${duplicate_skip:-false}" = "true" ]; then
+            echo "::notice::Schedule gate skip: another run owns this OCI slot. No soak was attempted; this run's success is not a soak result."
+            {
+              echo "## Schedule gate: skipped (duplicate OCI slot)"
+              echo ""
+              echo "Run \`$canonical_run\` already owns scheduled slot \`$slot_epoch\`."
+              echo "**No soak was attempted** — a green check on this run is not a soak result."
+            } >> "$GITHUB_STEP_SUMMARY"
           elif [ "$should_run" != "true" ] && [ "${idle_skip:-false}" = "true" ]; then
             echo "::notice::Schedule gate skip: nothing landed on $target_ref since the previous window, so tonight's soak would re-test already-soaked code. No soak was attempted; this run's success is not a soak result."
             {
@@ -376,11 +367,10 @@ jobs:
               echo "**No soak was attempted** — a green check on this run is not a soak result."
             } >> "$GITHUB_STEP_SUMMARY"
           elif [ "$should_run" != "true" ]; then
-            echo "::notice::Schedule gate no-op: cron slot resolved outside the Pacific 19:30 launch window. No soak was attempted; this run's success is not a soak result."
+            echo "::notice::Schedule gate no-op. No soak was attempted; this run's success is not a soak result."
             {
               echo "## Schedule gate: no-op"
               echo ""
-              echo "This scheduled trigger resolved outside the Pacific 19:30 launch window."
               echo "**No soak was attempted** — a green check on this run is not a soak result."
             } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/oci/soak-scheduler/Dockerfile
+++ b/oci/soak-scheduler/Dockerfile
@@ -1,0 +1,11 @@
+FROM ghcr.io/oracle/oci-cli@sha256:12ba572de6290354255e9d7ed0d387a428230a0a5b2b8969603ca8008f71734a
+USER root
+RUN microdnf install -y bash curl jq openssl tzdata \
+    && microdnf clean all
+COPY --from=fnproject/hotwrap@sha256:bf6303d7d216581c0e760f33dd74c3cdea83edad69f3d9614b7f573ba62c22b4 /hotwrap /hotwrap
+WORKDIR /function
+COPY --chown=oracle:oracle handler.sh ./
+RUN chmod 755 /function/handler.sh /hotwrap
+USER oracle
+CMD ["/function/handler.sh"]
+ENTRYPOINT ["/hotwrap"]

--- a/oci/soak-scheduler/README.md
+++ b/oci/soak-scheduler/README.md
@@ -19,9 +19,19 @@ Create or update a GitHub App installed only on `F1R3FLY-io/f1r3node-rust` with:
 
 Store its PEM private key in an OCI Vault secret. Record the App ID, installation ID, secret OCID, function compartment OCID, and subnet OCID. The deployment script never accepts the PEM contents directly.
 
-## Deploy
+## Deployment prerequisites
 
-The selected subnet must provide outbound HTTPS access to `api.github.com`. Authenticate Docker to the regional OCIR endpoint before deploying.
+Before deployment:
+
+1. Install and authenticate the OCI CLI and Docker.
+2. Create or select an OCI compartment, an outbound-enabled subnet, an OCI Vault secret containing the GitHub App PEM, and an OCIR repository namespace.
+3. Grant the deploying OCI principal permission to manage Functions, Resource Scheduler schedules, dynamic groups, policies, and the target OCIR repository.
+4. Authenticate Docker to `<region>.ocir.io` using an OCI auth token.
+5. Ensure the selected subnet can reach `api.github.com` over HTTPS.
+
+The script honors `OCI_PROFILE` and `OCI_CLI_CONFIG_FILE`. `OCI_REGION`, `OCI_TENANCY_OCID`, and `OCIR_NAMESPACE` can override profile-derived values. Existing Function application subnets are immutable in OCI; the script fails with recreation instructions rather than silently retaining a different subnet.
+
+## Deploy
 
 ```bash
 export OCI_COMPARTMENT_OCID='<function-and-scheduler-compartment-ocid>'
@@ -35,7 +45,15 @@ scripts/oci/deploy-soak-scheduler.sh
 
 The script builds and pushes the Bash/HotWrap Function image, creates or updates the Function, creates the 02:30 and 03:30 UTC schedules, and creates least-scope dynamic groups and IAM policy statements for Function invocation and Vault access. The image pins the OCI CLI and HotWrap base images by digest and contains the Bash, jq, curl, OpenSSL, and timezone tools used by the handler.
 
-Deploy only after the workflow change reaches `master`, because GitHub resolves `workflow_dispatch` from the configured `master` ref.
+Use this cutover order:
+
+1. Merge the workflow change through `dev` and promote it to `master`.
+2. Confirm `merge-recovery-soak.yml` on `master` accepts `scheduled_slot_epoch`.
+3. Run `scripts/oci/deploy-soak-scheduler.sh`.
+4. Invoke the eligible Function payload manually and complete the verification below.
+5. Confirm no GitHub `schedule` trigger remains enabled.
+
+GitHub resolves `workflow_dispatch` from the configured `master` ref, so deploying before step 1 will fail against workflow inputs that do not yet exist.
 
 ## Verify
 

--- a/oci/soak-scheduler/README.md
+++ b/oci/soak-scheduler/README.md
@@ -1,0 +1,63 @@
+# OCI merge-recovery soak scheduler
+
+This OCI Function replaces GitHub Actions `schedule` delivery for the merge-recovery soak. OCI Resource Scheduler invokes the Function at both UTC times that can represent 19:30 Pacific. A Bash handler in a custom Docker image dispatches GitHub only when the resolved slot is Monday through Friday at exactly 19:30 Pacific.
+
+```mermaid
+flowchart LR
+    RS[OCI Resource Scheduler<br/>02:30 and 03:30 UTC] --> FN[OCI Function]
+    FN --> V[OCI Vault<br/>GitHub App private key]
+    FN --> API[GitHub workflow dispatch API]
+    API --> WF[Merge Recovery Soak]
+```
+
+## GitHub App
+
+Create or update a GitHub App installed only on `F1R3FLY-io/f1r3node-rust` with:
+
+- Actions: read and write
+- Metadata: read
+
+Store its PEM private key in an OCI Vault secret. Record the App ID, installation ID, secret OCID, function compartment OCID, and subnet OCID. The deployment script never accepts the PEM contents directly.
+
+## Deploy
+
+The selected subnet must provide outbound HTTPS access to `api.github.com`. Authenticate Docker to the regional OCIR endpoint before deploying.
+
+```bash
+export OCI_COMPARTMENT_OCID='<function-and-scheduler-compartment-ocid>'
+export OCI_SUBNET_OCID='<outbound-enabled-subnet-ocid>'
+export GITHUB_APP_ID='<github-app-id>'
+export GITHUB_APP_INSTALLATION_ID='<github-app-installation-id>'
+export GITHUB_APP_PRIVATE_KEY_SECRET_OCID='<vault-secret-ocid>'
+
+scripts/oci/deploy-soak-scheduler.sh
+```
+
+The script builds and pushes the Bash/HotWrap Function image, creates or updates the Function, creates the 02:30 and 03:30 UTC schedules, and creates least-scope dynamic groups and IAM policy statements for Function invocation and Vault access. The image pins the OCI CLI and HotWrap base images by digest and contains the Bash, jq, curl, OpenSSL, and timezone tools used by the handler.
+
+Deploy only after the workflow change reaches `master`, because GitHub resolves `workflow_dispatch` from the configured `master` ref.
+
+## Verify
+
+Run the Bash tests from the repository root:
+
+```bash
+bash oci/soak-scheduler/test-handler.sh
+```
+
+The tests cover PDT and PST selection, daily and weekend routing, weekend-day suppression, late invocation rejection, duplicate suppression, and the GitHub dispatch payloads.
+
+For the live smoke test, invoke the currently eligible payload within 15 minutes of its UTC slot and confirm:
+
+1. Exactly one run appears with `Merge Recovery Soak [scheduled:<epoch>]` as its title.
+2. The schedule gate reports the same slot epoch and Pacific 19:30.
+3. Invoking the same payload again reports `duplicate` and creates no second run.
+4. The other UTC payload reports `ineligible`.
+
+## Timing and failure behavior
+
+- OCI schedules are UTC-only, so both UTC slots remain necessary across Pacific DST changes.
+- Invocations more than 15 minutes late fail instead of launching an hours-late soak.
+- Saturday and Sunday Pacific slots do not dispatch GitHub.
+- The Function checks recent workflow titles before dispatching to suppress Resource Scheduler retries.
+- The workflow independently preserves the intended slot epoch for duration, checkpoint, and restart calculations.

--- a/oci/soak-scheduler/handler.sh
+++ b/oci/soak-scheduler/handler.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_ROOT=https://api.github.com
+API_VERSION=2022-11-28
+USER_AGENT=f1r3node-oci-soak-scheduler
+TMP_FILES=()
+
+cleanup() {
+	if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+		rm -f "${TMP_FILES[@]}"
+	fi
+}
+trap cleanup EXIT
+
+required_config() {
+	local name="$1"
+	if [ -z "${!name:-}" ]; then
+		printf '%s is required\n' "$name" >&2
+		return 1
+	fi
+}
+
+epoch_format() {
+	local epoch="$1" zone="$2" format="$3"
+	if date -u -d @0 +%s >/dev/null 2>&1; then
+		TZ="$zone" date -d "@$epoch" "+$format"
+	else
+		TZ="$zone" date -r "$epoch" "+$format"
+	fi
+}
+
+utc_slot_epoch() {
+	local now_epoch="$1" hour="$2" day candidate
+	day="$(epoch_format "$now_epoch" UTC %F)"
+	if date -u -d @0 +%s >/dev/null 2>&1; then
+		candidate="$(date -u -d "$day ${hour}:30:00" +%s)"
+	else
+		candidate="$(TZ=UTC date -j -f '%Y-%m-%d %H:%M:%S' "$day ${hour}:30:00" +%s)"
+	fi
+	if [ "$candidate" -gt "$now_epoch" ]; then
+		candidate=$((candidate - 86400))
+	fi
+	printf '%s\n' "$candidate"
+}
+
+resolve_slot() {
+	local now_epoch="$1" hour="$2" max_delay="$3"
+	case "$hour" in
+	2 | 3) ;;
+	*)
+		echo 'slot_hour_utc must be 2 or 3' >&2
+		return 1
+		;;
+	esac
+	case "$max_delay" in
+	'' | *[!0-9]*)
+		echo 'MAX_TRIGGER_DELAY_SECONDS must be a non-negative integer' >&2
+		return 1
+		;;
+	esac
+	local slot_epoch delay pacific_hm pacific_weekday series target_ref duration
+	slot_epoch="$(utc_slot_epoch "$now_epoch" "$hour")"
+	delay=$((now_epoch - slot_epoch))
+	if [ "$delay" -gt "$max_delay" ]; then
+		printf 'scheduled invocation is %ss late; limit is %ss\n' "$delay" "$max_delay" >&2
+		return 1
+	fi
+	pacific_hm="$(epoch_format "$slot_epoch" America/Los_Angeles %H%M)"
+	pacific_weekday="$(epoch_format "$slot_epoch" America/Los_Angeles %u)"
+	if [ "$pacific_hm" != 1930 ] || [ "$pacific_weekday" -gt 5 ]; then
+		return 10
+	fi
+	if [ "$pacific_weekday" -eq 5 ]; then
+		series=weekend
+		target_ref=master
+		duration=weekend-60h
+	else
+		series=daily
+		target_ref=dev
+		duration=daily-24h
+	fi
+	printf '%s\t%s\t%s\t%s\n' "$slot_epoch" "$series" "$target_ref" "$duration"
+}
+
+base64url() {
+	openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+github_api() {
+	local method="$1" path="$2" token="$3" payload="${4:-}" response_file status
+	response_file="$(mktemp)"
+	TMP_FILES+=("$response_file")
+	local args=(
+		--silent --show-error
+		--output "$response_file"
+		--write-out '%{http_code}'
+		--request "$method"
+		--header 'Accept: application/vnd.github+json'
+		--header "Authorization: Bearer $token"
+		--header 'Content-Type: application/json'
+		--header "User-Agent: $USER_AGENT"
+		--header "X-GitHub-Api-Version: $API_VERSION"
+	)
+	if [ -n "$payload" ]; then
+		args+=(--data "$payload")
+	fi
+	status="$(curl "${args[@]}" "$API_ROOT$path")"
+	case "$status" in
+	200 | 201) cat "$response_file" ;;
+	204) printf '{}\n' ;;
+	*)
+		printf 'GitHub API %s %s failed with %s: ' "$method" "$path" "$status" >&2
+		head -c 1000 "$response_file" >&2
+		printf '\n' >&2
+		return 1
+		;;
+	esac
+}
+
+read_private_key() {
+	required_config GITHUB_APP_PRIVATE_KEY_SECRET_OCID
+	oci secrets secret-bundle get \
+		--auth resource_principal \
+		--secret-id "$GITHUB_APP_PRIVATE_KEY_SECRET_OCID" \
+		--stage CURRENT \
+		--query 'data."secret-bundle-content".content' \
+		--raw-output |
+		base64 -d
+}
+
+github_installation_token() {
+	local now_epoch="$1" private_key_file header claims signing_input signature app_jwt result token
+	required_config GITHUB_APP_ID
+	required_config GITHUB_APP_INSTALLATION_ID
+	private_key_file="$(mktemp)"
+	TMP_FILES+=("$private_key_file")
+	chmod 600 "$private_key_file"
+	read_private_key >"$private_key_file"
+	[ -s "$private_key_file" ] || {
+		echo 'OCI Vault returned an empty GitHub App private key' >&2
+		return 1
+	}
+	header="$(printf '%s' '{"alg":"RS256","typ":"JWT"}' | base64url)"
+	claims="$(jq -cn \
+		--argjson iat "$((now_epoch - 60))" \
+		--argjson exp "$((now_epoch + 540))" \
+		--arg iss "$GITHUB_APP_ID" \
+		'{iat:$iat,exp:$exp,iss:$iss}' |
+		base64url)"
+	signing_input="${header}.${claims}"
+	signature="$(printf '%s' "$signing_input" |
+		openssl dgst -sha256 -sign "$private_key_file" |
+		base64url)"
+	app_jwt="${signing_input}.${signature}"
+	result="$(github_api POST \
+		"/app/installations/${GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+		"$app_jwt" \
+		'{"permissions":{"actions":"write"}}')"
+	token="$(jq -er '.token | select(type == "string" and length > 0)' <<<"$result")"
+	printf '%s\n' "$token"
+}
+
+workflow_api_path() {
+	required_config GITHUB_REPOSITORY
+	required_config GITHUB_WORKFLOW
+	if ! [[ "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		echo 'GITHUB_REPOSITORY must have owner/repository form' >&2
+		return 1
+	fi
+	if ! [[ "$GITHUB_WORKFLOW" =~ ^[A-Za-z0-9_.-]+$ ]]; then
+		echo 'GITHUB_WORKFLOW must be a workflow file name' >&2
+		return 1
+	fi
+	printf '/repos/%s/actions/workflows/%s' "$GITHUB_REPOSITORY" "$GITHUB_WORKFLOW"
+}
+
+dispatch_slot() {
+	local token="$1" slot_epoch="$2" series="$3" target_ref="$4" duration="$5"
+	local workflow_path title runs payload
+	workflow_path="$(workflow_api_path)"
+	title="Merge Recovery Soak [scheduled:${slot_epoch}]"
+	runs="$(github_api GET "${workflow_path}/runs?event=workflow_dispatch&per_page=30" "$token")"
+	if jq -e --arg title "$title" '.workflow_runs[]? | select(.display_title == $title)' <<<"$runs" >/dev/null; then
+		jq -cn --argjson slot_epoch "$slot_epoch" --arg series "$series" \
+			'{status:"duplicate",slot_epoch:$slot_epoch,series:$series}'
+		return 0
+	fi
+	payload="$(jq -cn \
+		--arg ref "${GITHUB_WORKFLOW_REF:-master}" \
+		--arg target_ref "$target_ref" \
+		--arg duration "$duration" \
+		--arg slot_epoch "$slot_epoch" \
+		'{ref:$ref,inputs:{target_ref:$target_ref,duration:$duration,scheduled_slot_epoch:$slot_epoch}}')"
+	github_api POST "${workflow_path}/dispatches" "$token" "$payload" >/dev/null
+	jq -cn --argjson slot_epoch "$slot_epoch" --arg series "$series" \
+		'{status:"dispatched",slot_epoch:$slot_epoch,series:$series}'
+}
+
+main() {
+	local payload hour max_delay now_epoch slot status slot_epoch series target_ref duration token result pacific_slot
+	payload="$(cat)"
+	hour="$(jq -er '.slot_hour_utc | select(type == "number" and (. == 2 or . == 3))' <<<"$payload")" || {
+		echo 'slot_hour_utc must be 2 or 3' >&2
+		return 1
+	}
+	max_delay="${MAX_TRIGGER_DELAY_SECONDS:-900}"
+	now_epoch="${NOW_EPOCH:-$(date -u +%s)}"
+	set +e
+	slot="$(resolve_slot "$now_epoch" "$hour" "$max_delay")"
+	status=$?
+	set -e
+	if [ "$status" -eq 10 ]; then
+		jq -cn --argjson slot_hour_utc "$hour" '{status:"ineligible",slot_hour_utc:$slot_hour_utc}'
+		return 0
+	fi
+	[ "$status" -eq 0 ] || return "$status"
+	IFS=$'\t' read -r slot_epoch series target_ref duration <<<"$slot"
+	token="$(github_installation_token "$now_epoch")"
+	result="$(dispatch_slot "$token" "$slot_epoch" "$series" "$target_ref" "$duration")"
+	pacific_slot="$(epoch_format "$slot_epoch" America/Los_Angeles '%Y-%m-%dT%H:%M:%S%z')"
+	jq -c --arg pacific_slot "$pacific_slot" '. + {pacific_slot:$pacific_slot}' <<<"$result"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main
+fi

--- a/oci/soak-scheduler/handler.sh
+++ b/oci/soak-scheduler/handler.sh
@@ -68,7 +68,7 @@ resolve_slot() {
 	fi
 	pacific_hm="$(epoch_format "$slot_epoch" America/Los_Angeles %H%M)"
 	pacific_weekday="$(epoch_format "$slot_epoch" America/Los_Angeles %u)"
-	if [ "$pacific_hm" != 1930 ] || [ "$pacific_weekday" -gt 5 ]; then
+	if [ "$pacific_hm" != 1930 ] || [ "$pacific_weekday" -lt 1 ] || [ "$pacific_weekday" -gt 5 ]; then
 		return 10
 	fi
 	if [ "$pacific_weekday" -eq 5 ]; then
@@ -180,7 +180,7 @@ dispatch_slot() {
 	local workflow_path title runs payload
 	workflow_path="$(workflow_api_path)"
 	title="Merge Recovery Soak [scheduled:${slot_epoch}]"
-	runs="$(github_api GET "${workflow_path}/runs?event=workflow_dispatch&per_page=30" "$token")"
+	runs="$(github_api GET "${workflow_path}/runs?event=workflow_dispatch&per_page=100" "$token")"
 	if jq -e --arg title "$title" '.workflow_runs[]? | select(.display_title == $title)' <<<"$runs" >/dev/null; then
 		jq -cn --argjson slot_epoch "$slot_epoch" --arg series "$series" \
 			'{status:"duplicate",slot_epoch:$slot_epoch,series:$series}'

--- a/oci/soak-scheduler/test-handler.sh
+++ b/oci/soak-scheduler/test-handler.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source oci/soak-scheduler/handler.sh
+
+assert_slot() {
+	local now_epoch="$1" hour="$2" expected_series="$3" expected_ref="$4" result
+	result="$(resolve_slot "$now_epoch" "$hour" 900)"
+	IFS=$'\t' read -r _ series target_ref _ <<<"$result"
+	[ "$series" = "$expected_series" ]
+	[ "$target_ref" = "$expected_ref" ]
+}
+
+assert_ineligible() {
+	local now_epoch="$1" hour="$2" status
+	set +e
+	resolve_slot "$now_epoch" "$hour" 900 >/dev/null
+	status=$?
+	set -e
+	[ "$status" -eq 10 ]
+}
+
+assert_slot 1785551460 2 weekend master
+assert_ineligible 1785555060 3
+assert_slot 1796441460 3 weekend master
+assert_ineligible 1796437860 2
+assert_slot 1785810660 2 daily dev
+assert_ineligible 1785637860 2
+
+set +e
+resolve_slot 1785552361 2 900 >/dev/null 2>&1
+late_status=$?
+set -e
+[ "$late_status" -ne 0 ]
+
+export GITHUB_REPOSITORY=F1R3FLY-io/f1r3node-rust
+export GITHUB_WORKFLOW=merge-recovery-soak.yml
+export GITHUB_WORKFLOW_REF=master
+request_log="$(mktemp)"
+TMP_FILES+=("$request_log")
+mock_duplicate=false
+
+github_api() {
+	local method="$1" payload="${4:-}"
+	if [ "$method" = GET ]; then
+		if [ "$mock_duplicate" = true ]; then
+			printf '{"workflow_runs":[{"display_title":"Merge Recovery Soak [scheduled:300]"}]}\n'
+		else
+			printf '{"workflow_runs":[]}\n'
+		fi
+	else
+		printf '%s\n' "$payload" >>"$request_log"
+		printf '{}\n'
+	fi
+}
+
+daily_result="$(dispatch_slot token 100 daily dev daily-24h)"
+[ "$(jq -r .status <<<"$daily_result")" = dispatched ]
+[ "$(jq -r .inputs.target_ref <"$request_log")" = dev ]
+[ "$(jq -r .inputs.duration <"$request_log")" = daily-24h ]
+
+: >"$request_log"
+weekend_result="$(dispatch_slot token 200 weekend master weekend-60h)"
+[ "$(jq -r .series <<<"$weekend_result")" = weekend ]
+[ "$(jq -r .inputs.target_ref <"$request_log")" = master ]
+[ "$(jq -r .inputs.duration <"$request_log")" = weekend-60h ]
+
+: >"$request_log"
+mock_duplicate=true
+duplicate_result="$(dispatch_slot token 300 daily dev daily-24h)"
+[ "$(jq -r .status <<<"$duplicate_result")" = duplicate ]
+[ ! -s "$request_log" ]
+
+printf 'OCI soak scheduler Bash tests passed\n'

--- a/oci/soak-scheduler/test-handler.sh
+++ b/oci/soak-scheduler/test-handler.sh
@@ -20,12 +20,19 @@ assert_ineligible() {
 	[ "$status" -eq 10 ]
 }
 
-assert_slot 1785551460 2 weekend master
-assert_ineligible 1785555060 3
-assert_slot 1796441460 3 weekend master
-assert_ineligible 1796437860 2
-assert_slot 1785810660 2 daily dev
-assert_ineligible 1785637860 2
+pdt_friday_0231_utc=1785551460
+pdt_friday_0331_utc=1785555060
+pst_friday_0331_utc=1796441460
+pst_friday_0231_utc=1796437860
+pdt_monday_0231_utc=1785810660
+pdt_saturday_0231_utc=1785637860
+
+assert_slot "$pdt_friday_0231_utc" 2 weekend master
+assert_ineligible "$pdt_friday_0331_utc" 3
+assert_slot "$pst_friday_0331_utc" 3 weekend master
+assert_ineligible "$pst_friday_0231_utc" 2
+assert_slot "$pdt_monday_0231_utc" 2 daily dev
+assert_ineligible "$pdt_saturday_0231_utc" 2
 
 set +e
 resolve_slot 1785552361 2 900 >/dev/null 2>&1

--- a/scripts/oci/deploy-soak-scheduler.sh
+++ b/scripts/oci/deploy-soak-scheduler.sh
@@ -21,17 +21,41 @@ for command in docker git jq oci; do
 	}
 done
 
+config_value() {
+	local file="$1" profile="$2" key="$3"
+	[ -r "$file" ] || return 0
+	awk -F= -v profile="$profile" -v key="$key" '
+        /^[[:space:]]*\[/ {
+            section = $0
+            gsub(/^[[:space:]]*\[|\][[:space:]]*$/, "", section)
+            active = section == profile
+            next
+        }
+        active {
+            candidate = $1
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", candidate)
+            if (candidate == key) {
+                value = substr($0, index($0, "=") + 1)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+                print value
+                exit
+            }
+        }
+    ' "$file"
+}
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SOURCE="$ROOT/oci/soak-scheduler"
-OCI_REGION="${OCI_REGION:-$(awk -F= '$1 == "region" {gsub(/[[:space:]]/, "", $2); print $2; exit}' "$HOME/.oci/config")}"
 OCI_PROFILE="${OCI_PROFILE:-DEFAULT}"
+OCI_CONFIG_FILE="${OCI_CLI_CONFIG_FILE:-$HOME/.oci/config}"
+OCI_REGION="${OCI_REGION:-$(config_value "$OCI_CONFIG_FILE" "$OCI_PROFILE" region)}"
 OCIR_NAMESPACE="${OCIR_NAMESPACE:-$(oci os ns get --profile "$OCI_PROFILE" --query data --raw-output)}"
 OCIR_REPOSITORY="${OCIR_REPOSITORY:-f1r3node/soak-scheduler}"
 APPLICATION_NAME="${APPLICATION_NAME:-f1r3node-ci-schedulers}"
 FUNCTION_NAME="${FUNCTION_NAME:-f1r3node-soak-scheduler}"
 IMAGE_TAG="${IMAGE_TAG:-$(git -C "$ROOT" rev-parse --short=12 HEAD)}"
 IMAGE="${OCI_REGION}.ocir.io/${OCIR_NAMESPACE}/${OCIR_REPOSITORY}:${IMAGE_TAG}"
-TENANCY_OCID="${OCI_TENANCY_OCID:-$(awk -F= '$1 == "tenancy" {gsub(/[[:space:]]/, "", $2); print $2; exit}' "$HOME/.oci/config")}"
+TENANCY_OCID="${OCI_TENANCY_OCID:-$(config_value "$OCI_CONFIG_FILE" "$OCI_PROFILE" tenancy)}"
 SECRET_COMPARTMENT_OCID="${GITHUB_SECRET_COMPARTMENT_OCID:-$OCI_COMPARTMENT_OCID}"
 
 [ -n "$OCI_REGION" ] || {
@@ -68,15 +92,32 @@ application_id="$(oci fn application list \
 	--output json |
 	jq -r --arg name "$APPLICATION_NAME" '.data[] | select(."display-name" == $name and ."lifecycle-state" != "DELETED") | .id' |
 	head -1)"
+subnet_ids="$(jq -cn --arg id "$OCI_SUBNET_OCID" '[$id]')"
 if [ -z "$application_id" ]; then
-	subnet_ids="$(jq -cn --arg id "$OCI_SUBNET_OCID" '[$id]')"
 	application_id="$(oci fn application create \
 		--profile "$OCI_PROFILE" \
 		--compartment-id "$OCI_COMPARTMENT_OCID" \
 		--display-name "$APPLICATION_NAME" \
 		--subnet-ids "$subnet_ids" \
+		--wait-for-state ACTIVE \
 		--query data.id \
 		--raw-output)"
+else
+	application="$(oci fn application get \
+		--profile "$OCI_PROFILE" \
+		--application-id "$application_id" \
+		--output json)"
+	actual_subnet_ids="$(jq -c '.data."subnet-ids" | sort' <<<"$application")"
+	desired_subnet_ids="$(jq -c 'sort' <<<"$subnet_ids")"
+	if [ "$actual_subnet_ids" != "$desired_subnet_ids" ]; then
+		printf 'existing Function application %s uses subnet IDs %s; OCI cannot update application subnets in place, so recreate it with %s\n' \
+			"$application_id" "$actual_subnet_ids" "$desired_subnet_ids" >&2
+		exit 1
+	fi
+	if [ "$(jq -r '.data."lifecycle-state"' <<<"$application")" != ACTIVE ]; then
+		printf 'existing Function application %s is not ACTIVE\n' "$application_id" >&2
+		exit 1
+	fi
 fi
 
 function_config="$(jq -cn \
@@ -100,6 +141,7 @@ if [ -z "$function_id" ]; then
 		--memory-in-mbs 256 \
 		--timeout-in-seconds 120 \
 		--config "$function_config" \
+		--wait-for-state ACTIVE \
 		--query data.id \
 		--raw-output)"
 else
@@ -110,6 +152,7 @@ else
 		--memory-in-mbs 256 \
 		--timeout-in-seconds 120 \
 		--config "$function_config" \
+		--wait-for-state ACTIVE \
 		--force >/dev/null
 fi
 
@@ -192,13 +235,14 @@ upsert_dynamic_group "$schedule_02_group" "ALL {resource.type='resourceschedule'
 upsert_dynamic_group "$schedule_03_group" "ALL {resource.type='resourceschedule', resource.id='${schedule_03_id}'}" >/dev/null
 
 policy_name="f1r3node-soak-scheduler"
+secret_statement="Allow dynamic-group $function_group to read secret-bundles in compartment id $SECRET_COMPARTMENT_OCID"
+schedule_02_statement="Allow dynamic-group $schedule_02_group to use fn-invocation in compartment id $OCI_COMPARTMENT_OCID where target.function.id = '$function_id'"
+schedule_03_statement="Allow dynamic-group $schedule_03_group to use fn-invocation in compartment id $OCI_COMPARTMENT_OCID where target.function.id = '$function_id'"
 statements="$(jq -cn \
-	--arg function_group "$function_group" \
-	--arg schedule_02_group "$schedule_02_group" \
-	--arg schedule_03_group "$schedule_03_group" \
-	--arg function_compartment "$OCI_COMPARTMENT_OCID" \
-	--arg secret_compartment "$SECRET_COMPARTMENT_OCID" \
-	'["Allow dynamic-group \($function_group) to read secret-bundles in compartment id \($secret_compartment)","Allow dynamic-group \($schedule_02_group) to manage functions-family in compartment id \($function_compartment)","Allow dynamic-group \($schedule_03_group) to manage functions-family in compartment id \($function_compartment)"]')"
+	--arg secret "$secret_statement" \
+	--arg schedule_02 "$schedule_02_statement" \
+	--arg schedule_03 "$schedule_03_statement" \
+	'[$secret,$schedule_02,$schedule_03]')"
 policy_id="$(oci iam policy list \
 	--profile "$OCI_PROFILE" \
 	--compartment-id "$TENANCY_OCID" \

--- a/scripts/oci/deploy-soak-scheduler.sh
+++ b/scripts/oci/deploy-soak-scheduler.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required=(
+	OCI_COMPARTMENT_OCID
+	OCI_SUBNET_OCID
+	GITHUB_APP_ID
+	GITHUB_APP_INSTALLATION_ID
+	GITHUB_APP_PRIVATE_KEY_SECRET_OCID
+)
+for name in "${required[@]}"; do
+	if [ -z "${!name:-}" ]; then
+		printf '%s is required\n' "$name" >&2
+		exit 2
+	fi
+done
+for command in docker git jq oci; do
+	command -v "$command" >/dev/null || {
+		printf '%s is required\n' "$command" >&2
+		exit 2
+	}
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE="$ROOT/oci/soak-scheduler"
+OCI_REGION="${OCI_REGION:-$(awk -F= '$1 == "region" {gsub(/[[:space:]]/, "", $2); print $2; exit}' "$HOME/.oci/config")}"
+OCI_PROFILE="${OCI_PROFILE:-DEFAULT}"
+OCIR_NAMESPACE="${OCIR_NAMESPACE:-$(oci os ns get --profile "$OCI_PROFILE" --query data --raw-output)}"
+OCIR_REPOSITORY="${OCIR_REPOSITORY:-f1r3node/soak-scheduler}"
+APPLICATION_NAME="${APPLICATION_NAME:-f1r3node-ci-schedulers}"
+FUNCTION_NAME="${FUNCTION_NAME:-f1r3node-soak-scheduler}"
+IMAGE_TAG="${IMAGE_TAG:-$(git -C "$ROOT" rev-parse --short=12 HEAD)}"
+IMAGE="${OCI_REGION}.ocir.io/${OCIR_NAMESPACE}/${OCIR_REPOSITORY}:${IMAGE_TAG}"
+TENANCY_OCID="${OCI_TENANCY_OCID:-$(awk -F= '$1 == "tenancy" {gsub(/[[:space:]]/, "", $2); print $2; exit}' "$HOME/.oci/config")}"
+SECRET_COMPARTMENT_OCID="${GITHUB_SECRET_COMPARTMENT_OCID:-$OCI_COMPARTMENT_OCID}"
+
+[ -n "$OCI_REGION" ] || {
+	echo "OCI_REGION is required" >&2
+	exit 2
+}
+[ -n "$TENANCY_OCID" ] || {
+	echo "OCI_TENANCY_OCID is required" >&2
+	exit 2
+}
+
+repo_id="$(oci artifacts container repository list \
+	--profile "$OCI_PROFILE" \
+	--compartment-id "$OCI_COMPARTMENT_OCID" \
+	--all \
+	--output json |
+	jq -r --arg name "$OCIR_REPOSITORY" '.data.items[] | select(."display-name" == $name) | .id' |
+	head -1)"
+if [ -z "$repo_id" ]; then
+	oci artifacts container repository create \
+		--profile "$OCI_PROFILE" \
+		--compartment-id "$OCI_COMPARTMENT_OCID" \
+		--display-name "$OCIR_REPOSITORY" \
+		--is-public false >/dev/null
+fi
+
+docker build --platform linux/amd64 -t "$IMAGE" "$SOURCE"
+docker push "$IMAGE"
+
+application_id="$(oci fn application list \
+	--profile "$OCI_PROFILE" \
+	--compartment-id "$OCI_COMPARTMENT_OCID" \
+	--all \
+	--output json |
+	jq -r --arg name "$APPLICATION_NAME" '.data[] | select(."display-name" == $name and ."lifecycle-state" != "DELETED") | .id' |
+	head -1)"
+if [ -z "$application_id" ]; then
+	subnet_ids="$(jq -cn --arg id "$OCI_SUBNET_OCID" '[$id]')"
+	application_id="$(oci fn application create \
+		--profile "$OCI_PROFILE" \
+		--compartment-id "$OCI_COMPARTMENT_OCID" \
+		--display-name "$APPLICATION_NAME" \
+		--subnet-ids "$subnet_ids" \
+		--query data.id \
+		--raw-output)"
+fi
+
+function_config="$(jq -cn \
+	--arg app_id "$GITHUB_APP_ID" \
+	--arg installation_id "$GITHUB_APP_INSTALLATION_ID" \
+	--arg secret_ocid "$GITHUB_APP_PRIVATE_KEY_SECRET_OCID" \
+	'{GITHUB_REPOSITORY:"F1R3FLY-io/f1r3node-rust",GITHUB_WORKFLOW:"merge-recovery-soak.yml",GITHUB_WORKFLOW_REF:"master",GITHUB_APP_ID:$app_id,GITHUB_APP_INSTALLATION_ID:$installation_id,GITHUB_APP_PRIVATE_KEY_SECRET_OCID:$secret_ocid,MAX_TRIGGER_DELAY_SECONDS:"900"}')"
+function_id="$(oci fn function list \
+	--profile "$OCI_PROFILE" \
+	--application-id "$application_id" \
+	--all \
+	--output json |
+	jq -r --arg name "$FUNCTION_NAME" '.data[] | select(."display-name" == $name and ."lifecycle-state" != "DELETED") | .id' |
+	head -1)"
+if [ -z "$function_id" ]; then
+	function_id="$(oci fn function create \
+		--profile "$OCI_PROFILE" \
+		--application-id "$application_id" \
+		--display-name "$FUNCTION_NAME" \
+		--image "$IMAGE" \
+		--memory-in-mbs 256 \
+		--timeout-in-seconds 120 \
+		--config "$function_config" \
+		--query data.id \
+		--raw-output)"
+else
+	oci fn function update \
+		--profile "$OCI_PROFILE" \
+		--function-id "$function_id" \
+		--image "$IMAGE" \
+		--memory-in-mbs 256 \
+		--timeout-in-seconds 120 \
+		--config "$function_config" \
+		--force >/dev/null
+fi
+
+create_schedule() {
+	local hour="$1" name schedule_id resources
+	name="f1r3node-soak-${hour}30-utc"
+	resources="$(jq -cn \
+		--arg id "$function_id" \
+		--argjson hour "$hour" \
+		'[{id:$id,metadata:{resourceType:"FunctionsFunction"},parameters:[{parameterType:"BODY",value:{slot_hour_utc:$hour}}]}]')"
+	schedule_id="$(oci resource-scheduler schedule list \
+		--profile "$OCI_PROFILE" \
+		--compartment-id "$OCI_COMPARTMENT_OCID" \
+		--all \
+		--output json |
+		jq -r --arg name "$name" '.data.items[] | select(."display-name" == $name and ."lifecycle-state" != "DELETED") | .id' |
+		head -1)"
+	if [ -z "$schedule_id" ]; then
+		schedule_id="$(oci resource-scheduler schedule create \
+			--profile "$OCI_PROFILE" \
+			--compartment-id "$OCI_COMPARTMENT_OCID" \
+			--display-name "$name" \
+			--description "Dispatch the F1R3node merge recovery soak at the eligible Pacific slot" \
+			--action START_RESOURCE \
+			--recurrence-type CRON \
+			--recurrence-details "30 ${hour} * * *" \
+			--resources "$resources" \
+			--freeform-tags '{"managed-by":"f1r3node-rust"}' \
+			--query data.id \
+			--raw-output)"
+	else
+		oci resource-scheduler schedule update \
+			--profile "$OCI_PROFILE" \
+			--schedule-id "$schedule_id" \
+			--action START_RESOURCE \
+			--recurrence-type CRON \
+			--recurrence-details "30 ${hour} * * *" \
+			--resources "$resources" \
+			--force >/dev/null
+	fi
+	printf '%s\n' "$schedule_id"
+}
+
+schedule_02_id="$(create_schedule 2)"
+schedule_03_id="$(create_schedule 3)"
+
+upsert_dynamic_group() {
+	local name="$1" rule="$2" id
+	id="$(oci iam dynamic-group list \
+		--profile "$OCI_PROFILE" \
+		--compartment-id "$TENANCY_OCID" \
+		--all \
+		--output json |
+		jq -r --arg name "$name" '.data[] | select(.name == $name and ."lifecycle-state" != "DELETED") | .id' |
+		head -1)"
+	if [ -z "$id" ]; then
+		id="$(oci iam dynamic-group create \
+			--profile "$OCI_PROFILE" \
+			--compartment-id "$TENANCY_OCID" \
+			--name "$name" \
+			--description "$name" \
+			--matching-rule "$rule" \
+			--query data.id \
+			--raw-output)"
+	else
+		oci iam dynamic-group update \
+			--profile "$OCI_PROFILE" \
+			--dynamic-group-id "$id" \
+			--matching-rule "$rule" \
+			--force >/dev/null
+	fi
+	printf '%s\n' "$id"
+}
+
+function_group="f1r3node_soak_scheduler_function"
+schedule_02_group="f1r3node_soak_scheduler_02"
+schedule_03_group="f1r3node_soak_scheduler_03"
+upsert_dynamic_group "$function_group" "ALL {resource.type='fnfunc', resource.id='${function_id}'}" >/dev/null
+upsert_dynamic_group "$schedule_02_group" "ALL {resource.type='resourceschedule', resource.id='${schedule_02_id}'}" >/dev/null
+upsert_dynamic_group "$schedule_03_group" "ALL {resource.type='resourceschedule', resource.id='${schedule_03_id}'}" >/dev/null
+
+policy_name="f1r3node-soak-scheduler"
+statements="$(jq -cn \
+	--arg function_group "$function_group" \
+	--arg schedule_02_group "$schedule_02_group" \
+	--arg schedule_03_group "$schedule_03_group" \
+	--arg function_compartment "$OCI_COMPARTMENT_OCID" \
+	--arg secret_compartment "$SECRET_COMPARTMENT_OCID" \
+	'["Allow dynamic-group \($function_group) to read secret-bundles in compartment id \($secret_compartment)","Allow dynamic-group \($schedule_02_group) to manage functions-family in compartment id \($function_compartment)","Allow dynamic-group \($schedule_03_group) to manage functions-family in compartment id \($function_compartment)"]')"
+policy_id="$(oci iam policy list \
+	--profile "$OCI_PROFILE" \
+	--compartment-id "$TENANCY_OCID" \
+	--all \
+	--output json |
+	jq -r --arg name "$policy_name" '.data[] | select(.name == $name and ."lifecycle-state" != "DELETED") | .id' |
+	head -1)"
+if [ -z "$policy_id" ]; then
+	policy_id="$(oci iam policy create \
+		--profile "$OCI_PROFILE" \
+		--compartment-id "$TENANCY_OCID" \
+		--name "$policy_name" \
+		--description "$policy_name" \
+		--statements "$statements" \
+		--query data.id \
+		--raw-output)"
+else
+	oci iam policy update \
+		--profile "$OCI_PROFILE" \
+		--policy-id "$policy_id" \
+		--statements "$statements" \
+		--force >/dev/null
+fi
+
+jq -n \
+	--arg image "$IMAGE" \
+	--arg application_id "$application_id" \
+	--arg function_id "$function_id" \
+	--arg schedule_02_id "$schedule_02_id" \
+	--arg schedule_03_id "$schedule_03_id" \
+	--arg policy_id "$policy_id" \
+	'{image:$image,application_id:$application_id,function_id:$function_id,schedules:[$schedule_02_id,$schedule_03_id],policy_id:$policy_id}'

--- a/scripts/restart-soak.sh
+++ b/scripts/restart-soak.sh
@@ -8,11 +8,11 @@
 # is excluded from baseline duty — a short manual run must never become the
 # baseline a full-window run is judged against. It also cannot spill into the
 # next scheduled slot: the run ends at the window end you choose, and the
-# next cron slot proceeds normally.
+# next OCI Resource Scheduler slot proceeds normally.
 #
 #   scripts/restart-soak.sh --last-failed
-#       Find the most recent FAILED scheduled soak run, recompute the window
-#       its cron slot defined (Fri 19:30 Pacific + 60h = weekend, Mon-Thu
+#       Find the most recent FAILED OCI-scheduled soak run, recompute the window
+#       its recorded slot defined (Fri 19:30 Pacific + 60h = weekend, Mon-Thu
 #       19:30 Pacific + 22h = daily), and restart for whatever remains of it.
 #
 #   scripts/restart-soak.sh --series daily --until-next-slot
@@ -25,7 +25,7 @@
 #
 # Options:
 #   --last-failed          derive series/target/window from the latest failed
-#                          scheduled run (mutually exclusive with the rest)
+#                          OCI-scheduled run (mutually exclusive with the rest)
 #   --series X             daily | weekend
 #   --target-ref R         branch/SHA to soak (default: dev for daily,
 #                          master for weekend — matching the schedule gate)
@@ -52,16 +52,25 @@ NEXT_SLOT_MARGIN=1800
 
 usage() { sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; }
 
-command -v gh >/dev/null || { echo "gh CLI not found" >&2; exit 2; }
-command -v python3 >/dev/null || { echo "python3 not found (needed for Pacific-time window maths)" >&2; exit 2; }
-command -v jq >/dev/null || { echo "jq not found" >&2; exit 2; }
+command -v gh >/dev/null || {
+	echo "gh CLI not found" >&2
+	exit 2
+}
+command -v python3 >/dev/null || {
+	echo "python3 not found (needed for Pacific-time window maths)" >&2
+	exit 2
+}
+command -v jq >/dev/null || {
+	echo "jq not found" >&2
+	exit 2
+}
 
 py() { python3 - "$@"; }
 
 # Prints "<slot_epoch> <series>" for the 19:30 Pacific slot at or before the
 # given epoch — the slot that launched a scheduled run created at that time.
 slot_before() {
-  py "$1" <<'PY'
+	py "$1" <<'PY'
 import sys
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -76,7 +85,7 @@ PY
 }
 
 next_slot_epoch() {
-  py <<'PY'
+	py <<'PY'
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 tz = ZoneInfo("America/Los_Angeles")
@@ -89,7 +98,7 @@ PY
 }
 
 pacific() {
-  py "$1" <<'PY'
+	py "$1" <<'PY'
 import sys
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -107,87 +116,126 @@ DRY_RUN=false
 ASSUME_YES=false
 
 while [ $# -gt 0 ]; do
-  case "$1" in
-    --last-failed) LAST_FAILED=true ;;
-    --series) SERIES="${2:?--series needs a value}"; shift ;;
-    --target-ref) TARGET_REF="${2:?--target-ref needs a value}"; shift ;;
-    --window-end) WINDOW_END="${2:?--window-end needs a value}"; shift ;;
-    --until-next-slot) UNTIL_NEXT_SLOT=true ;;
-    --hours) HOURS="${2:?--hours needs a value}"; shift ;;
-    --dry-run) DRY_RUN=true ;;
-    --yes) ASSUME_YES=true ;;
-    -h|--help) usage; exit 0 ;;
-    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
-  esac
-  shift
+	case "$1" in
+	--last-failed) LAST_FAILED=true ;;
+	--series)
+		SERIES="${2:?--series needs a value}"
+		shift
+		;;
+	--target-ref)
+		TARGET_REF="${2:?--target-ref needs a value}"
+		shift
+		;;
+	--window-end)
+		WINDOW_END="${2:?--window-end needs a value}"
+		shift
+		;;
+	--until-next-slot) UNTIL_NEXT_SLOT=true ;;
+	--hours)
+		HOURS="${2:?--hours needs a value}"
+		shift
+		;;
+	--dry-run) DRY_RUN=true ;;
+	--yes) ASSUME_YES=true ;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "unknown argument: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
 done
 
 NOW="$(date +%s)"
 
 if [ "$LAST_FAILED" = "true" ]; then
-  if [ -n "$SERIES$TARGET_REF$WINDOW_END$HOURS" ] || [ "$UNTIL_NEXT_SLOT" = "true" ]; then
-    echo "--last-failed derives everything itself; do not combine it with other selectors" >&2
-    exit 2
-  fi
-  # Only scheduled runs: their window is defined by the cron slot, which can
-  # be recomputed from the run's creation time. A dispatched run's window
-  # lives in its inputs, which the API does not expose.
-  failed="$(gh run list --repo "$REPO_SLUG" --workflow "$WORKFLOW" \
-      --status failure --limit 30 \
-      --json databaseId,createdAt,event,url \
-    | jq -r '[.[] | select(.event == "schedule")][0] // empty
-             | "\(.databaseId)\t\(.createdAt)\t\(.url)"')"
-  [ -n "$failed" ] || { echo "no failed scheduled soak run found" >&2; exit 1; }
-  run_id="${failed%%$'\t'*}"
-  rest="${failed#*$'\t'}"
-  created_at="${rest%%$'\t'*}"
-  run_url="${rest#*$'\t'}"
-  created_epoch="$(py "$created_at" <<'PY'
+	if [ -n "$SERIES$TARGET_REF$WINDOW_END$HOURS" ] || [ "$UNTIL_NEXT_SLOT" = "true" ]; then
+		echo "--last-failed derives everything itself; do not combine it with other selectors" >&2
+		exit 2
+	fi
+	failed="$(gh run list --repo "$REPO_SLUG" --workflow "$WORKFLOW" \
+		--status failure --limit 30 \
+		--json databaseId,createdAt,displayTitle,event,url |
+		jq -r '[.[] | select(.event == "schedule" or (.displayTitle | test("^Merge Recovery Soak \\[scheduled:[0-9]+\\]$")))][0] // empty
+             | "\(.databaseId)\t\(.createdAt)\t\(.displayTitle)\t\(.url)"')"
+	[ -n "$failed" ] || {
+		echo "no failed OCI-scheduled soak run found" >&2
+		exit 1
+	}
+	run_id="${failed%%$'\t'*}"
+	rest="${failed#*$'\t'}"
+	created_at="${rest%%$'\t'*}"
+	rest="${rest#*$'\t'}"
+	display_title="${rest%%$'\t'*}"
+	run_url="${rest#*$'\t'}"
+	if [[ "$display_title" =~ \[scheduled:([0-9]+)\] ]]; then
+		slot_epoch="${BASH_REMATCH[1]}"
+	else
+		created_epoch="$(
+			py "$created_at" <<'PY'
 import sys
 from datetime import datetime
 print(int(datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00")).timestamp()))
 PY
-)"
-  read -r slot_epoch SERIES <<<"$(slot_before "$created_epoch")"
-  if [ "$SERIES" = "weekend" ]; then
-    WINDOW_END=$((slot_epoch + 216000))
-    TARGET_REF="master"
-  else
-    WINDOW_END=$((slot_epoch + 79200))
-    TARGET_REF="dev"
-  fi
-  echo "latest failed scheduled run: $run_id ($run_url)"
-  echo "  slot:   $(pacific "$slot_epoch") -> $SERIES"
+		)"
+		read -r slot_epoch _ <<<"$(slot_before "$created_epoch")"
+	fi
+	read -r _ SERIES <<<"$(slot_before "$slot_epoch")"
+	if [ "$SERIES" = "weekend" ]; then
+		WINDOW_END=$((slot_epoch + 216000))
+		TARGET_REF="master"
+	else
+		WINDOW_END=$((slot_epoch + 79200))
+		TARGET_REF="dev"
+	fi
+	echo "latest failed scheduled run: $run_id ($run_url)"
+	echo "  slot:   $(pacific "$slot_epoch") -> $SERIES"
 else
-  case "$SERIES" in
-    daily|weekend) ;;
-    "") echo "--series is required (daily | weekend) unless using --last-failed" >&2; exit 2 ;;
-    *) echo "--series must be daily or weekend" >&2; exit 2 ;;
-  esac
-  if [ -z "$TARGET_REF" ]; then
-    TARGET_REF="dev"
-    [ "$SERIES" = "weekend" ] && TARGET_REF="master"
-  fi
-  ends=0
-  [ -n "$WINDOW_END" ] && ends=$((ends + 1))
-  [ -n "$HOURS" ] && ends=$((ends + 1))
-  [ "$UNTIL_NEXT_SLOT" = "true" ] && ends=$((ends + 1))
-  if [ "$ends" -ne 1 ]; then
-    echo "pick exactly one of --window-end, --hours, --until-next-slot" >&2
-    exit 2
-  fi
-  if [ "$UNTIL_NEXT_SLOT" = "true" ]; then
-    WINDOW_END=$(( $(next_slot_epoch) - NEXT_SLOT_MARGIN ))
-  elif [ -n "$HOURS" ]; then
-    [[ "$HOURS" =~ ^[1-9][0-9]*$ ]] || { echo "--hours must be a positive integer" >&2; exit 2; }
-    WINDOW_END=$((NOW + HOURS * 3600))
-  fi
-  [[ "$WINDOW_END" =~ ^[1-9][0-9]*$ ]] || { echo "--window-end must be epoch seconds" >&2; exit 2; }
+	case "$SERIES" in
+	daily | weekend) ;;
+	"")
+		echo "--series is required (daily | weekend) unless using --last-failed" >&2
+		exit 2
+		;;
+	*)
+		echo "--series must be daily or weekend" >&2
+		exit 2
+		;;
+	esac
+	if [ -z "$TARGET_REF" ]; then
+		TARGET_REF="dev"
+		[ "$SERIES" = "weekend" ] && TARGET_REF="master"
+	fi
+	ends=0
+	[ -n "$WINDOW_END" ] && ends=$((ends + 1))
+	[ -n "$HOURS" ] && ends=$((ends + 1))
+	[ "$UNTIL_NEXT_SLOT" = "true" ] && ends=$((ends + 1))
+	if [ "$ends" -ne 1 ]; then
+		echo "pick exactly one of --window-end, --hours, --until-next-slot" >&2
+		exit 2
+	fi
+	if [ "$UNTIL_NEXT_SLOT" = "true" ]; then
+		WINDOW_END=$(($(next_slot_epoch) - NEXT_SLOT_MARGIN))
+	elif [ -n "$HOURS" ]; then
+		[[ "$HOURS" =~ ^[1-9][0-9]*$ ]] || {
+			echo "--hours must be a positive integer" >&2
+			exit 2
+		}
+		WINDOW_END=$((NOW + HOURS * 3600))
+	fi
+	[[ "$WINDOW_END" =~ ^[1-9][0-9]*$ ]] || {
+		echo "--window-end must be epoch seconds" >&2
+		exit 2
+	}
 fi
 
 case "$SERIES" in
-  daily) WINDOW_NOMINAL=79200 ;;
-  weekend) WINDOW_NOMINAL=216000 ;;
+daily) WINDOW_NOMINAL=79200 ;;
+weekend) WINDOW_NOMINAL=216000 ;;
 esac
 
 REMAINING=$((WINDOW_END - NOW))
@@ -203,19 +251,19 @@ REMAINING=$((WINDOW_END - NOW))
 # intent and still ends before the slot. An explicit --hours/--window-end is
 # rejected instead, because the operator named a span we cannot honour.
 if [ "$REMAINING" -gt "$WINDOW_NOMINAL" ]; then
-  if [ "$UNTIL_NEXT_SLOT" = "true" ]; then
-    echo "note: $((REMAINING / 3600))h to the next slot exceeds the ${SERIES} window ($((WINDOW_NOMINAL / 3600))h); capping"
-    WINDOW_END=$((NOW + WINDOW_NOMINAL))
-    REMAINING="$WINDOW_NOMINAL"
-  else
-    echo "window is ${REMAINING}s, beyond the ${WINDOW_NOMINAL}s ${SERIES} window; the gate would refuse it. A restart can only shorten the window it inherits." >&2
-    exit 1
-  fi
+	if [ "$UNTIL_NEXT_SLOT" = "true" ]; then
+		echo "note: $((REMAINING / 3600))h to the next slot exceeds the ${SERIES} window ($((WINDOW_NOMINAL / 3600))h); capping"
+		WINDOW_END=$((NOW + WINDOW_NOMINAL))
+		REMAINING="$WINDOW_NOMINAL"
+	else
+		echo "window is ${REMAINING}s, beyond the ${WINDOW_NOMINAL}s ${SERIES} window; the gate would refuse it. A restart can only shorten the window it inherits." >&2
+		exit 1
+	fi
 fi
 
 if [ "$REMAINING" -lt "$FLOOR_SECONDS" ]; then
-  echo "only ${REMAINING}s remain before $(pacific "$WINDOW_END") — under the 2h floor; the gate would refuse, so not dispatching" >&2
-  exit 1
+	echo "only ${REMAINING}s remain before $(pacific "$WINDOW_END") — under the 2h floor; the gate would refuse, so not dispatching" >&2
+	exit 1
 fi
 
 DURATION="daily-24h"
@@ -228,23 +276,27 @@ echo "  window ends: $(pacific "$WINDOW_END") (~$((REMAINING / 3600))h from now)
 echo "  marked:      restarted (retry_attempt=1; excluded from baselines)"
 
 CMD=(gh workflow run "$WORKFLOW" --repo "$REPO_SLUG"
-  -f "target_ref=$TARGET_REF"
-  -f "duration=$DURATION"
-  -f "window_end_epoch=$WINDOW_END"
-  -f "series=$SERIES"
-  -f "retry_attempt=1")
+	-f "target_ref=$TARGET_REF"
+	-f "duration=$DURATION"
+	-f "window_end_epoch=$WINDOW_END"
+	-f "series=$SERIES"
+	-f "retry_attempt=1")
 
 if [ "$DRY_RUN" = "true" ]; then
-  printf 'dry run — would execute:\n  %q' "${CMD[0]}"
-  printf ' %q' "${CMD[@]:1}"
-  printf '\n'
-  exit 0
+	printf 'dry run — would execute:\n  %q' "${CMD[0]}"
+	printf ' %q' "${CMD[@]:1}"
+	printf '\n'
+	exit 0
 fi
 
 if [ "$ASSUME_YES" != "true" ]; then
-  printf 'dispatch this run? [y/N] '
-  read -r answer
-  case "$answer" in y|Y|yes|YES) ;; *) echo "aborted"; exit 1 ;; esac
+	printf 'dispatch this run? [y/N] '
+	read -r answer
+	case "$answer" in y | Y | yes | YES) ;; *)
+		echo "aborted"
+		exit 1
+		;;
+	esac
 fi
 
 "${CMD[@]}"


### PR DESCRIPTION
- replace delayed GitHub cron events with DST-aware OCI scheduling
- add a Bash OCI Function and idempotent deployment automation
- route daily and weekend series while preserving restart behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788178633&installation_model_id=426883&pr_number=187&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F187&signature=1a2ed4750083c46e03c3d3487339bc342858dea16f15d243718dcc41a3ffbff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->