### PR TITLE
hotfix(ci): restore soak checkpoint publishing

### DIFF
--- a/.github/actions/soak-segment/action.yml
+++ b/.github/actions/soak-segment/action.yml
@@ -235,39 +235,47 @@ runs:
         ARTIFACT: soak-checkpoint-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.label }}
         KIND: ${{ inputs.kind }}
         REPO: ${{ github.repository }}
-        REF: ${{ github.ref_name }}
+        REF: ${{ github.event.repository.default_branch }}
       shell: bash -euo pipefail {0}
       run: |
         # Fail-soft, deliberately. A checkpoint is a convenience; the run's real
         # result is published at the end regardless. Losing a mid-run update
         # must never take down a soak that is otherwise healthy, so a failure
         # here is a warning and the next segment starts anyway.
-        payload="$(jq -cn \
-          --arg ref "$REF" \
-          --arg run_id "$GITHUB_RUN_ID" \
-          --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
-          --arg artifact "$ARTIFACT" \
-          --arg kind "$KIND" \
-          '{ref:$ref,inputs:{run_id:$run_id,run_attempt:$run_attempt,artifact:$artifact,kind:$kind}}')"
-        response="$(mktemp)"
-        status=000
-        if ! status="$(curl --silent --show-error \
-          --output "$response" \
-          --write-out '%{http_code}' \
-          --request POST \
-          --header 'Accept: application/vnd.github+json' \
-          --header "Authorization: Bearer $GH_TOKEN" \
-          --header 'Content-Type: application/json' \
-          --header 'X-GitHub-Api-Version: 2022-11-28' \
-          --data "$payload" \
-          "https://api.github.com/repos/${REPO}/actions/workflows/soak-checkpoint-publish.yml/dispatches")"; then
-          status=000
+        dispatch_checkpoint() {
+          local payload response http_status api_message
+          [ -n "${GH_TOKEN:-}" ] || return 1
+          payload="$(jq -cn \
+            --arg ref "$REF" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg artifact "$ARTIFACT" \
+            --arg kind "$KIND" \
+            '{ref:$ref,inputs:{run_id:$run_id,run_attempt:$run_attempt,artifact:$artifact,kind:$kind}}')" || return 1
+          response="$(mktemp)" || return 1
+          http_status=000
+          if ! http_status="$(curl --silent --show-error \
+            --output "$response" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Content-Type: application/json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            --data "$payload" \
+            "https://api.github.com/repos/${REPO}/actions/workflows/soak-checkpoint-publish.yml/dispatches")"; then
+            http_status=000
+          fi
+          if [ "$http_status" = 204 ]; then
+            rm -f "$response"
+            echo "checkpoint publish dispatched for ${ARTIFACT}"
+            return 0
+          fi
+          api_message="$(jq -r '.message? // empty | strings | gsub("[\\r\\n]"; " ")' "$response" 2>/dev/null || true)"
+          rm -f "$response"
+          echo "::warning::checkpoint publish dispatch failed with HTTP ${http_status}; the soak continues and its final result still publishes normally"
+          [ -z "$api_message" ] || echo "::notice::GitHub API response: ${api_message}"
+        }
+        if ! dispatch_checkpoint; then
+          echo "::warning::checkpoint publish setup failed; the soak continues and its final result still publishes normally"
         fi
-        if [ "$status" = 204 ]; then
-          echo "checkpoint publish dispatched for ${ARTIFACT}"
-        else
-          echo "::warning::checkpoint publish dispatch failed with HTTP ${status}; the soak continues and its final result still publishes normally"
-          head -c 1000 "$response"
-          echo
-        fi
-        rm -f "$response"

--- a/.github/actions/soak-segment/action.yml
+++ b/.github/actions/soak-segment/action.yml
@@ -234,18 +234,40 @@ runs:
         # containing shell metacharacters would execute rather than be quoted.
         ARTIFACT: soak-checkpoint-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.label }}
         KIND: ${{ inputs.kind }}
+        REPO: ${{ github.repository }}
+        REF: ${{ github.ref_name }}
       shell: bash -euo pipefail {0}
       run: |
         # Fail-soft, deliberately. A checkpoint is a convenience; the run's real
         # result is published at the end regardless. Losing a mid-run update
         # must never take down a soak that is otherwise healthy, so a failure
         # here is a warning and the next segment starts anyway.
-        if gh workflow run soak-checkpoint-publish.yml \
-             --field run_id="${GITHUB_RUN_ID}" \
-             --field run_attempt="${GITHUB_RUN_ATTEMPT}" \
-             --field artifact="${ARTIFACT}" \
-             --field kind="${KIND}"; then
+        payload="$(jq -cn \
+          --arg ref "$REF" \
+          --arg run_id "$GITHUB_RUN_ID" \
+          --arg run_attempt "$GITHUB_RUN_ATTEMPT" \
+          --arg artifact "$ARTIFACT" \
+          --arg kind "$KIND" \
+          '{ref:$ref,inputs:{run_id:$run_id,run_attempt:$run_attempt,artifact:$artifact,kind:$kind}}')"
+        response="$(mktemp)"
+        status=000
+        if ! status="$(curl --silent --show-error \
+          --output "$response" \
+          --write-out '%{http_code}' \
+          --request POST \
+          --header 'Accept: application/vnd.github+json' \
+          --header "Authorization: Bearer $GH_TOKEN" \
+          --header 'Content-Type: application/json' \
+          --header 'X-GitHub-Api-Version: 2022-11-28' \
+          --data "$payload" \
+          "https://api.github.com/repos/${REPO}/actions/workflows/soak-checkpoint-publish.yml/dispatches")"; then
+          status=000
+        fi
+        if [ "$status" = 204 ]; then
           echo "checkpoint publish dispatched for ${ARTIFACT}"
         else
-          echo "::warning::could not dispatch the checkpoint publish for ${ARTIFACT}; the soak continues and its final result still publishes normally"
+          echo "::warning::checkpoint publish dispatch failed with HTTP ${status}; the soak continues and its final result still publishes normally"
+          head -c 1000 "$response"
+          echo
         fi
+        rm -f "$response"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/check-workflow-invariants.sh
 
+      - name: Verify soak summary aggregation
+        shell: bash -euo pipefail {0}
+        run: scripts/bench/test-write-soak-summary.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/scripts/bench/test-write-soak-summary.sh
+++ b/scripts/bench/test-write-soak-summary.sh
@@ -4,23 +4,28 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
-mkdir -p "$TMP/iteration-00001-docker" "$TMP/iteration-00002-subprocess"
-printf '%s\n' '{"iteration":1,"provider":"docker","duration_s":60,"ok":false,"rss_peak_mb":15580,"cpu_peak_pct":42.5,"finalization_latency":{"p50_ms":100,"p95_ms":200,"p99_ms":300},"too_far_ahead_errors":2,"metrics":{"lfb_spread":{"p50":3,"samples":4}}}' >"$TMP/iteration-00001-docker/metrics.json"
-printf '%s\n' '{"iteration":2,"provider":"subprocess","duration_s":120,"ok":false,"rss_peak_mb":null,"finalization_latency":{},"metrics":{}}' >"$TMP/iteration-00002-subprocess/metrics.json"
+write_summary() {
+	local output_dir="$1" iterations="$2" failures="$3"
+	SOAK_OUTPUT_DIR="$output_dir" \
+		SOAK_METRICS_REGISTRY="$ROOT/scripts/bench/soak-metrics.json" \
+		SOAK_TARGET_REF=dev \
+		SOAK_TARGET_SHA=1086923fb257407baa2e15ce57841987503dbbb5 \
+		SOAK_VERSION=0.4.42 \
+		SOAK_STARTED_AT=1000 \
+		SOAK_FINISHED_AT=1180 \
+		SOAK_DURATION_SECONDS=3600 \
+		SOAK_ITERATIONS="$iterations" \
+		SOAK_FAILURES="$failures" \
+		SOAK_BENCH_SEGMENTS=1 \
+		SOAK_BENCH_FAILURES=1 \
+		"$ROOT/scripts/bench/write-soak-summary.sh"
+}
 
-SOAK_OUTPUT_DIR="$TMP" \
-	SOAK_METRICS_REGISTRY="$ROOT/scripts/bench/soak-metrics.json" \
-	SOAK_TARGET_REF=dev \
-	SOAK_TARGET_SHA=1086923fb257407baa2e15ce57841987503dbbb5 \
-	SOAK_VERSION=0.4.42 \
-	SOAK_STARTED_AT=1000 \
-	SOAK_FINISHED_AT=1180 \
-	SOAK_DURATION_SECONDS=3600 \
-	SOAK_ITERATIONS=2 \
-	SOAK_FAILURES=2 \
-	SOAK_BENCH_SEGMENTS=1 \
-	SOAK_BENCH_FAILURES=1 \
-	"$ROOT/scripts/bench/write-soak-summary.sh"
+BASE="$TMP/base"
+mkdir -p "$BASE/iteration-00001-docker" "$BASE/iteration-00002-subprocess"
+printf '%s\n' '{"iteration":1,"provider":"docker","duration_s":60,"ok":false,"rss_peak_mb":15580,"cpu_peak_pct":42.5,"finalization_latency":{"p50_ms":100,"p95_ms":200,"p99_ms":300},"too_far_ahead_errors":2,"metrics":{"lfb_spread":{"p50":3,"samples":4}}}' >"$BASE/iteration-00001-docker/metrics.json"
+printf '%s\n' '{"iteration":2,"provider":"subprocess","duration_s":120,"ok":false,"rss_peak_mb":null,"finalization_latency":{},"metrics":{}}' >"$BASE/iteration-00002-subprocess/metrics.json"
+write_summary "$BASE" 2 2
 
 jq -e '
   .target_ref == "dev"
@@ -35,6 +40,29 @@ jq -e '
   and .tracked_metrics.lfb_spread.p95 == null
   and .tracked_metrics.lfb_spread.max == null
   and .tracked_metrics.lfb_spread.samples == 4
-' "$TMP/summary.json" >/dev/null
+' "$BASE/summary.json" >/dev/null
+
+EMPTY="$TMP/empty"
+mkdir -p "$EMPTY"
+write_summary "$EMPTY" 0 0
+jq -e '
+  .rss_peak_mb == null
+  and .cpu_peak_pct == null
+  and .tracked_metrics == {}
+  and .iteration_metrics == []
+' "$EMPTY/summary.json" >/dev/null
+
+SPARSE="$TMP/sparse"
+mkdir -p "$SPARSE/iteration-00001-docker"
+printf '%s\n' '{"iteration":1,"provider":"docker","ok":true,"rss_peak_mb":null,"metrics":{"lfb_spread":{"samples":2}}}' >"$SPARSE/iteration-00001-docker/metrics.json"
+write_summary "$SPARSE" 1 0
+jq -e '
+  .rss_peak_mb == null
+  and .cpu_peak_pct == null
+  and .tracked_metrics.lfb_spread.p50 == null
+  and .tracked_metrics.lfb_spread.p95 == null
+  and .tracked_metrics.lfb_spread.max == null
+  and .tracked_metrics.lfb_spread.samples == 2
+' "$SPARSE/summary.json" >/dev/null
 
 printf 'soak summary writer tests passed\n'

--- a/scripts/bench/test-write-soak-summary.sh
+++ b/scripts/bench/test-write-soak-summary.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/iteration-00001-docker" "$TMP/iteration-00002-subprocess"
+printf '%s\n' '{"iteration":1,"provider":"docker","duration_s":60,"ok":false,"rss_peak_mb":15580,"cpu_peak_pct":42.5,"finalization_latency":{"p50_ms":100,"p95_ms":200,"p99_ms":300},"too_far_ahead_errors":2,"metrics":{"lfb_spread":{"p50":3,"samples":4}}}' >"$TMP/iteration-00001-docker/metrics.json"
+printf '%s\n' '{"iteration":2,"provider":"subprocess","duration_s":120,"ok":false,"rss_peak_mb":null,"finalization_latency":{},"metrics":{}}' >"$TMP/iteration-00002-subprocess/metrics.json"
+
+SOAK_OUTPUT_DIR="$TMP" \
+	SOAK_METRICS_REGISTRY="$ROOT/scripts/bench/soak-metrics.json" \
+	SOAK_TARGET_REF=dev \
+	SOAK_TARGET_SHA=1086923fb257407baa2e15ce57841987503dbbb5 \
+	SOAK_VERSION=0.4.42 \
+	SOAK_STARTED_AT=1000 \
+	SOAK_FINISHED_AT=1180 \
+	SOAK_DURATION_SECONDS=3600 \
+	SOAK_ITERATIONS=2 \
+	SOAK_FAILURES=2 \
+	SOAK_BENCH_SEGMENTS=1 \
+	SOAK_BENCH_FAILURES=1 \
+	"$ROOT/scripts/bench/write-soak-summary.sh"
+
+jq -e '
+  .target_ref == "dev"
+  and .started_at == 1000
+  and .elapsed_seconds == 180
+  and .iterations == 2
+  and .failures == 2
+  and .rss_peak_mb == 15580
+  and .providers.docker.failures == 1
+  and .providers.subprocess.failures == 1
+  and .tracked_metrics.lfb_spread.p50 == 3
+  and .tracked_metrics.lfb_spread.p95 == null
+  and .tracked_metrics.lfb_spread.max == null
+  and .tracked_metrics.lfb_spread.samples == 4
+' "$TMP/summary.json" >/dev/null
+
+printf 'soak summary writer tests passed\n'

--- a/scripts/bench/write-soak-summary.sh
+++ b/scripts/bench/write-soak-summary.sh
@@ -35,6 +35,7 @@ jq -n \
 	--argjson bench_failures "$BENCH_FAILURES" \
 	'
     def median: sort | if length == 0 then null else .[(length - 1) / 2 | floor] end;
+    def max_or_null: if length == 0 then null else max end;
     ($iters[0] | map(select(type == "object"))) as $all
     | def numeric_values(path): [$all[] | path | select(type == "number")];
       def provider_split(p):
@@ -78,8 +79,8 @@ jq -n \
           failures: $failures,
           failure_rate: (if $iterations > 0 then ($failures / $iterations) else 0 end),
           iterations_per_hour: (if $elapsed > 0 then ($iterations * 3600 / $elapsed * 100 | floor / 100) else 0 end),
-          rss_peak_mb: (numeric_values(.rss_peak_mb?) | max),
-          cpu_peak_pct: (numeric_values(.cpu_peak_pct?) | max),
+          rss_peak_mb: (numeric_values(.rss_peak_mb?) | max_or_null),
+          cpu_peak_pct: (numeric_values(.cpu_peak_pct?) | max_or_null),
           finalization_p50_ms: (numeric_values(.finalization_latency?.p50_ms?) | median),
           finalization_p95_ms: (numeric_values(.finalization_latency?.p95_ms?) | median),
           finalization_p99_ms: (numeric_values(.finalization_latency?.p99_ms?) | median),

--- a/scripts/bench/write-soak-summary.sh
+++ b/scripts/bench/write-soak-summary.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${SOAK_OUTPUT_DIR:?SOAK_OUTPUT_DIR is required}"
+REGISTRY="${SOAK_METRICS_REGISTRY:?SOAK_METRICS_REGISTRY is required}"
+TARGET_REF="${SOAK_TARGET_REF:-unknown}"
+TARGET_SHA="${SOAK_TARGET_SHA:-unknown}"
+VERSION="${SOAK_VERSION:-unknown}"
+STARTED_AT="${SOAK_STARTED_AT:?SOAK_STARTED_AT is required}"
+FINISHED_AT="${SOAK_FINISHED_AT:?SOAK_FINISHED_AT is required}"
+DURATION_SECONDS="${SOAK_DURATION_SECONDS:?SOAK_DURATION_SECONDS is required}"
+ITERATIONS="${SOAK_ITERATIONS:?SOAK_ITERATIONS is required}"
+FAILURES="${SOAK_FAILURES:?SOAK_FAILURES is required}"
+BENCH_SEGMENTS="${SOAK_BENCH_SEGMENTS:?SOAK_BENCH_SEGMENTS is required}"
+BENCH_FAILURES="${SOAK_BENCH_FAILURES:?SOAK_BENCH_FAILURES is required}"
+
+ITERATIONS_JSON="$OUTPUT_DIR/iterations.json"
+while IFS= read -r -d '' metrics; do
+	jq -e 'select(type == "object")' "$metrics" 2>/dev/null || true
+done < <(find "$OUTPUT_DIR" -path '*iteration-*/metrics.json' -print0 | sort -z) |
+	jq -s 'sort_by(.iteration // 0)' >"$ITERATIONS_JSON"
+
+jq -n \
+	--slurpfile iters "$ITERATIONS_JSON" \
+	--slurpfile registry "$REGISTRY" \
+	--arg target_ref "$TARGET_REF" \
+	--arg target_sha "$TARGET_SHA" \
+	--arg version "$VERSION" \
+	--argjson started "$STARTED_AT" \
+	--argjson finished "$FINISHED_AT" \
+	--argjson requested "$DURATION_SECONDS" \
+	--argjson iterations "$ITERATIONS" \
+	--argjson failures "$FAILURES" \
+	--argjson bench_segments "$BENCH_SEGMENTS" \
+	--argjson bench_failures "$BENCH_FAILURES" \
+	'
+    def median: sort | if length == 0 then null else .[(length - 1) / 2 | floor] end;
+    ($iters[0] | map(select(type == "object"))) as $all
+    | def numeric_values(path): [$all[] | path | select(type == "number")];
+      def provider_split(p):
+        ($all | map(select(.provider? == p))) as $provider_iters
+        | {iterations: ($provider_iters | length),
+           failures: ($provider_iters | map(select((.ok? // false) | not)) | length),
+           avg_duration_s: (([$provider_iters[] | .duration_s? | select(type == "number")]) as $durations
+             | if ($durations | length) > 0
+               then (($durations | add) / ($durations | length) | floor)
+               else null end)};
+      def rollup_tracked_metrics:
+        ($registry[0].metrics // []) as $defs
+        | [ $defs[] | . as $def
+            | ([$all[] | .metrics?[$def.key]? | select(type == "object")]) as $samples
+            | select(($samples | length) > 0)
+            | {
+                key: $def.key,
+                value: (
+                  reduce ($def.aggregate // ["p50", "p95", "max"])[] as $agg
+                    ({};
+                     ($samples | map(.[$agg]? | select(type == "number"))) as $values
+                     | . + {($agg): (if ($values | length) == 0 then null
+                                      elif $agg == "max" then ($values | max)
+                                      elif $agg == "min" then ($values | min)
+                                      else ($values | median) end)})
+                  | . + {samples: ([$samples[] | .samples? | select(type == "number")] | add // 0)}
+                )
+              }
+          ]
+        | from_entries;
+      ($finished - $started) as $elapsed
+      | {
+          target_ref: $target_ref,
+          target_sha: $target_sha,
+          version: $version,
+          started_at: $started,
+          finished_at: $finished,
+          requested_seconds: $requested,
+          elapsed_seconds: $elapsed,
+          iterations: $iterations,
+          failures: $failures,
+          failure_rate: (if $iterations > 0 then ($failures / $iterations) else 0 end),
+          iterations_per_hour: (if $elapsed > 0 then ($iterations * 3600 / $elapsed * 100 | floor / 100) else 0 end),
+          rss_peak_mb: (numeric_values(.rss_peak_mb?) | max),
+          cpu_peak_pct: (numeric_values(.cpu_peak_pct?) | max),
+          finalization_p50_ms: (numeric_values(.finalization_latency?.p50_ms?) | median),
+          finalization_p95_ms: (numeric_values(.finalization_latency?.p95_ms?) | median),
+          finalization_p99_ms: (numeric_values(.finalization_latency?.p99_ms?) | median),
+          too_far_ahead_errors: (numeric_values(.too_far_ahead_errors?) | add // 0),
+          providers: {docker: provider_split("docker"), subprocess: provider_split("subprocess")},
+          bench_segments: $bench_segments,
+          bench_failures: $bench_failures,
+          tracked_metrics: rollup_tracked_metrics,
+          iteration_metrics: $all
+        }
+  ' >"$OUTPUT_DIR/summary.json"

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -513,86 +513,19 @@ FINISHED_AT="$(date +%s)"
 } | tee "$OUTPUT_DIR/summary.txt"
 
 if command -v jq >/dev/null; then
-  find "$OUTPUT_DIR" -path '*iteration-*/metrics.json' -print0 \
-    | sort -z \
-    | xargs -0 --no-run-if-empty cat \
-    | jq -s 'sort_by(.iteration)' > "$OUTPUT_DIR/iterations.json"
-  [ -s "$OUTPUT_DIR/iterations.json" ] || echo '[]' > "$OUTPUT_DIR/iterations.json"
-  jq -n \
-    --slurpfile iters "$OUTPUT_DIR/iterations.json" \
-    --slurpfile registry "$SCRIPT_DIR/bench/soak-metrics.json" \
-    --arg target_ref "$TARGET_REF" \
-    --arg target_sha "$TARGET_SHA" \
-    --arg version "$VERSION" \
-    --argjson started "$STARTED_AT" \
-    --argjson finished "$FINISHED_AT" \
-    --argjson requested "$DURATION_SECONDS" \
-    --argjson iterations "$ITERATIONS" \
-    --argjson failures "$FAILURES" \
-    --argjson bench_segments "$BENCH_SEGMENTS" \
-    --argjson bench_failures "$BENCH_FAILURES" \
-    '
-    def median: sort | if length == 0 then null else .[(length - 1) / 2 | floor] end;
-    def provider_split(p):
-      ($iters[0] | map(select(.provider == p))) as $p_iters
-      | {iterations: ($p_iters | length),
-         failures: ($p_iters | map(select(.ok | not)) | length),
-         avg_duration_s: (if ($p_iters | length) > 0
-                          then (($p_iters | map(.duration_s) | add) / ($p_iters | length) | floor)
-                          else null end)};
-    # Rolls up a SOAK_METRIC-registry metric across iterations: "max"/"min"
-    # fold with max/min across iterations, any other declared aggregate (p50,
-    # p95, ...) folds with the cross-iteration median — the same treatment
-    # finalization_p95_ms already gets below. Declaring a metric in
-    # soak-metrics.json is enough for it to reach here; no further code change
-    # is needed per metric.
-    def rollup_tracked_metrics:
-      ($registry[0].metrics // []) as $defs
-      | [ $defs[] | . as $def
-          | ($iters[0] | map(.metrics[$def.key]) | map(select(. != null))) as $samples
-          | select(($samples | length) > 0)
-          | {
-              key: $def.key,
-              value: (
-                reduce ($def.aggregate // ["p50", "p95", "max"])[] as $agg
-                  ({}; . + {
-                    ($agg): (
-                      if $agg == "max" then ($samples | map(.max) | select(length > 0) | max)
-                      elif $agg == "min" then ($samples | map(.min) | select(length > 0) | min)
-                      else ($samples | map(.[$agg]) | select(length > 0) | median)
-                      end
-                    )
-                  })
-                | . + {samples: ($samples | map(.samples // 0) | add)}
-              )
-            }
-        ]
-      | from_entries;
-    ($finished - $started) as $elapsed
-    | {
-        target_ref: $target_ref,
-        target_sha: $target_sha,
-        version: $version,
-        started_at: $started,
-        finished_at: $finished,
-        requested_seconds: $requested,
-        elapsed_seconds: $elapsed,
-        iterations: $iterations,
-        failures: $failures,
-        failure_rate: (if $iterations > 0 then ($failures / $iterations) else 0 end),
-        iterations_per_hour: (if $elapsed > 0 then ($iterations * 3600 / $elapsed * 100 | floor / 100) else 0 end),
-        rss_peak_mb: ($iters[0] | map(.rss_peak_mb | select(. != null)) | max),
-        cpu_peak_pct: ($iters[0] | map(.cpu_peak_pct | select(. != null)) | max),
-        finalization_p50_ms: ($iters[0] | map(.finalization_latency.p50_ms | select(. != null)) | median),
-        finalization_p95_ms: ($iters[0] | map(.finalization_latency.p95_ms | select(. != null)) | median),
-        finalization_p99_ms: ($iters[0] | map(.finalization_latency.p99_ms | select(. != null)) | median),
-        too_far_ahead_errors: ($iters[0] | map(.too_far_ahead_errors // 0) | add),
-        providers: {docker: provider_split("docker"), subprocess: provider_split("subprocess")},
-        bench_segments: $bench_segments,
-        bench_failures: $bench_failures,
-        tracked_metrics: rollup_tracked_metrics,
-        iteration_metrics: $iters[0]
-      }' > "$OUTPUT_DIR/summary.json" 2>/dev/null \
+  SOAK_OUTPUT_DIR="$OUTPUT_DIR" \
+  SOAK_METRICS_REGISTRY="$SCRIPT_DIR/bench/soak-metrics.json" \
+  SOAK_TARGET_REF="$TARGET_REF" \
+  SOAK_TARGET_SHA="$TARGET_SHA" \
+  SOAK_VERSION="$VERSION" \
+  SOAK_STARTED_AT="$STARTED_AT" \
+  SOAK_FINISHED_AT="$FINISHED_AT" \
+  SOAK_DURATION_SECONDS="$DURATION_SECONDS" \
+  SOAK_ITERATIONS="$ITERATIONS" \
+  SOAK_FAILURES="$FAILURES" \
+  SOAK_BENCH_SEGMENTS="$BENCH_SEGMENTS" \
+  SOAK_BENCH_FAILURES="$BENCH_FAILURES" \
+    "$SCRIPT_DIR/bench/write-soak-summary.sh" \
     || printf 'summary.json emission failed (non-fatal)\n' >&2
 fi
 


### PR DESCRIPTION
- dispatch checkpoint publication through the GitHub API without gh
- isolate and harden summary generation for partial metrics
- add CI regression coverage for summary aggregation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788190790&installation_model_id=426883&pr_number=188&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F188&signature=6cb94f38f538ee52fc25b6f79157e91ed68c70ec3812ef00d704de9db2957b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->