### PR TITLE
fix(soak): fail closed on host protection; repair checkpoint, bench, …

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,5 @@
 self-hosted-runner:
   labels:
     - f1r3fly-rust-ci-ephemeral
+    - f1r3fly-rust-soak
     - oracle-cloud

--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=369d49df2f97e65b3d0ad869aa668a7383b11179
+SYSTEM_INTEGRATION_REF=66de4f95141cbef9c1308d58fbb872b66cf75197

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -18,12 +18,12 @@ PIPELINE=.github/workflows/_integration-pipeline.yml
 fail=0
 
 err() {
-    printf '::error::%s\n' "$1"
-    fail=1
+	printf '::error::%s\n' "$1"
+	fail=1
 }
 
 ok() {
-    printf 'ok: %s\n' "$1"
+	printf 'ok: %s\n' "$1"
 }
 
 # Emit one line of facts per job in a workflow file:
@@ -35,7 +35,7 @@ ok() {
 # and counting those would let the guard pass on a workflow whose real `needs:`
 # had been deleted.
 scan_jobs() {
-    awk '
+	awk '
         /^[[:space:]]*#/ { next }
         /^  [A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ {
             job = $1
@@ -71,11 +71,11 @@ scan_jobs() {
 #    Removing either `needs:` is the abuse path the ephemeral-launch approval
 #    exists to close.
 for job in launch_ephemeral_runners build_docker_image; do
-    if scan_jobs "$PIPELINE" | awk -v j="$job" '$1 == j && $5 == 1 { found = 1 } END { exit !found }'; then
-        ok "$job gates on await_approval"
-    else
-        err "$job in $PIPELINE no longer depends on await_approval; unapproved fork PRs could spend CI resources"
-    fi
+	if scan_jobs "$PIPELINE" | awk -v j="$job" '$1 == j && $5 == 1 { found = 1 } END { exit !found }'; then
+		ok "$job gates on await_approval"
+	else
+		err "$job in $PIPELINE no longer depends on await_approval; unapproved fork PRs could spend CI resources"
+	fi
 done
 
 # 2. Credential concentration. Exactly one job in the reusable pipeline may hold
@@ -84,24 +84,24 @@ done
 cred_jobs="$(scan_jobs "$PIPELINE" | awk '$3 == 1 || $4 == 1 { print $1 }')"
 cred_count="$(printf '%s' "$cred_jobs" | grep -c . || true)"
 if [ "$cred_count" = "1" ] && [ "$cred_jobs" = "launch_ephemeral_runners" ]; then
-    ok "credentials confined to launch_ephemeral_runners"
+	ok "credentials confined to launch_ephemeral_runners"
 else
-    # Flattened to one line: a GitHub error annotation captures only its first
-    # line, so a multi-line job list would hide every name after the first.
-    cred_list="$(printf '%s' "$cred_jobs" | tr '\n' ' ')"
-    err "expected exactly one credential-bearing job (launch_ephemeral_runners) in $PIPELINE, found: ${cred_list:-none}"
+	# Flattened to one line: a GitHub error annotation captures only its first
+	# line, so a multi-line job list would hide every name after the first.
+	cred_list="$(printf '%s' "$cred_jobs" | tr '\n' ' ')"
+	err "expected exactly one credential-bearing job (launch_ephemeral_runners) in $PIPELINE, found: ${cred_list:-none}"
 fi
 
 # 3. Environment scoping. Any job anywhere that reads OCI or GitHub App
 #    credentials must name an environment, so access is a property of the
 #    environment rather than of the repository secret store.
 for workflow in .github/workflows/*.yml; do
-    while read -r job has_env reads_oci reads_app _gated _calls _inherits; do
-        [ -n "${job:-}" ] || continue
-        if [ "$reads_oci$reads_app" != "00" ] && [ "$has_env" = "0" ]; then
-            err "$workflow job '$job' reads privileged credentials without naming an environment"
-        fi
-    done <<EOF
+	while read -r job has_env reads_oci reads_app _gated _calls _inherits; do
+		[ -n "${job:-}" ] || continue
+		if [ "$reads_oci$reads_app" != "00" ] && [ "$has_env" = "0" ]; then
+			err "$workflow job '$job' reads privileged credentials without naming an environment"
+		fi
+	done <<EOF
 $(scan_jobs "$workflow")
 EOF
 done
@@ -113,12 +113,12 @@ ok "every credential-reading job names an environment"
 #    config as malformed (runs 30495007422 and 30498890544). Guarded because the
 #    line reads like redundant over-sharing and invites deletion.
 for caller in .github/workflows/ci.yml .github/workflows/ci-fork-pr.yml; do
-    while read -r job _has_env _reads_oci _reads_app _gated calls inherits; do
-        [ -n "${job:-}" ] || continue
-        if [ "$calls" = "1" ] && [ "$inherits" = "0" ]; then
-            err "$caller job '$job' calls the integration pipeline without 'secrets: inherit'; the launch job would see empty credentials"
-        fi
-    done <<EOF
+	while read -r job _has_env _reads_oci _reads_app _gated calls inherits; do
+		[ -n "${job:-}" ] || continue
+		if [ "$calls" = "1" ] && [ "$inherits" = "0" ]; then
+			err "$caller job '$job' calls the integration pipeline without 'secrets: inherit'; the launch job would see empty credentials"
+		fi
+	done <<EOF
 $(scan_jobs "$caller")
 EOF
 done
@@ -160,30 +160,30 @@ ocid_required=".github/workflows/ci-runner-reaper.yml"
 ocid_optional=".github/workflows/merge-recovery-soak.yml"
 ocid_values=""
 for ocid_file in $ocid_optional; do
-    ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
-        "$ocid_file" 2>/dev/null \
-        | sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
-    [ -n "$ocid_found" ] && ocid_values="${ocid_values}${ocid_found}
+	ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
+		"$ocid_file" 2>/dev/null |
+		sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
+	[ -n "$ocid_found" ] && ocid_values="${ocid_values}${ocid_found}
 "
 done
 for ocid_file in $ocid_required; do
-    ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
-        "$ocid_file" 2>/dev/null \
-        | sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
-    ocid_count="$(printf '%s' "$ocid_found" | grep -c . || true)"
-    if [ "$ocid_count" -ne 1 ]; then
-        err "$ocid_file must pin exactly one literal CI_RUNNER_COMPARTMENT_OCID, found $ocid_count (an Actions variable trades a compile-time guarantee for an admin-mutable one — see the note in ci-runner-reaper.yml)"
-    else
-        ocid_values="${ocid_values}${ocid_found}
+	ocid_found="$(grep -hoE 'CI_RUNNER_COMPARTMENT_OCID:[[:space:]]*"ocid1\.compartment\.[A-Za-z0-9._-]+"' \
+		"$ocid_file" 2>/dev/null |
+		sed -E 's/.*"(ocid1\.compartment\.[A-Za-z0-9._-]+)"/\1/' || true)"
+	ocid_count="$(printf '%s' "$ocid_found" | grep -c . || true)"
+	if [ "$ocid_count" -ne 1 ]; then
+		err "$ocid_file must pin exactly one literal CI_RUNNER_COMPARTMENT_OCID, found $ocid_count (an Actions variable trades a compile-time guarantee for an admin-mutable one — see the note in ci-runner-reaper.yml)"
+	else
+		ocid_values="${ocid_values}${ocid_found}
 "
-    fi
+	fi
 done
 if [ "$fail" -eq 0 ]; then
-    if [ "$(printf '%s' "$ocid_values" | sort -u | grep -c .)" -ne 1 ]; then
-        err "CI_RUNNER_COMPARTMENT_OCID differs across the workflows that pin it ($ocid_required $ocid_optional); every literal must name the same compartment"
-    else
-        ok "CI_RUNNER_COMPARTMENT_OCID pinned as a literal in $ocid_required, and consistent wherever else it appears"
-    fi
+	if [ "$(printf '%s' "$ocid_values" | sort -u | grep -c .)" -ne 1 ]; then
+		err "CI_RUNNER_COMPARTMENT_OCID differs across the workflows that pin it ($ocid_required $ocid_optional); every literal must name the same compartment"
+	else
+		ok "CI_RUNNER_COMPARTMENT_OCID pinned as a literal in $ocid_required, and consistent wherever else it appears"
+	fi
 fi
 
 # 6. Fork-checkout hygiene. Every checkout of the code under test must set
@@ -204,14 +204,14 @@ fi
 fork_bad_persist=""
 fork_bad_optin=""
 while read -r line_no flags; do
-    case "$flags" in
-        *P*) ;;
-        *) fork_bad_persist="$fork_bad_persist $PIPELINE:$line_no" ;;
-    esac
-    case "$flags" in
-        *A*) ;;
-        *) fork_bad_optin="$fork_bad_optin $PIPELINE:$line_no" ;;
-    esac
+	case "$flags" in
+	*P*) ;;
+	*) fork_bad_persist="$fork_bad_persist $PIPELINE:$line_no" ;;
+	esac
+	case "$flags" in
+	*A*) ;;
+	*) fork_bad_optin="$fork_bad_optin $PIPELINE:$line_no" ;;
+	esac
 done <<EOF
 $(awk '
     function flush() {
@@ -232,13 +232,13 @@ $(awk '
 ' "$PIPELINE")
 EOF
 if [ -n "$fork_bad_persist" ]; then
-    err "checkout of fork-authored code without 'persist-credentials: false' at:${fork_bad_persist}; a writable token must never reach a workspace holding untrusted code"
+	err "checkout of fork-authored code without 'persist-credentials: false' at:${fork_bad_persist}; a writable token must never reach a workspace holding untrusted code"
 fi
 if [ -n "$fork_bad_optin" ]; then
-    err "checkout of fork-authored code without 'allow-unsafe-pr-checkout: true' at:${fork_bad_optin}; actions/checkout refuses fork code under pull_request_target without it, which breaks every fork PR at clone"
+	err "checkout of fork-authored code without 'allow-unsafe-pr-checkout: true' at:${fork_bad_optin}; actions/checkout refuses fork code under pull_request_target without it, which breaks every fork PR at clone"
 fi
 if [ -z "$fork_bad_persist$fork_bad_optin" ]; then
-    ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
+	ok "fork-code checkouts set persist-credentials:false and allow-unsafe-pr-checkout:true"
 fi
 
 # 8. Every `run:` block in every workflow must be parseable by its shell.
@@ -263,11 +263,11 @@ skipped_shells=""
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 while IFS= read -r wf; do
-    # Extract every run: block with its job/step identity. Ruby is already a
-    # hard dependency of this repo's tooling and ships with a YAML parser, so
-    # the blocks come from a real parse rather than an indentation heuristic
-    # that block scalars would defeat.
-    ruby -ryaml -e '
+	# Extract every run: block with its job/step identity. Ruby is already a
+	# hard dependency of this repo's tooling and ships with a YAML parser, so
+	# the blocks come from a real parse rather than an indentation heuristic
+	# that block scalars would defeat.
+	ruby -ryaml -e '
       wf = ARGV[0]; out = ARGV[1]
       doc = YAML.load_file(wf) rescue nil
       exit 0 unless doc.is_a?(Hash) && doc["jobs"].is_a?(Hash)
@@ -287,32 +287,35 @@ while IFS= read -r wf; do
         end
       end' "$wf" "$scratch" 2>/dev/null || continue
 
-    [ -f "$scratch/index.txt" ] || continue
-    while IFS=$'\t' read -r blockfile kind label; do
-        case "$kind" in
-            bash | sh | "") ;;
-            *) skipped_shells="${skipped_shells}
-  ${wf}: ${label} (shell: ${kind})"; continue ;;
-        esac
-        if ! errout="$(bash -n "$scratch/$blockfile" 2>&1)"; then
-            bad_syntax="${bad_syntax}
+	[ -f "$scratch/index.txt" ] || continue
+	while IFS=$'\t' read -r blockfile kind label; do
+		case "$kind" in
+		bash | sh | "") ;;
+		*)
+			skipped_shells="${skipped_shells}
+  ${wf}: ${label} (shell: ${kind})"
+			continue
+			;;
+		esac
+		if ! errout="$(bash -n "$scratch/$blockfile" 2>&1)"; then
+			bad_syntax="${bad_syntax}
   ${wf}: ${label}
     ${errout}"
-        fi
-    done < "$scratch/index.txt"
-    rm -f "$scratch"/index.txt "$scratch"/block-*.sh
+		fi
+	done <"$scratch/index.txt"
+	rm -f "$scratch"/index.txt "$scratch"/block-*.sh
 done < <(find .github/workflows -name '*.yml' -o -name '*.yaml' | sort)
 
 if [ -n "$bad_syntax" ]; then
-    err "workflow run: block(s) fail 'bash -n' and will die at runtime:${bad_syntax}"
+	err "workflow run: block(s) fail 'bash -n' and will die at runtime:${bad_syntax}"
 else
-    ok "every workflow run: block parses under bash -n"
+	ok "every workflow run: block parses under bash -n"
 fi
 if [ -n "$skipped_shells" ]; then
-    printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
+	printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
 fi
 
-cat > "$scratch/check-canary.rb" <<'RUBY'
+cat >"$scratch/check-canary.rb" <<'RUBY'
 require "yaml"
 doc = YAML.load_file(ARGV[0])
 jobs = doc.fetch("jobs")
@@ -332,14 +335,14 @@ puts "protection injection step is missing or not gate-controlled" unless inject
 RUBY
 canary_errors="$(ruby "$scratch/check-canary.rb" .github/workflows/merge-recovery-soak.yml)"
 if [ -n "$canary_errors" ]; then
-    err "soak canary isolation invariants failed: $(printf '%s' "$canary_errors" | tr '\n' ';')"
+	err "soak canary isolation invariants failed: $(printf '%s' "$canary_errors" | tr '\n' ';')"
 else
-    ok "soak canaries are bounded and cannot retry, checkpoint-publish, dashboard-publish, or notify"
+	ok "soak canaries are bounded and cannot retry, checkpoint-publish, dashboard-publish, or notify"
 fi
 
 if [ "$fail" -ne 0 ]; then
-    printf '::error::%s\n' "workflow security invariants violated; see errors above"
-    exit 1
+	printf '::error::%s\n' "workflow security invariants violated; see errors above"
+	exit 1
 fi
 
 echo "All workflow security invariants hold."

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -332,12 +332,20 @@ puts "canary retry attempts are not rejected" unless body&.include?("INPUT_RETRY
 puts "protection injection is not restricted to canaries" unless body&.include?("inject_protection_breach requires canary")
 injection = jobs.dig("soak", "steps").find { |step| step["name"] == "Configure injected protection breach" }
 puts "protection injection step is missing or not gate-controlled" unless injection&.dig("if").to_s == "needs.schedule_gate.outputs.inject_protection_breach == 'true'"
+puts "OCI scheduled slots are not handled before manual dispatches" unless body&.include?('if [ -n "$INPUT_SCHEDULED_SLOT" ]; then')
+puts "OCI scheduled inputs are not isolated from manual controls" unless body&.include?("scheduled_slot_epoch cannot be combined")
+puts "Friday routing does not consistently target master" unless body&.scan("target_ref=master")&.length.to_i >= 2
+puts "daily routing does not consistently target dev" unless body&.scan("target_ref=dev")&.length.to_i >= 2
+puts "OCI scheduled runs are not deduplicated" unless body&.include?("scheduled slot already belongs to run")
+raw = File.read(ARGV[0])
+puts "scheduled_slot_epoch input is missing" unless raw.include?("scheduled_slot_epoch:")
+puts "scheduled run names are not slot-stable" unless raw.include?("Merge Recovery Soak [scheduled:{0}]")
 RUBY
-canary_errors="$(ruby "$scratch/check-canary.rb" .github/workflows/merge-recovery-soak.yml)"
-if [ -n "$canary_errors" ]; then
-	err "soak canary isolation invariants failed: $(printf '%s' "$canary_errors" | tr '\n' ';')"
+soak_errors="$(ruby "$scratch/check-canary.rb" .github/workflows/merge-recovery-soak.yml)"
+if [ -n "$soak_errors" ]; then
+	err "soak workflow invariants failed: $(printf '%s' "$soak_errors" | tr '\n' ';')"
 else
-	ok "soak canaries are bounded and cannot retry, checkpoint-publish, dashboard-publish, or notify"
+	ok "soak canaries are isolated and scheduled routing maps daily to dev and weekend to master"
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -312,6 +312,31 @@ if [ -n "$skipped_shells" ]; then
     printf 'note: non-bash run: blocks not syntax-checked:%s\n' "$skipped_shells"
 fi
 
+cat > "$scratch/check-canary.rb" <<'RUBY'
+require "yaml"
+doc = YAML.load_file(ARGV[0])
+jobs = doc.fetch("jobs")
+%w[retry_within_window perf_report notify_failure].each do |job_id|
+  condition = jobs.dig(job_id, "if").to_s
+  expected = "outputs.canary != #{39.chr}true#{39.chr}"
+  puts "#{job_id} does not exclude canaries" unless condition.include?(expected)
+end
+gate = jobs.dig("schedule_gate", "steps").find { |step| step["id"] == "resolve" }
+body = gate && gate["run"].to_s
+puts "canary duration is not bounded to 1800s" unless body&.include?("duration_seconds=1800")
+puts "canary checkpoint slots are not cleared" unless body&.include?("checkpoints=()")
+puts "canary retry attempts are not rejected" unless body&.include?("INPUT_RETRY_ATTEMPT")
+puts "protection injection is not restricted to canaries" unless body&.include?("inject_protection_breach requires canary")
+injection = jobs.dig("soak", "steps").find { |step| step["name"] == "Configure injected protection breach" }
+puts "protection injection step is missing or not gate-controlled" unless injection&.dig("if").to_s == "needs.schedule_gate.outputs.inject_protection_breach == 'true'"
+RUBY
+canary_errors="$(ruby "$scratch/check-canary.rb" .github/workflows/merge-recovery-soak.yml)"
+if [ -n "$canary_errors" ]; then
+    err "soak canary isolation invariants failed: $(printf '%s' "$canary_errors" | tr '\n' ';')"
+else
+    ok "soak canaries are bounded and cannot retry, checkpoint-publish, dashboard-publish, or notify"
+fi
+
 if [ "$fail" -ne 0 ]; then
     printf '::error::%s\n' "workflow security invariants violated; see errors above"
     exit 1

--- a/.github/scripts/test-soak-schedule-routing.sh
+++ b/.github/scripts/test-soak-schedule-routing.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ruby -ryaml -e '
+  doc = YAML.load_file(ARGV[0])
+  step = doc.dig("jobs", "schedule_gate", "steps").find { |item| item["id"] == "resolve" }
+  abort "schedule gate not found" unless step && step["run"].is_a?(String)
+  File.write(ARGV[1], step["run"])
+' "$ROOT/.github/workflows/merge-recovery-soak.yml" "$TMP/gate.sh"
+
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/date" <<'SH'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  "-u +%s") printf '%s\n' "$FAKE_NOW_EPOCH" ;;
+  *" +%H%M") printf '%s\n' "${FAKE_PACIFIC_HM:-1930}" ;;
+  *" +%u") printf '%s\n' "$FAKE_PACIFIC_WEEKDAY" ;;
+  *" +%FT%TZ") printf '%s\n' '2026-01-01T00:00:00Z' ;;
+  *" +%Y-%m-%dT%H:%M:%SZ") printf '%s\n' '2026-01-01T00:00:00Z' ;;
+  *" +%F") printf '%s\n' '2026-01-01' ;;
+  *" +%s")
+    case "$args" in
+      *":30:00"*) printf '%s\n' "$FAKE_SLOT_EPOCH" ;;
+      *) printf '0\n' ;;
+    esac
+    ;;
+  *) printf 'unsupported fake date invocation: %s\n' "$args" >&2; exit 1 ;;
+esac
+SH
+cat >"$TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"/commits?"*) printf '1\n' ;;
+  *) printf '%s\n' '{"workflow_runs":[]}' ;;
+esac
+SH
+chmod +x "$TMP/bin/date" "$TMP/bin/gh"
+
+run_gate() {
+	local mode="$1" weekday="$2" slot="$3" output
+	output="$TMP/output-$mode-$weekday"
+	: >"$output"
+	PATH="$TMP/bin:$PATH" \
+		FAKE_NOW_EPOCH="$((slot + 60))" \
+		FAKE_SLOT_EPOCH="$slot" \
+		FAKE_PACIFIC_WEEKDAY="$weekday" \
+		EVENT_NAME="$([ "$mode" = oci ] && printf workflow_dispatch || printf schedule)" \
+		EVENT_SCHEDULE="30 2 * * *" \
+		INPUT_SCHEDULED_SLOT="$([ "$mode" = oci ] && printf '%s' "$slot")" \
+		INPUT_DURATION=daily-24h \
+		INPUT_TARGET_REF=dev \
+		INPUT_WINDOW_END="" \
+		INPUT_SERIES="" \
+		INPUT_RETRY_ATTEMPT=0 \
+		INPUT_CANARY=false \
+		INPUT_INJECT_PROTECTION_BREACH=false \
+		GH_TOKEN=test \
+		GITHUB_REPOSITORY=F1R3FLY-io/f1r3node-rust \
+		GITHUB_RUN_ID=999 \
+		GITHUB_OUTPUT="$output" \
+		GITHUB_STEP_SUMMARY="$TMP/summary" \
+		bash -euo pipefail "$TMP/gate.sh" >/dev/null
+	printf '%s\n' "$output"
+}
+
+for mode in oci cron; do
+	friday="$(run_gate "$mode" 5 1785551400)"
+	grep -qx 'target_ref=master' "$friday"
+	grep -qx 'duration_seconds=216000' "$friday"
+	grep -qx 'kind=weekend' "$friday"
+	grep -qx 'run_benchmarks=true' "$friday"
+
+	monday="$(run_gate "$mode" 1 1785810600)"
+	grep -qx 'target_ref=dev' "$monday"
+	grep -qx 'duration_seconds=79200' "$monday"
+	grep -qx 'kind=daily' "$monday"
+	grep -qx 'run_benchmarks=false' "$monday"
+done
+
+if PATH="$TMP/bin:$PATH" \
+	FAKE_NOW_EPOCH=1785551460 \
+	FAKE_SLOT_EPOCH=1785551400 \
+	FAKE_PACIFIC_WEEKDAY=5 \
+	EVENT_NAME=workflow_dispatch \
+	EVENT_SCHEDULE="" \
+	INPUT_SCHEDULED_SLOT=1785551400 \
+	INPUT_DURATION=daily-24h \
+	INPUT_TARGET_REF=dev \
+	INPUT_WINDOW_END="" \
+	INPUT_SERIES="" \
+	INPUT_RETRY_ATTEMPT=0 \
+	INPUT_CANARY=true \
+	INPUT_INJECT_PROTECTION_BREACH=false \
+	GH_TOKEN=test \
+	GITHUB_REPOSITORY=F1R3FLY-io/f1r3node-rust \
+	GITHUB_RUN_ID=999 \
+	GITHUB_OUTPUT="$TMP/conflict-output" \
+	GITHUB_STEP_SUMMARY="$TMP/summary" \
+	bash -euo pipefail "$TMP/gate.sh" >/dev/null 2>&1; then
+	echo 'scheduled slot accepted conflicting canary controls' >&2
+	exit 1
+fi
+
+printf 'soak schedule routing tests passed\n'

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: 369d49df2f97e65b3d0ad869aa668a7383b11179
+  SYSTEM_INTEGRATION_REF: 66de4f95141cbef9c1308d58fbb872b66cf75197
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,10 @@ jobs:
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/check-workflow-invariants.sh
 
+      - name: Verify soak schedule routing
+        shell: bash -euo pipefail {0}
+        run: bash .github/scripts/test-soak-schedule-routing.sh
+
       - name: Verify soak summary aggregation
         shell: bash -euo pipefail {0}
         run: scripts/bench/test-write-soak-summary.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,18 @@ jobs:
         shell: bash -euo pipefail {0}
         run: scripts/bench/test-write-soak-summary.sh
 
+      - name: Verify soak verdicts
+        shell: bash -euo pipefail {0}
+        run: scripts/bench/test-aggregate-perf-report.sh
+
+      - name: Verify soak fail-closed driver
+        shell: bash -euo pipefail {0}
+        run: scripts/bench/test-run-merge-recovery-soak.sh
+
+      - name: Verify soak dashboard restoration
+        shell: bash -euo pipefail {0}
+        run: scripts/bench/test-restore-soak-dashboard-run.sh
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -105,7 +105,7 @@ env:
   # by grep: main already contained the string __RUNNER_LABELS__, the cloud-init
   # template placeholder, long before the override existed. Grepping would have
   # said yes against a launcher that ignores the variable.
-  SYSTEM_INTEGRATION_REF: 369d49df2f97e65b3d0ad869aa668a7383b11179
+  SYSTEM_INTEGRATION_REF: 66de4f95141cbef9c1308d58fbb872b66cf75197
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -1269,6 +1269,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      # actions: read is for the checkpoint-recovery fallback below, which
+      # lists and downloads this run's own artifacts through the API.
+      actions: read
       pages: write
       id-token: write
     concurrency:
@@ -1285,11 +1288,48 @@ jobs:
           path: ci-control
           persist-credentials: false
 
+      # continue-on-error, because this artifact only exists when the soak job
+      # lived long enough to reach its always() upload. A runner lost mid-run
+      # (30713818751: VM frozen at ~2h of a 45h budget) uploads nothing, and
+      # failing here left the dashboard showing the PREVIOUS run's state for a
+      # night that actually died — the checkpoint recovery below publishes
+      # what the run managed to report before it was lost.
       - name: Download soak results
+        id: results
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: merge-recovery-soak-${{ needs.schedule_gate.outputs.duration_seconds }}s-${{ github.run_id }}-${{ github.run_attempt }}
           path: soak-results
+
+      - name: Recover latest checkpoint (runner lost)
+        if: steps.results.outcome == 'failure'
+        shell: bash -euo pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          # The final results artifact never made it off the VM. Each completed
+          # segment uploaded a checkpoint before that, so the newest one is the
+          # last state the run is known to have reached — publish that instead
+          # of nothing. Its weekly-summary.json carries status=in_progress, so
+          # the assemble step updates the latest-* files without appending a
+          # dead run's partial numbers to the history series.
+          prefix="soak-checkpoint-${RUN_ID}-${RUN_ATTEMPT}-"
+          name="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            | jq -r --arg prefix "$prefix" \
+              '[.artifacts[] | select(.name | startswith($prefix)) | select(.expired | not)]
+               | sort_by(.created_at) | last.name // empty' || true)"
+          if [ -z "$name" ]; then
+            echo "::error::soak results artifact is missing and no checkpoint was ever uploaded; the run died before its first checkpoint. Nothing to publish — see the post-mortem artifact."
+            exit 1
+          fi
+          mkdir -p soak-results/report
+          gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --name "$name" --dir soak-results/report
+          echo "::warning::final soak results were never uploaded (runner lost); publishing the last checkpoint ${name} instead"
+          echo "Recovered checkpoint: ${name}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Assemble dashboard site
         shell: bash -euo pipefail {0}
@@ -1387,17 +1427,28 @@ jobs:
           # and burning a slot of the daily retention cap. Runs whose id is
           # missing or "unknown" are always appended — they cannot be told
           # apart, so collapsing them would merge genuinely distinct runs.
-          hist="site/data/history${SERIES_SUFFIX}.json"
-          [ -e "$hist" ] || echo '[]' > "$hist"
-          jq -s --argjson max "$MAX_HISTORY" \
-            '.[0] as $hist | .[1] as $new
-             | ($new.run.run_id // "") as $rid
-             | (if $rid == "" or $rid == "unknown" then $hist
-                else ($hist | map(select((.run.run_id // "") != $rid))) end) as $kept
-             | ($kept + [$new] | sort_by(.run.date)) as $all
-             | if $max > 0 and ($all | length) > $max then $all[-$max:] else $all end' \
-            "$hist" soak-results/report/weekly-summary.json > /tmp/history-merged.json
-          mv /tmp/history-merged.json "$hist"
+          #
+          # A recovered checkpoint (status=in_progress — the runner died and
+          # the fallback above republished the last mid-run state) updates the
+          # latest-* files below but never joins the history: a history entry
+          # means one completed run, and a partial night's lower numbers would
+          # poison every later week-over-week comparison drawn against it.
+          if jq -e '(.run.status // "complete") == "in_progress"' \
+            soak-results/report/weekly-summary.json >/dev/null; then
+            echo "recovered checkpoint: updating latest-* only, not appending to history"
+          else
+            hist="site/data/history${SERIES_SUFFIX}.json"
+            [ -e "$hist" ] || echo '[]' > "$hist"
+            jq -s --argjson max "$MAX_HISTORY" \
+              '.[0] as $hist | .[1] as $new
+               | ($new.run.run_id // "") as $rid
+               | (if $rid == "" or $rid == "unknown" then $hist
+                  else ($hist | map(select((.run.run_id // "") != $rid))) end) as $kept
+               | ($kept + [$new] | sort_by(.run.date)) as $all
+               | if $max > 0 and ($all | length) > $max then $all[-$max:] else $all end' \
+              "$hist" soak-results/report/weekly-summary.json > /tmp/history-merged.json
+            mv /tmp/history-merged.json "$hist"
+          fi
           cp soak-results/report/weekly-summary.json "site/data/latest-summary${SERIES_SUFFIX}.json"
           cp soak-results/report/verdict.json "site/data/latest-verdict${SERIES_SUFFIX}.json"
           cp soak-results/report/perf-report.md "site/data/latest-report${SERIES_SUFFIX}.md"
@@ -1683,6 +1734,71 @@ jobs:
           if grep -q 'Idle .* with no job; killing runner' /tmp/postmortem/console.log 2>/dev/null; then
             echo "::warning::CONFIRMED: the cloud-init idle watchdog killed the runner while a job was active"
           fi
+
+      # The self-tag exempts the VM from the reaper until window end + 2h so a
+      # healthy soak is never shot mid-run. But this job only runs when the run
+      # is already dead, and a weekend VM frozen on Friday night then sits
+      # billable behind that exemption until Sunday + 2h — the 16-OCPU leak of
+      # 2026-08-01. With the post-mortem captured above, the exemption has done
+      # its job: shrink the deadline to a short grace so the next hourly reaper
+      # pass collects the VM. 30 minutes rather than immediate, because a
+      # "lost" runner can be an OCI host stall the VM recovers from — give its
+      # own self-termination path first claim before the reaper's backstop.
+      #
+      # Fail-soft throughout: the original deadline still bounds the leak at
+      # window end + 2h, so a failure here costs money, not correctness — and
+      # must never bury the post-mortem this job exists to produce.
+      - name: Release reaper exemption
+        if: always() && steps.resolve.outputs.instance_id != ''
+        env:
+          IID: ${{ steps.resolve.outputs.instance_id }}
+          SUPPRESS_LABEL_WARNING: "True"
+        shell: bash -e {0}
+        run: |
+          state="$(jq -r '.data."lifecycle-state" // empty' /tmp/postmortem/instance.json 2>/dev/null || true)"
+          case "$state" in
+            TERMINATED|TERMINATING)
+              echo "instance is $state; nothing to release"
+              exit 0
+              ;;
+          esac
+          new_deadline="$(( $(date -u +%s) + 1800 ))"
+          released=""
+          for attempt in 1 2 3; do
+            # Same read-modify-write as the self-tag step: --freeform-tags
+            # replaces the whole map, so an unreadable or unparseable read
+            # means retry, never write.
+            if ! existing="$(oci compute instance get --instance-id "$IID" \
+                 --query 'data."freeform-tags"' --raw-output 2>&1)"; then
+              printf 'attempt %s/3: could not read current tags\n' "$attempt"
+              sleep 10
+              continue
+            fi
+            case "$existing" in ''|null) existing='{}' ;; esac
+            if ! jq -e 'type == "object"' <<<"$existing" >/dev/null 2>&1; then
+              printf 'attempt %s/3: current tags did not parse as a JSON object\n' "$attempt"
+              sleep 10
+              continue
+            fi
+            current="$(jq -r '."soak-deadline-epoch" // empty' <<<"$existing")"
+            if [ -n "$current" ] && [ "$current" -le "$new_deadline" ] 2>/dev/null; then
+              echo "existing deadline $current is already within the grace window"
+              released=1
+              break
+            fi
+            merged="$(jq -c --arg d "$new_deadline" \
+              '. + {"soak-deadline-epoch": $d}' <<<"$existing")"
+            if oci compute instance update --instance-id "$IID" --force \
+                 --freeform-tags "$merged" >/dev/null 2>&1; then
+              released=1
+              echo "reaper exemption released: $IID reapable after $(date -u -d "@${new_deadline}" +%FT%TZ)"
+              break
+            fi
+            printf 'attempt %s/3: tag update failed\n' "$attempt"
+            sleep 10
+          done
+          [ -n "$released" ] || \
+            echo "::warning::could not release the reaper exemption for $IID; the VM stays billable until its original window-end deadline"
 
       - name: Upload post-mortem
         if: always()

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -47,6 +47,16 @@ on:
         required: false
         default: "0"
         type: string
+      canary:
+        description: Run a 30-minute non-publishing OCI protection canary
+        required: false
+        default: false
+        type: boolean
+      inject_protection_breach:
+        description: Force a canary host-floor breach after workload startup
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -138,6 +148,8 @@ jobs:
       # restarted run to this instant so it conforms to the original slot.
       end_epoch: ${{ steps.resolve.outputs.end_epoch }}
       retry_attempt: ${{ steps.resolve.outputs.retry_attempt }}
+      canary: ${{ steps.resolve.outputs.canary }}
+      inject_protection_breach: ${{ steps.resolve.outputs.inject_protection_breach }}
       # Pacific 07:30/13:00 instants inside the run, as epoch seconds. Empty
       # slots are skipped; see the resolve step for why there are five.
       checkpoint_1: ${{ steps.resolve.outputs.checkpoint_1 }}
@@ -156,10 +168,22 @@ jobs:
           INPUT_WINDOW_END: ${{ inputs.window_end_epoch }}
           INPUT_SERIES: ${{ inputs.series }}
           INPUT_RETRY_ATTEMPT: ${{ inputs.retry_attempt }}
+          INPUT_CANARY: ${{ inputs.canary }}
+          INPUT_INJECT_PROTECTION_BREACH: ${{ inputs.inject_protection_breach }}
           # Read-only, for the "did anything land since the last window?" check.
           GH_TOKEN: ${{ github.token }}
         shell: bash -euo pipefail {0}
         run: |
+          case "${INPUT_INJECT_PROTECTION_BREACH:-false}" in
+            true)
+              if [ "${INPUT_CANARY:-false}" != "true" ]; then
+                echo "::error::inject_protection_breach requires canary"
+                exit 1
+              fi
+              ;;
+            false|"") ;;
+            *) echo "::error::inject_protection_breach must be true or false"; exit 1 ;;
+          esac
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ "$INPUT_DURATION" = "weekend-60h" ]; then
               duration_seconds=216000
@@ -179,7 +203,13 @@ jobs:
             # scheduled run would have — it can never spill into the next
             # slot. The checkpoint enumeration below then yields exactly the
             # original window's remaining Pacific instants.
-            if [ -n "$INPUT_WINDOW_END" ]; then
+            if [ "$INPUT_CANARY" = "true" ]; then
+              if [ -n "$INPUT_WINDOW_END" ] || [ -n "$INPUT_SERIES" ] || [ "${INPUT_RETRY_ATTEMPT:-0}" != "0" ]; then
+                echo "::error::canary cannot be combined with window_end_epoch, series, or a retry attempt"
+                exit 1
+              fi
+              duration_seconds=1800
+            elif [ -n "$INPUT_WINDOW_END" ]; then
               case "$INPUT_WINDOW_END" in
                 *[!0-9]*) echo "::error::window_end_epoch must be epoch seconds"; exit 1 ;;
               esac
@@ -340,6 +370,9 @@ jobs:
               fi
             done
           done
+          if [ "${INPUT_CANARY:-false}" = "true" ]; then
+            checkpoints=()
+          fi
           cp1=""; cp2=""; cp3=""; cp4=""; cp5=""
           [ "${#checkpoints[@]}" -ge 1 ] && cp1="${checkpoints[0]}"
           [ "${#checkpoints[@]}" -ge 2 ] && cp2="${checkpoints[1]}"
@@ -408,6 +441,8 @@ jobs:
             echo "kind=$kind"
             echo "end_epoch=$end_epoch"
             echo "retry_attempt=$retry_attempt"
+            echo "canary=${INPUT_CANARY:-false}"
+            echo "inject_protection_breach=${INPUT_INJECT_PROTECTION_BREACH:-false}"
             echo "checkpoint_1=$cp1"
             echo "checkpoint_2=$cp2"
             echo "checkpoint_3=$cp3"
@@ -739,6 +774,7 @@ jobs:
       !cancelled() &&
       needs.schedule_gate.outputs.should_run == 'true' &&
       needs.schedule_gate.outputs.retry_attempt == '0' &&
+      needs.schedule_gate.outputs.canary != 'true' &&
       (needs.launch_runner.result == 'failure' ||
        (needs.soak.result == 'failure' &&
         needs.soak.outputs.completed != 'true'))
@@ -984,6 +1020,14 @@ jobs:
         run: |
           poetry lock --no-update
           poetry install --with integration
+
+      - name: Configure injected protection breach
+        if: needs.schedule_gate.outputs.inject_protection_breach == 'true'
+        shell: bash -euo pipefail {0}
+        run: |
+          total_mb="$(awk '/^MemTotal:/ {print int($2 / 1024)}' /proc/meminfo)"
+          test "$total_mb" -gt 0
+          echo "SOAK_HOST_FREE_FLOOR_MB=$((total_mb + 1024))" >> "$GITHUB_ENV"
 
       # The soak runs as consecutive segments sharing one output directory, so
       # results can be published part-way through. The script resumes from its
@@ -1265,7 +1309,7 @@ jobs:
     # Both series publish. Gating this on run_benchmarks made it weekend-only,
     # so the dashboard's Daily tab had no producer and nightly results expired
     # with the artifact.
-    if: needs.schedule_gate.outputs.should_run == 'true' && !cancelled()
+    if: needs.schedule_gate.outputs.should_run == 'true' && needs.schedule_gate.outputs.canary != 'true' && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -1828,6 +1872,7 @@ jobs:
     if: >-
       always() &&
       needs.schedule_gate.outputs.should_run == 'true' &&
+      needs.schedule_gate.outputs.canary != 'true' &&
       (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     runs-on: ubuntu-latest
     environment: oci-credentials

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -1,5 +1,8 @@
 name: Merge Recovery Soak
 
+run-name: >-
+  ${{ inputs.scheduled_slot_epoch != '' && format('Merge Recovery Soak [scheduled:{0}]', inputs.scheduled_slot_epoch) || 'Merge Recovery Soak' }}
+
 on:
   schedule:
     # Both slots target Pacific 19:30; one matches PDT (UTC-7), the other PST
@@ -11,6 +14,11 @@ on:
     - cron: "30 3 * * *"
   workflow_dispatch:
     inputs:
+      scheduled_slot_epoch:
+        description: Intended OCI Resource Scheduler slot in epoch seconds; empty means manual mode
+        required: false
+        default: ""
+        type: string
       target_ref:
         description: Branch, tag, or SHA to validate
         required: true
@@ -59,6 +67,7 @@ on:
         type: boolean
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -135,6 +144,9 @@ jobs:
     name: Resolve Pacific Schedule
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: merge-recovery-soak-slot-${{ inputs.scheduled_slot_epoch != '' && inputs.scheduled_slot_epoch || github.run_id }}
+      cancel-in-progress: false
     outputs:
       should_run: ${{ steps.resolve.outputs.should_run }}
       duration_seconds: ${{ steps.resolve.outputs.duration_seconds }}
@@ -163,6 +175,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SCHEDULE: ${{ github.event.schedule }}
+          INPUT_SCHEDULED_SLOT: ${{ inputs.scheduled_slot_epoch }}
           INPUT_DURATION: ${{ inputs.duration }}
           INPUT_TARGET_REF: ${{ inputs.target_ref }}
           INPUT_WINDOW_END: ${{ inputs.window_end_epoch }}
@@ -184,7 +197,67 @@ jobs:
             false|"") ;;
             *) echo "::error::inject_protection_breach must be true or false"; exit 1 ;;
           esac
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ -n "$INPUT_SCHEDULED_SLOT" ]; then
+            if [ "${INPUT_CANARY:-false}" = "true" ] || [ "${INPUT_INJECT_PROTECTION_BREACH:-false}" = "true" ] || [ -n "$INPUT_WINDOW_END" ] || [ -n "$INPUT_SERIES" ] || [ "${INPUT_RETRY_ATTEMPT:-0}" != "0" ]; then
+              echo "::error::scheduled_slot_epoch cannot be combined with canary, injection, restart, series, or retry inputs"
+              exit 1
+            fi
+            case "$INPUT_SCHEDULED_SLOT" in
+              ''|*[!0-9]*) echo "::error::scheduled_slot_epoch must be epoch seconds"; exit 1 ;;
+            esac
+            now_epoch="$(date -u +%s)"
+            slot_epoch="$INPUT_SCHEDULED_SLOT"
+            trigger_delay=$((now_epoch - slot_epoch))
+            if [ "$trigger_delay" -lt 0 ] || [ "$trigger_delay" -gt 900 ]; then
+              echo "::error::scheduled_slot_epoch delay ${trigger_delay}s is outside the accepted 0..900s range"
+              exit 1
+            fi
+            pacific_hm="$(TZ=America/Los_Angeles date -d "@$slot_epoch" +%H%M)"
+            pacific_weekday="$(TZ=America/Los_Angeles date -d "@$slot_epoch" +%u)"
+            if [ "$pacific_hm" != "1930" ] || [ "$pacific_weekday" -lt 1 ] || [ "$pacific_weekday" -gt 5 ]; then
+              echo "::error::OCI slot $(date -u -d "@$slot_epoch" +%FT%TZ) does not resolve to an eligible Pacific 19:30 weekday"
+              exit 1
+            fi
+            echo "source=oci-resource-scheduler slot=$(date -u -d "@$slot_epoch" +%FT%TZ) pacific_hm=$pacific_hm pacific_weekday=$pacific_weekday trigger_delay=${trigger_delay}s"
+            should_run=true
+            idle_skip=false
+            duplicate_skip=false
+            expected_title="Merge Recovery Soak [scheduled:${slot_epoch}]"
+            canonical_run="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null \
+              | jq -r --arg title "$expected_title" '[.workflow_runs[] | select(.display_title == $title) | .id] | min // empty' \
+              || true)"
+            if [ -n "$canonical_run" ] && [ "$canonical_run" != "$GITHUB_RUN_ID" ]; then
+              should_run=false
+              duplicate_skip=true
+              echo "scheduled slot already belongs to run $canonical_run; suppressing duplicate run $GITHUB_RUN_ID"
+            fi
+            if [ "$pacific_weekday" -eq 5 ]; then
+              target_ref=master
+              duration_seconds=216000
+            else
+              target_ref=dev
+              duration_seconds=79200
+              if [ "$should_run" = "true" ]; then
+                if [ "$pacific_weekday" -eq 1 ]; then
+                  prev_slot_epoch=$((slot_epoch - 4 * 86400))
+                else
+                  prev_slot_epoch=$((slot_epoch - 86400))
+                fi
+                since="$(date -u -d "@$((prev_slot_epoch - 7200))" +%Y-%m-%dT%H:%M:%SZ)"
+                new_commits="$(gh api \
+                  "repos/${GITHUB_REPOSITORY}/commits?sha=${target_ref}&since=${since}" \
+                  --jq 'length' 2>/dev/null || echo "")"
+                if [ "$new_commits" = "0" ]; then
+                  should_run=false
+                  idle_skip=true
+                  echo "no commits on $target_ref since $since; skipping tonight's soak"
+                else
+                  echo "commits on $target_ref since $since: ${new_commits:-unknown (check failed; soaking anyway)}"
+                fi
+              fi
+            fi
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ "$INPUT_DURATION" = "weekend-60h" ]; then
               duration_seconds=216000
             else
@@ -316,6 +389,7 @@ jobs:
             elif [ "$pacific_hm" = "1930" ] && [ "$pacific_weekday" -eq 5 ]; then
               # Friday 19:30 + 60h = Monday 07:30 Pacific.
               should_run=true
+              target_ref=master
               duration_seconds=216000
             fi
           fi
@@ -397,6 +471,14 @@ jobs:
               echo "## Restart gate: skipped (window nearly over)"
               echo ""
               echo "The original window ends too soon for a restart to be worth an OCI runner."
+              echo "**No soak was attempted** — a green check on this run is not a soak result."
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$should_run" != "true" ] && [ "${duplicate_skip:-false}" = "true" ]; then
+            echo "::notice::Schedule gate skip: another run owns this OCI slot. No soak was attempted; this run's success is not a soak result."
+            {
+              echo "## Schedule gate: skipped (duplicate OCI slot)"
+              echo ""
+              echo "Run \`$canonical_run\` already owns scheduled slot \`$slot_epoch\`."
               echo "**No soak was attempted** — a green check on this run is not a soak result."
             } >> "$GITHUB_STEP_SUMMARY"
           elif [ "$should_run" != "true" ] && [ "${idle_skip:-false}" = "true" ]; then

--- a/.github/workflows/soak-checkpoint-publish.yml
+++ b/.github/workflows/soak-checkpoint-publish.yml
@@ -95,15 +95,25 @@ jobs:
           # The soak run is still in progress. Artifacts are readable as soon as
           # they finish uploading, but the dispatch can outrun that, so retry a
           # few times before giving up.
+          #
+          # --repo is load-bearing: this step's working directory is not a git
+          # checkout (the checkout lands in ci-control/), and without it every
+          # gh invocation dies on "failed to determine base repo" before ever
+          # reaching the API — which run 30716000285 then reported as five
+          # rounds of "artifact not ready" against an artifact that existed.
+          # The real error is echoed per attempt so a recurrence names itself.
           for attempt in 1 2 3 4 5; do
-            if gh run download "$RUN_ID" --name "$ARTIFACT" --dir checkpoint; then
+            if download_err="$(gh run download "$RUN_ID" \
+                 --repo "$GITHUB_REPOSITORY" \
+                 --name "$ARTIFACT" --dir checkpoint 2>&1)"; then
               break
             fi
+            printf 'attempt %s failed: %s\n' "$attempt" "$download_err"
             if [ "$attempt" = "5" ]; then
               echo "::error::artifact ${ARTIFACT} not readable on run ${RUN_ID} after 5 attempts"
               exit 1
             fi
-            echo "attempt ${attempt}: artifact not ready, retrying"
+            echo "attempt ${attempt}: retrying"
             sleep 15
           done
           test -s checkpoint/weekly-summary.json || {

--- a/.github/workflows/soak-dashboard-pages.yml
+++ b/.github/workflows/soak-dashboard-pages.yml
@@ -7,6 +7,36 @@ on:
       - .github/dashboard/**
       - .github/workflows/soak-dashboard-pages.yml
   workflow_dispatch:
+    inputs:
+      remove_run_id:
+        description: Run ID to remove from one dashboard history
+        required: false
+        default: ""
+        type: string
+      restore_run_id:
+        description: Run ID whose final report becomes latest after removal
+        required: false
+        default: ""
+        type: string
+      restore_run_attempt:
+        description: Restore run attempt
+        required: false
+        default: "1"
+        type: string
+      restore_duration_seconds:
+        description: Restore run artifact duration component
+        required: false
+        default: ""
+        type: string
+      restore_series:
+        description: Series to repair
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - daily
+          - weekend
 
 permissions:
   contents: read
@@ -17,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write
@@ -36,6 +67,12 @@ jobs:
         shell: bash -euo pipefail {0}
         env:
           DASHBOARD_URL: https://f1r3fly-io.github.io/f1r3node-rust/
+          GH_TOKEN: ${{ github.token }}
+          REMOVE_RUN_ID: ${{ inputs.remove_run_id }}
+          RESTORE_RUN_ID: ${{ inputs.restore_run_id }}
+          RESTORE_RUN_ATTEMPT: ${{ inputs.restore_run_attempt }}
+          RESTORE_DURATION_SECONDS: ${{ inputs.restore_duration_seconds }}
+          RESTORE_SERIES: ${{ inputs.restore_series }}
         run: |
           # Bootstrap/refresh deploy: publish the dashboard shell while
           # preserving any data already published by the weekend soak's
@@ -119,6 +156,24 @@ jobs:
               }
             done
           done
+          if [ -n "$REMOVE_RUN_ID" ]; then
+            case "$REMOVE_RUN_ID/$RESTORE_RUN_ID/$RESTORE_RUN_ATTEMPT/$RESTORE_DURATION_SECONDS" in
+              *[!0-9/]*|*//*|/*|*/) echo "::error::dashboard repair inputs must be non-empty integers"; exit 1 ;;
+            esac
+            case "$RESTORE_SERIES" in
+              daily|weekend) ;;
+              *) echo "::error::restore_series must be daily or weekend"; exit 1 ;;
+            esac
+            artifact="merge-recovery-soak-${RESTORE_DURATION_SECONDS}s-${RESTORE_RUN_ID}-${RESTORE_RUN_ATTEMPT}"
+            gh run download "$RESTORE_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$artifact" --dir restore
+            SITE_DIR=site/data \
+            RESTORE_REPORT_DIR=restore/report \
+            REMOVE_RUN_ID="$REMOVE_RUN_ID" \
+            RESTORE_RUN_ID="$RESTORE_RUN_ID" \
+            RESTORE_RUN_ATTEMPT="$RESTORE_RUN_ATTEMPT" \
+            RESTORE_SERIES="$RESTORE_SERIES" \
+              bash scripts/bench/restore-soak-dashboard-run.sh
+          fi
           # Seed a grey "no data" badge for any series that has not published
           # one, exactly as the reports below are seeded.
           #

--- a/docs/work-logs/randomized-exercise-soak-planning-2026-08-01.md
+++ b/docs/work-logs/randomized-exercise-soak-planning-2026-08-01.md
@@ -1,0 +1,49 @@
+# Work Log: Randomized Exercise Soak Planning
+
+## Session
+
+- **Started:** 2026-08-01T16:55:13Z
+- **Branch:** `feature/randomized-exercise-soak`
+- **Parallel repository:** `F1R3FLY-io/system-integration`
+- **Parallel branch:** `feature/randomized-exercise-soak-catalogue`
+- **Status:** planning artifacts ready for review
+
+## Decisions
+
+- Exercise epochs are bounded executions of versioned valid-operation workloads.
+- Workload IDs use `SOAK-EPOCH-NNN`, separate from planning EPIC/EPOCH IDs.
+- Exact identity is the epoch ID/revision plus catalog schema, definition SHA/digest, orchestrator SHA, seed, provider, topology, and effective limits.
+- Initial delivery uses the existing six-node single shard and both providers.
+- The first six profiles cover steady traffic, bursts, channel contention, large valid deploys, dependent chains, and mixed contracts.
+- Selection is seeded, weighted, and coverage-constrained rather than purely random.
+- Multiple epochs may run per segment, but admission must preserve checkpoint and reset reserves.
+- Ordinary workload failures preserve evidence, reset, and continue. Safety, host-protection, or reset failures stop immediately.
+- Newly discovered valid-workload regressions are minimized and added as experimental epochs before promotion.
+- Infrastructure failures remain outside the workload catalog.
+- Executable catalog ownership belongs to system-integration; orchestration and reporting belong here.
+
+## Artifacts
+
+- `docs/randomized-exercise-soak.md`
+- `docs/UserStories.md`: US-005 through US-008
+- `docs/ToDos.md`: EPIC-011 through EPIC-016
+- `docs/ci-pins.md`
+- `../system-integration/docs/specs/randomized-exercise-soak-contract.md`
+- `../system-integration/docs/handoffs/agent-session-f1r3node-rust--pi-session-019fa4ad--20260801T165513Z.md`
+
+## Cross-Repository Handoff
+
+The system-integration handoff requests an executor/catalog contract, deterministic valid workload generators, provider parity, finalized-state invariants, clean reset, structured results, and replay manifests. Interface changes are complete only when mirrored contract fixtures pass in both repositories. The follow-up pin design splits privileged `runnerRef` from fast-moving `catalogRef` in `.github/ci-pins.jsonc`; compatible catalog additions should require only a one-line catalog pin bump.
+
+## Next Work
+
+1. Ratify EPIC-011's identity and schema.
+2. Receive the executor agent's proposed CLI and result schema.
+3. Add mirrored compatibility fixtures.
+4. Validate the pinned catalog before OCI launch.
+5. Implement the deterministic planner after duration and capability metadata stabilize.
+
+## Blockers
+
+- Executor CLI and result schema are awaiting the parallel system-integration agent.
+- Epoch duration estimates require implementation evidence before minimum weekend coverage can become release-gating.

--- a/docs/work-logs/soak-oci-image-defects-20260801.md
+++ b/docs/work-logs/soak-oci-image-defects-20260801.md
@@ -7,8 +7,11 @@ branch: hotfix/full-fix-of-actual-OCI-image
 parallel_repository: F1R3FLY-io/system-integration
 parallel_branch: hotfix/full-fix-of-actual-OCI-image
 next_steps:
-  - Commit both repos (per-commit consent required)
-  - Live OCI canary on the real Ubuntu 22.04 image (user approval pending)
+
+- Commit and push the post-canary corrections in this repository
+- Run the dashboard restoration workflow for canary run 30726357502
+- Re-run CI and review PR #190
+
 ---
 
 ## Root causes (run 30713818751, 2026-08-01 weekend soak)
@@ -39,9 +42,11 @@ One real event amplified by seven tooling defects:
 7. The frozen VM stayed behind its reaper exemption (window end + 2h — for a
    Friday weekend-soak freeze, ~2 days of billed 16-OCPU) until manually
    terminated.
-8. The silent 28–46min gaps between iterations were `cp -a` of the full
-   integration-tests data dir (LMDB included) on the failure path, not a
-   pytest teardown hang — pytest teardown completed in ~1s every time.
+8. Full-directory evidence copies explained earlier 28–46min gaps, but the OCI
+   canary showed a second delay: pytest printed its terminal summary at 01:16:29
+   while the foreground pipeline did not return until 01:25:36. The soak driver
+   now backgrounds the iteration, polls the independent guardian marker, and
+   terminates the timeout process promptly when protection fires.
 
 ## Changes (this repo)
 
@@ -60,7 +65,12 @@ One real event amplified by seven tooling defects:
     and timed;
   - minimal fallback `summary.json` when the full rollup fails, preserving the
     checkpoint metadata contract;
-  - bench segment/bench.log tails surfaced on failure.
+  - bench segment/bench.log tails surfaced on failure;
+  - foreground pytest runs are actively terminated when the independent marker
+    appears, with the matching process tree and FIFO cleaned up.
+- `scripts/bench/aggregate-perf-report.sh` — complete runs regress on any
+  passive iteration failure or host-protection marker, independent of baseline
+  availability.
 - `scripts/bench/run-bench-segment.sh` — `DEPLOYER_KEY` defaults to
   `BOOTSTRAP_PRIVATE_KEY` from `$NODE_REPO_DIR/docker/.env` (documented funded
   fixture); bench.log tail on failure.
@@ -71,7 +81,14 @@ One real event amplified by seven tooling defects:
     checkpoint artifact (publishes latest-* only, never appends in_progress
     state to history); job gains `actions: read`;
   - capture_diagnostics: new "Release reaper exemption" step shrinks
-    `soak-deadline-epoch` to now+30min after the post-mortem, fail-soft.
+    `soak-deadline-epoch` to now+30min after the post-mortem, fail-soft;
+  - 30-minute canaries cannot retry, checkpoint-publish, dashboard-publish, or
+    send production failure notifications; optional breach injection derives a
+    guaranteed host floor from the actual runner's total RAM.
+- `scripts/bench/restore-soak-dashboard-run.sh` and
+  `.github/workflows/soak-dashboard-pages.yml` — validate the restore run,
+  attempt, series, status, and history ordering before removing exactly one
+  accidental entry and restoring its predecessor.
 
 ## Changes (../system-integration)
 
@@ -90,6 +107,16 @@ One real event amplified by seven tooling defects:
   iteration, `early_exit_reason=host_protection_breach`, segment-2 resume
   no-ops, checkpoint passes the exact publish-workflow metadata validation;
   fallback summary also passes the contract.
+- OCI canary run 30726357502 used the production Ubuntu 22.04 image and pinned
+  system-integration `66de4f95`. The independent guardian fired at 10134MB
+  available, killed all six containers, restored 30GB available, stopped after
+  one iteration, uploaded valid checkpoint/final artifacts, and the instance
+  self-terminated with its boot volume.
+- The checkpoint artifact downloaded successfully from a non-git working
+  directory with explicit `--repo`, and its metadata passed the publisher's
+  exact validation expression.
+- All four amd64/arm64 Docker/subprocess OCI integration lanes passed against
+  `66de4f95` in run 30725659408.
 
 ## Open items
 
@@ -100,6 +127,16 @@ One real event amplified by seven tooling defects:
 - Per-container docker memory caps in the harness provider — recommended
   follow-up in system-integration; the orchestrator guardian covers the host
   meanwhile.
-- Live canary on the real OCI Ubuntu 22.04 image (normal low-load pass,
-  injected protection failure, checkpoint publish, self-termination) —
-  awaiting user approval; requires the branches to be pushed first.
+- Canary run 30726357502 exposed a false dashboard verdict: one failed passive
+  iteration was published as PASS because verdict logic only compared failure
+  rate to a baseline whose metrics were null. Absolute passive failures now
+  produce a regression verdict and have dedicated tests.
+- The canary branch had already been temporarily admitted to `github-pages`, so
+  the canary appended run 30726357502 to the production daily history despite
+  the intended non-publishing validation. Both temporary environment policies
+  are removed. A validated restoration helper and workflow inputs remove that
+  entry and restore run 30516534214 after these corrections are pushed.
+- The checkpoint dispatch intentionally targeted the default branch, so its
+  workflow ran pre-fix master code and reproduced the missing-`--repo` failure.
+  The corrected command and metadata contract passed separately; the first
+  post-merge checkpoint remains the end-to-end deployment proof.

--- a/docs/work-logs/soak-oci-image-defects-20260801.md
+++ b/docs/work-logs/soak-oci-image-defects-20260801.md
@@ -1,0 +1,105 @@
+# Work Log: Weekend Soak Defect Sweep (run 30713818751 post-mortem)
+
+---
+handoff_status: ready
+claimed_by: claude-session-917f64e8
+branch: hotfix/full-fix-of-actual-OCI-image
+parallel_repository: F1R3FLY-io/system-integration
+parallel_branch: hotfix/full-fix-of-actual-OCI-image
+next_steps:
+  - Commit both repos (per-commit consent required)
+  - Live OCI canary on the real Ubuntu 22.04 image (user approval pending)
+---
+
+## Root causes (run 30713818751, 2026-08-01 weekend soak)
+
+One real event amplified by seven tooling defects:
+
+1. Every load iteration breached the host-protection ceiling (18095/15319/17052MB
+   vs 14336MB); the guardian correctly killed the nodes each time, but the soak
+   loop counted it as an ordinary failure and kept relaunching for 2+ hours.
+2. `write-soak-summary.sh` used jq variable `$def` — a jq keyword rejected by
+   jq 1.6 on the Ubuntu 22.04 runner (CI lints on ubuntu-latest jq 1.7, which
+   accepts it) — killing the summary and, via null `started_at`/`elapsed_seconds`
+   metadata, invalidating the checkpoint.
+3. Soak Checkpoint Publish ran `gh run download` in a non-git cwd without
+   `--repo`; every attempt died on "not a git repository" but was reported as
+   "artifact not ready" — against an artifact that existed.
+4. Bench segments failed 100% silently: `latency-benchmark.sh` hard-requires
+   `DEPLOYER_KEY` and nothing in the soak path supplied it; its output went to
+   a bench.log that died with the VM.
+5. The kernel OOM killer shot pytest (oom_score_adj 500) at ~21:11 while
+   docker-provider node containers — uncapped, not pytest children — kept
+   growing until the VM froze and the runner was lost. The harness's docker
+   provider sets no per-container memory limit; the "platform-capped"
+   assumption in resource_monitor.py was wrong.
+6. The final results artifact upload lives at job end, so the lost runner
+   uploaded nothing and Publish Soak Dashboard hard-failed on the missing
+   artifact with no fallback.
+7. The frozen VM stayed behind its reaper exemption (window end + 2h — for a
+   Friday weekend-soak freeze, ~2 days of billed 16-OCPU) until manually
+   terminated.
+8. The silent 28–46min gaps between iterations were `cp -a` of the full
+   integration-tests data dir (LMDB included) on the failure path, not a
+   pytest teardown hang — pytest teardown completed in ~1s every time.
+
+## Changes (this repo)
+
+- `scripts/bench/write-soak-summary.sh` — `$def` → `$mdef` (jq 1.6).
+- `scripts/bench/test-write-soak-summary.sh` — jq-keyword-as-variable lint
+  across all soak scripts (runs in the CI Lint job).
+- `scripts/run-merge-recovery-soak.sh` —
+  - fail-closed on any host-protection breach (three detection channels:
+    orchestrator guardian marker, harness marker, pytest.log message);
+    writes `early-exit.txt` so later segments no-op; still reaches the
+    completion marker so `retry_within_window` does not relaunch;
+  - orchestrator-level host guardian: independent background process watching
+    MemAvailable, SIGKILLs `/tmp/rnode` processes and `rnode.*` containers on
+    sustained floor breach — survives pytest death (the observed failure);
+  - failure-evidence copy is now selective (logs/CSV/JSON/conf via tar), loud,
+    and timed;
+  - minimal fallback `summary.json` when the full rollup fails, preserving the
+    checkpoint metadata contract;
+  - bench segment/bench.log tails surfaced on failure.
+- `scripts/bench/run-bench-segment.sh` — `DEPLOYER_KEY` defaults to
+  `BOOTSTRAP_PRIVATE_KEY` from `$NODE_REPO_DIR/docker/.env` (documented funded
+  fixture); bench.log tail on failure.
+- `.github/workflows/soak-checkpoint-publish.yml` — explicit `--repo` on
+  `gh run download`; real error echoed per retry.
+- `.github/workflows/merge-recovery-soak.yml` —
+  - perf_report: results download non-fatal + recovery of the newest
+    checkpoint artifact (publishes latest-* only, never appends in_progress
+    state to history); job gains `actions: read`;
+  - capture_diagnostics: new "Release reaper exemption" step shrinks
+    `soak-deadline-epoch` to now+30min after the post-mortem, fail-soft.
+
+## Changes (../system-integration)
+
+- `integration-tests/test/infra/resource_monitor.py` — persists the breach
+  reason to `host-protection-breach.txt` in the monitor output dir
+  (machine-readable orchestrator channel); corrected the wrong
+  "Docker/K8s — platform-capped" comment.
+
+## Validation done
+
+- `bash -n` all scripts; `check-workflow-invariants.sh` green; workflow YAML
+  parses; summary test harness green.
+- Real jq 1.6 binary: full test harness + driver + aggregator pass; the old
+  `$def` program reproduces the production error exactly.
+- Driver simulation with breach-emitting pytest stub: fail-closed after one
+  iteration, `early_exit_reason=host_protection_breach`, segment-2 resume
+  no-ops, checkpoint passes the exact publish-workflow metadata validation;
+  fallback summary also passes the contract.
+
+## Open items
+
+- RSS ceiling tuning: the load profile genuinely peaks over 14336MB on the
+  32GB VM (observed 16–18GB). Fail-closed now stops the burn, but either the
+  ceiling or the load profile needs adjusting before the next weekend soak
+  passes. Surfaced, deliberately not changed here.
+- Per-container docker memory caps in the harness provider — recommended
+  follow-up in system-integration; the orchestrator guardian covers the host
+  meanwhile.
+- Live canary on the real OCI Ubuntu 22.04 image (normal low-load pass,
+  injected protection failure, checkpoint publish, self-termination) —
+  awaiting user approval; requires the branches to be pushed first.

--- a/scripts/bench/aggregate-perf-report.sh
+++ b/scripts/bench/aggregate-perf-report.sh
@@ -109,6 +109,12 @@ if [ -n "$BASELINE_JSON" ] && [ -s "$BASELINE_JSON" ]; then
 	BASELINE_ARG="$(cat "$BASELINE_JSON")"
 fi
 
+PROTECTION_BREACH=false
+if [ -s "$SOAK_DIR/host-guardian-breach.txt" ] ||
+	grep -q '^host_protection_breach:' "$SOAK_DIR/early-exit.txt" 2>/dev/null; then
+	PROTECTION_BREACH=true
+fi
+
 jq -n \
 	--slurpfile segments "$SEGMENTS_JSON" \
 	--argjson passive "$PASSIVE_ARG" \
@@ -118,6 +124,7 @@ jq -n \
 	--argjson duration "$DURATION_SECONDS" \
 	--argjson retry_attempt "$RETRY_ATTEMPT" \
 	--argjson window "$WINDOW_SECONDS" \
+	--argjson protection_breach "$PROTECTION_BREACH" \
 	--arg date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 	--arg status "$SOAK_STATUS" \
 	'
@@ -146,6 +153,7 @@ jq -n \
         restarted: ($retry_attempt > 0),
         retry_attempt: $retry_attempt,
         status: $status,
+        protection_breach: $protection_breach,
         # Seconds actually soaked so far, against the run
         # budget — lets the dashboard show progress on a checkpoint.
         elapsed_seconds: ($passive.elapsed_seconds // null)
@@ -181,6 +189,7 @@ jq -n \
 	--argjson current "$(cat "$OUT_DIR/weekly-summary.json")" \
 	--argjson baseline "$BASELINE_ARG" \
 	--argjson thresholds "$(cat "$THRESHOLDS_JSON")" \
+	--argjson protection_breach "$PROTECTION_BREACH" \
 	--arg status "$SOAK_STATUS" \
 	'
   def pct_over(cur; base; pct):
@@ -196,6 +205,10 @@ jq -n \
       []
       | if $p == null
           then . + ["no passive soak summary was produced (no data)"] else . end
+      | if $p != null and (($p.failures // 0) > 0)
+          then . + ["\($p.failures) passive soak iteration(s) failed"] else . end
+      | if $protection_breach
+          then . + ["host protection breach aborted the soak"] else . end
       | if $bp != null and $p != null and $p.failure_rate != null and $bp.failure_rate != null
            and $p.failure_rate > ($bp.failure_rate + $thresholds.failure_rate_max_increase_pts)
           then . + ["failure rate \($p.failure_rate) exceeds baseline \($bp.failure_rate) by more than \($thresholds.failure_rate_max_increase_pts * 100)pts"] else . end

--- a/scripts/bench/restore-soak-dashboard-run.sh
+++ b/scripts/bench/restore-soak-dashboard-run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SITE_DIR="${SITE_DIR:?SITE_DIR is required}"
+RESTORE_REPORT_DIR="${RESTORE_REPORT_DIR:?RESTORE_REPORT_DIR is required}"
+REMOVE_RUN_ID="${REMOVE_RUN_ID:?REMOVE_RUN_ID is required}"
+RESTORE_RUN_ID="${RESTORE_RUN_ID:?RESTORE_RUN_ID is required}"
+RESTORE_RUN_ATTEMPT="${RESTORE_RUN_ATTEMPT:?RESTORE_RUN_ATTEMPT is required}"
+RESTORE_SERIES="${RESTORE_SERIES:?RESTORE_SERIES is required}"
+
+case "$REMOVE_RUN_ID/$RESTORE_RUN_ID/$RESTORE_RUN_ATTEMPT" in
+*[!0-9/]* | *//* | /* | */)
+	echo "run IDs must be positive integers" >&2
+	exit 2
+	;;
+esac
+case "$RESTORE_SERIES" in
+daily) suffix="-daily" ;;
+weekend) suffix="" ;;
+*)
+	echo "RESTORE_SERIES must be daily or weekend" >&2
+	exit 2
+	;;
+esac
+
+history="$SITE_DIR/history${suffix}.json"
+summary="$RESTORE_REPORT_DIR/weekly-summary.json"
+verdict="$RESTORE_REPORT_DIR/verdict.json"
+report="$RESTORE_REPORT_DIR/perf-report.md"
+
+jq -e 'type == "array"' "$history" >/dev/null
+jq -e --arg run_id "$RESTORE_RUN_ID" --argjson run_attempt "$RESTORE_RUN_ATTEMPT" --arg kind "$RESTORE_SERIES" '
+  type == "object"
+  and (.run.run_id | tostring) == $run_id
+  and .run.run_attempt == $run_attempt
+  and .run.kind == $kind
+  and .run.status == "complete"
+' "$summary" >/dev/null
+jq -e --arg run_id "$RESTORE_RUN_ID" --argjson run_attempt "$RESTORE_RUN_ATTEMPT" --arg kind "$RESTORE_SERIES" '
+  type == "object"
+  and (.run.run_id | tostring) == $run_id
+  and .run.run_attempt == $run_attempt
+  and .run.kind == $kind
+  and .run.status == "complete"
+' "$verdict" >/dev/null
+test -s "$report"
+
+before="$(jq 'length' "$history")"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+jq --arg remove "$REMOVE_RUN_ID" '
+  map(select((.run.run_id | tostring) != $remove))
+' "$history" >"$tmp"
+after="$(jq 'length' "$tmp")"
+if [ "$((before - after))" -ne 1 ]; then
+	echo "history must contain exactly one entry for run $REMOVE_RUN_ID" >&2
+	exit 1
+fi
+jq -e --arg restore "$RESTORE_RUN_ID" '
+  length > 0 and ((last.run.run_id | tostring) == $restore)
+' "$tmp" >/dev/null
+mv "$tmp" "$history"
+trap - EXIT
+
+cp "$summary" "$SITE_DIR/latest-summary${suffix}.json"
+cp "$verdict" "$SITE_DIR/latest-verdict${suffix}.json"
+cp "$report" "$SITE_DIR/latest-report${suffix}.md"
+
+for spec in badge.json:badge-soak badge-stability.json:badge-stability badge-perf.json:badge-perf; do
+	source="$RESTORE_REPORT_DIR/${spec%%:*}"
+	target="$SITE_DIR/${spec##*:}${suffix}.json"
+	if [ -s "$source" ]; then
+		cp "$source" "$target"
+	else
+		rm -f "$target"
+	fi
+done

--- a/scripts/bench/run-bench-segment.sh
+++ b/scripts/bench/run-bench-segment.sh
@@ -35,6 +35,22 @@ SHARD_YML="$NODE_REPO_DIR/docker/shard.yml"
 [ -f "$SHARD_YML" ] || { echo "missing $SHARD_YML" >&2; exit 2; }
 command -v jq >/dev/null || { echo "jq not found" >&2; exit 2; }
 
+# latency-benchmark.sh needs a funded deployer. Default to the shard's own
+# bootstrap key from the checked-in fixture env — the documented default
+# ("funded locally and in wallets.txt", docs/vps-cloud-testing.md) that the
+# benchmark script requires but nothing in the soak path ever supplied, which
+# made every soak bench segment die on its first line (run 30713818751:
+# bench_segments=1 bench_failures=1, every week, silently).
+if [ -z "${DEPLOYER_KEY:-}" ]; then
+  DEPLOYER_KEY="$(awk -F= '$1 == "BOOTSTRAP_PRIVATE_KEY" { print $2; exit }' \
+    "$NODE_REPO_DIR/docker/.env" 2>/dev/null || true)"
+  if [ -z "$DEPLOYER_KEY" ]; then
+    echo "DEPLOYER_KEY not set and no BOOTSTRAP_PRIVATE_KEY in $NODE_REPO_DIR/docker/.env" >&2
+    exit 2
+  fi
+fi
+export DEPLOYER_KEY
+
 mkdir -p "$OUT_DIR"
 COMPOSE=(docker compose -f "$SHARD_YML" -p soak-bench)
 SAMPLER_PID=""
@@ -111,7 +127,8 @@ if [ "$BENCH_STATUS" -ne 0 ] || [ ! -s "$BENCH_OUT/metrics.json" ]; then
     --argjson rss "${RSS_PEAK_MB:-0}" \
     '{segment_index: $idx, started_at: $started, offset_seconds: $offset,
       rss_peak_mb: $rss, ok: false}' > "$OUT_DIR/metrics.json"
-  echo "benchmark flood failed (status $BENCH_STATUS)" >&2
+  echo "benchmark flood failed (status $BENCH_STATUS); bench.log tail:" >&2
+  tail -20 "$OUT_DIR/bench.log" >&2 || true
   exit 1
 fi
 

--- a/scripts/bench/run-bench-segment.sh
+++ b/scripts/bench/run-bench-segment.sh
@@ -42,7 +42,7 @@ command -v jq >/dev/null || { echo "jq not found" >&2; exit 2; }
 # made every soak bench segment die on its first line (run 30713818751:
 # bench_segments=1 bench_failures=1, every week, silently).
 if [ -z "${DEPLOYER_KEY:-}" ]; then
-  DEPLOYER_KEY="$(awk -F= '$1 == "BOOTSTRAP_PRIVATE_KEY" { print $2; exit }' \
+  DEPLOYER_KEY="$(awk -F= '$1 == "BOOTSTRAP_PRIVATE_KEY" { gsub(/^["'\'']|["'\'']$/, "", $2); print $2; exit }' \
     "$NODE_REPO_DIR/docker/.env" 2>/dev/null || true)"
   if [ -z "$DEPLOYER_KEY" ]; then
     echo "DEPLOYER_KEY not set and no BOOTSTRAP_PRIVATE_KEY in $NODE_REPO_DIR/docker/.env" >&2

--- a/scripts/bench/test-aggregate-perf-report.sh
+++ b/scripts/bench/test-aggregate-perf-report.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/failed" "$TMP/failed-report"
+cat >"$TMP/failed/summary.json" <<'JSON'
+{
+  "target_ref": "dev",
+  "target_sha": "0123456789abcdef",
+  "version": "0.4.43",
+  "started_at": 1000,
+  "finished_at": 1100,
+  "elapsed_seconds": 100,
+  "iterations": 1,
+  "failures": 1,
+  "failure_rate": 1,
+  "iterations_per_hour": 36,
+  "rss_peak_mb": 17100,
+  "cpu_peak_pct": 100,
+  "finalization_p50_ms": null,
+  "finalization_p95_ms": null,
+  "finalization_p99_ms": null,
+  "too_far_ahead_errors": 0,
+  "providers": {
+    "docker": {"iterations": 1, "failures": 1, "avg_duration_s": 100},
+    "subprocess": {"iterations": 0, "failures": 0, "avg_duration_s": null}
+  },
+  "tracked_metrics": {}
+}
+JSON
+SOAK_DIR="$TMP/failed" OUT_DIR="$TMP/failed-report" RUN_ID=1 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=1 \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '
+  .verdict == "regress"
+  and .bootstrap == true
+  and (.failures | any(test("1 passive soak iteration\\(s\\) failed")))
+' "$TMP/failed-report/verdict.json" >/dev/null
+
+mkdir -p "$TMP/checkpoint-report"
+SOAK_DIR="$TMP/failed" OUT_DIR="$TMP/checkpoint-report" RUN_ID=1 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=1 \
+	SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '.verdict == "in_progress" and .failures == []' \
+	"$TMP/checkpoint-report/verdict.json" >/dev/null
+
+mkdir -p "$TMP/passing" "$TMP/passing-report"
+jq '.failures = 0 | .failure_rate = 0 | .providers.docker.failures = 0' \
+	"$TMP/failed/summary.json" >"$TMP/passing/summary.json"
+SOAK_DIR="$TMP/passing" OUT_DIR="$TMP/passing-report" RUN_ID=2 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '.verdict == "pass" and .bootstrap == true and .failures == []' \
+	"$TMP/passing-report/verdict.json" >/dev/null
+
+mkdir -p "$TMP/breach" "$TMP/breach-report"
+cp "$TMP/passing/summary.json" "$TMP/breach/summary.json"
+printf '%s\n' 'host_protection_breach: injected guardian marker' \
+	>"$TMP/breach/early-exit.txt"
+SOAK_DIR="$TMP/breach" OUT_DIR="$TMP/breach-report" RUN_ID=3 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '
+  .verdict == "regress"
+  and .run.protection_breach == true
+  and (.failures | any(. == "host protection breach aborted the soak"))
+' "$TMP/breach-report/verdict.json" >/dev/null
+
+printf 'soak report verdict tests passed\n'

--- a/scripts/bench/test-restore-soak-dashboard-run.sh
+++ b/scripts/bench/test-restore-soak-dashboard-run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/site" "$TMP/restore"
+cat >"$TMP/site/history-daily.json" <<'JSON'
+[
+  {"run":{"run_id":"100","kind":"daily","status":"complete","date":"2026-01-01T00:00:00Z"}},
+  {"run":{"run_id":"200","kind":"daily","status":"complete","date":"2026-01-02T00:00:00Z"}}
+]
+JSON
+printf '%s\n' '{"run":{"run_id":"200"}}' >"$TMP/site/latest-summary-daily.json"
+printf '%s\n' '{"run":{"run_id":"200"}}' >"$TMP/site/latest-verdict-daily.json"
+printf '%s\n' canary >"$TMP/site/latest-report-daily.md"
+printf '%s\n' '{}' >"$TMP/site/badge-soak-daily.json"
+printf '%s\n' '{}' >"$TMP/site/badge-stability-daily.json"
+printf '%s\n' '{}' >"$TMP/site/badge-perf-daily.json"
+printf '%s\n' '{"run":{"run_id":"100","run_attempt":1,"kind":"daily","status":"complete"}}' \
+	>"$TMP/restore/weekly-summary.json"
+printf '%s\n' '{"run":{"run_id":"100","run_attempt":1,"kind":"daily","status":"complete"},"verdict":"regress"}' \
+	>"$TMP/restore/verdict.json"
+printf '%s\n' restored >"$TMP/restore/perf-report.md"
+
+SITE_DIR="$TMP/site" RESTORE_REPORT_DIR="$TMP/restore" REMOVE_RUN_ID=200 \
+	RESTORE_RUN_ID=100 RESTORE_RUN_ATTEMPT=1 RESTORE_SERIES=daily \
+	"$ROOT/scripts/bench/restore-soak-dashboard-run.sh"
+
+jq -e 'length == 1 and .[0].run.run_id == "100"' "$TMP/site/history-daily.json" >/dev/null
+jq -e '.run.run_id == "100"' "$TMP/site/latest-summary-daily.json" >/dev/null
+jq -e '.run.run_id == "100"' "$TMP/site/latest-verdict-daily.json" >/dev/null
+grep -qx restored "$TMP/site/latest-report-daily.md"
+test ! -e "$TMP/site/badge-soak-daily.json"
+test ! -e "$TMP/site/badge-stability-daily.json"
+test ! -e "$TMP/site/badge-perf-daily.json"
+
+if SITE_DIR="$TMP/site" RESTORE_REPORT_DIR="$TMP/restore" REMOVE_RUN_ID=999 \
+	RESTORE_RUN_ID=100 RESTORE_RUN_ATTEMPT=1 RESTORE_SERIES=daily \
+	"$ROOT/scripts/bench/restore-soak-dashboard-run.sh" >/dev/null 2>&1; then
+	echo 'missing removal target was accepted' >&2
+	exit 1
+fi
+
+printf 'soak dashboard restoration tests passed\n'

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -20,8 +20,8 @@ SH
 chmod +x "$TMP/bin/poetry"
 
 PATH="$TMP/bin:$PATH" \
-FAKE_POETRY_PID_FILE="$TMP/fake-poetry.pid" \
-SOAK_DURATION_SECONDS=120 \
+	FAKE_POETRY_PID_FILE="$TMP/fake-poetry.pid" \
+	SOAK_DURATION_SECONDS=120 \
 	SYSTEM_INTEGRATION_DIR="$TMP/system-integration" \
 	SOAK_OUTPUT_DIR="$TMP/output" \
 	SOAK_RSS_CEILING_MB=0 \

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+DRIVER_PID=""
+cleanup() {
+	[ -z "$DRIVER_PID" ] || kill "$DRIVER_PID" 2>/dev/null || true
+	rm -rf "$TMP"
+}
+trap cleanup EXIT
+mkdir -p "$TMP/bin" "$TMP/system-integration"
+cat >"$TMP/bin/poetry" <<'SH'
+#!/usr/bin/env bash
+trap 'exit 143' TERM INT
+printf '%s\n' "$$" >"$FAKE_POETRY_PID_FILE"
+printf 'fake pytest started\n'
+while :; do sleep 1; done
+SH
+chmod +x "$TMP/bin/poetry"
+
+PATH="$TMP/bin:$PATH" \
+FAKE_POETRY_PID_FILE="$TMP/fake-poetry.pid" \
+SOAK_DURATION_SECONDS=120 \
+	SYSTEM_INTEGRATION_DIR="$TMP/system-integration" \
+	SOAK_OUTPUT_DIR="$TMP/output" \
+	SOAK_RSS_CEILING_MB=0 \
+	SOAK_HOST_FREE_FLOOR_MB=0 \
+	SOAK_GUARDIAN_POLL_SECONDS=1 \
+	"$ROOT/scripts/run-merge-recovery-soak.sh" >"$TMP/driver.log" 2>&1 &
+DRIVER_PID=$!
+
+for _ in $(seq 1 20); do
+	[ -e "$TMP/output/iteration-00001-docker/.started" ] && break
+	sleep 0.25
+done
+test -e "$TMP/output/iteration-00001-docker/.started"
+printf '%s\n' 'injected orchestrator host guardian breach' \
+	>"$TMP/output/host-guardian-breach.txt"
+
+for _ in $(seq 1 20); do
+	kill -0 "$DRIVER_PID" 2>/dev/null || break
+	sleep 0.5
+done
+if kill -0 "$DRIVER_PID" 2>/dev/null; then
+	cat "$TMP/driver.log" >&2
+	echo 'soak driver did not stop promptly after guardian breach' >&2
+	exit 1
+fi
+set +e
+wait "$DRIVER_PID"
+status=$?
+set -e
+DRIVER_PID=""
+[ "$status" -eq 1 ]
+
+test "$(find "$TMP/output" -maxdepth 1 -type d -name 'iteration-*' | wc -l | tr -d ' ')" = 1
+grep -q '^host_protection_breach:' "$TMP/output/early-exit.txt"
+grep -q '^early_exit_reason=host_protection_breach$' "$TMP/output/summary.txt"
+jq -e '.iterations == 1 and .failures == 1 and .iteration_metrics[0].exit_code == 1' \
+	"$TMP/output/summary.json" >/dev/null
+test ! -e "$TMP/output/iteration-00001-docker/.pytest-output.fifo"
+test -s "$TMP/fake-poetry.pid"
+! kill -0 "$(cat "$TMP/fake-poetry.pid")" 2>/dev/null
+
+printf 'soak fail-closed driver tests passed\n'

--- a/scripts/bench/test-write-soak-summary.sh
+++ b/scripts/bench/test-write-soak-summary.sh
@@ -65,4 +65,16 @@ jq -e '
   and .tracked_metrics.lfb_spread.samples == 2
 ' "$SPARSE/summary.json" >/dev/null
 
+# jq 1.6 compatibility lint. The soak VM (Ubuntu 22.04) ships jq 1.6, which
+# rejects jq keywords as variable names ("$def" cost run 30713818751 its
+# summary and, through null metadata, its checkpoint). CI runs on jq 1.7+,
+# which accepts them, so parsing alone cannot catch the regression here.
+JQ_KEYWORDS='def|if|then|elif|else|end|as|reduce|foreach|try|catch|label|import|include|and|or|not|__loc__'
+if grep -rnE "(as \\\$|--arg |--argjson |--slurpfile )($JQ_KEYWORDS)\\b" \
+  "$ROOT/scripts/bench" "$ROOT/scripts/oci" "$ROOT/scripts/run-merge-recovery-soak.sh" \
+  --include='*.sh' 2>/dev/null; then
+  printf 'jq keyword used as a variable name (breaks jq 1.6 on the soak runner)\n' >&2
+  exit 1
+fi
+
 printf 'soak summary writer tests passed\n'

--- a/scripts/bench/write-soak-summary.sh
+++ b/scripts/bench/write-soak-summary.sh
@@ -48,13 +48,13 @@ jq -n \
                else null end)};
       def rollup_tracked_metrics:
         ($registry[0].metrics // []) as $defs
-        | [ $defs[] | . as $def
-            | ([$all[] | .metrics?[$def.key]? | select(type == "object")]) as $samples
+        | [ $defs[] | . as $mdef
+            | ([$all[] | .metrics?[$mdef.key]? | select(type == "object")]) as $samples
             | select(($samples | length) > 0)
             | {
-                key: $def.key,
+                key: $mdef.key,
                 value: (
-                  reduce ($def.aggregate // ["p50", "p95", "max"])[] as $agg
+                  reduce ($mdef.aggregate // ["p50", "p95", "max"])[] as $agg
                     ({};
                      ($samples | map(.[$agg]? | select(type == "number"))) as $values
                      | . + {($agg): (if ($values | length) == 0 then null

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -419,6 +419,19 @@ fi
 HOST_GUARDIAN_BREACH="$OUTPUT_DIR/host-guardian-breach.txt"
 rm -f "$HOST_GUARDIAN_BREACH"
 HOST_GUARDIAN_PID=""
+ITERATION_PID=""
+ITERATION_TEE_PID=""
+ITERATION_FIFO=""
+cleanup_soak_processes() {
+  [ -z "$HOST_GUARDIAN_PID" ] || kill "$HOST_GUARDIAN_PID" 2>/dev/null || true
+  if [ -n "$ITERATION_PID" ]; then
+    kill "$ITERATION_PID" 2>/dev/null || true
+    pkill -KILL -f 'integration-tests/test/tests/custom/test_load.py' 2>/dev/null || true
+  fi
+  [ -z "$ITERATION_TEE_PID" ] || kill "$ITERATION_TEE_PID" 2>/dev/null || true
+  [ -z "$ITERATION_FIFO" ] || rm -f "$ITERATION_FIFO"
+}
+trap cleanup_soak_processes EXIT
 if [ "$HOST_FREE_FLOOR_MB" -gt 0 ] && [ -r /proc/meminfo ]; then
   (
     over=0
@@ -444,7 +457,6 @@ if [ "$HOST_FREE_FLOOR_MB" -gt 0 ] && [ -r /proc/meminfo ]; then
     done
   ) &
   HOST_GUARDIAN_PID=$!
-  trap '[ -n "$HOST_GUARDIAN_PID" ] && kill "$HOST_GUARDIAN_PID" 2>/dev/null' EXIT
   printf 'orchestrator host guardian watching MemAvailable floor %sMB (pid %s)\n' \
     "$HOST_FREE_FLOOR_MB" "$HOST_GUARDIAN_PID"
 fi
@@ -501,9 +513,14 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 
   ITER_STARTED="$(date +%s)"
   touch "$ITERATION_DIR/.started"
+  ITERATION_FIFO="$ITERATION_DIR/.pytest-output.fifo"
+  rm -f "$ITERATION_FIFO"
+  mkfifo "$ITERATION_FIFO"
+  tee "$ITERATION_DIR/pytest.log" < "$ITERATION_FIFO" &
+  ITERATION_TEE_PID=$!
   (
     cd "$SYSTEM_INTEGRATION_DIR"
-    timeout --signal=TERM --kill-after=120 "${REMAINING}s" \
+    exec timeout --signal=TERM --kill-after=30 "${REMAINING}s" \
       poetry run pytest \
       integration-tests/test/tests/custom/test_load.py \
       --provider="$PROVIDER" \
@@ -512,8 +529,34 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
       --host-free-floor-mb "$HOST_FREE_FLOOR_MB" \
       -v --tb=short --instafail --maxfail=20 \
       --timeout=1200
-  ) 2>&1 | tee "$ITERATION_DIR/pytest.log"
-  STATUS="${PIPESTATUS[0]}"
+  ) > "$ITERATION_FIFO" 2>&1 &
+  ITERATION_PID=$!
+  GUARDIAN_INTERRUPTED=0
+  while kill -0 "$ITERATION_PID" 2>/dev/null; do
+    if [ -s "$HOST_GUARDIAN_BREACH" ]; then
+      GUARDIAN_INTERRUPTED=1
+      kill -TERM "$ITERATION_PID" 2>/dev/null || true
+      for _ in $(seq 1 15); do
+        kill -0 "$ITERATION_PID" 2>/dev/null || break
+        sleep 1
+      done
+      kill -KILL "$ITERATION_PID" 2>/dev/null || true
+      break
+    fi
+    sleep "${SOAK_GUARDIAN_POLL_SECONDS:-2}"
+  done
+  wait "$ITERATION_PID" 2>/dev/null
+  STATUS=$?
+  wait "$ITERATION_TEE_PID" 2>/dev/null || true
+  rm -f "$ITERATION_FIFO"
+  ITERATION_PID=""
+  ITERATION_TEE_PID=""
+  ITERATION_FIFO=""
+  if [ "$GUARDIAN_INTERRUPTED" -eq 1 ]; then
+    STATUS=1
+    pkill -9 -f '/tmp/rnode' 2>/dev/null || true
+    docker ps -aq --filter 'name=rnode.' 2>/dev/null | xargs -r docker rm -f >/dev/null 2>&1 || true
+  fi
   # No `set -e` restore: this script never enables errexit (line 2 is
   # `set -uo pipefail`), and turning it on here made the first failed
   # iteration fatal — the metric pipelines return nonzero when a failed

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -432,10 +432,14 @@ if [ "$HOST_FREE_FLOOR_MB" -gt 0 ] && [ -r /proc/meminfo ]; then
       fi
       over=$((over + 1))
       [ "$over" -lt 3 ] && continue
+      # Kill first, marker second: the marker asserts the host was defended,
+      # so it must not exist before the kills have run. `|| true` on each —
+      # pkill exits 1 with no matching process (normal when only containers
+      # are up), and neither miss may stop the other mitigation.
+      pkill -9 -f '/tmp/rnode' 2>/dev/null || true
+      docker ps -q --filter 'name=rnode.' 2>/dev/null | xargs -r docker kill 2>/dev/null || true
       printf 'orchestrator host guardian: host available RAM %sMB < floor %sMB for 3 consecutive samples (5s each); killed all node processes and containers to protect the host\n' \
         "$free_mb" "$HOST_FREE_FLOOR_MB" > "$HOST_GUARDIAN_BREACH"
-      pkill -9 -f '/tmp/rnode' 2>/dev/null
-      docker ps -q --filter 'name=rnode.' 2>/dev/null | xargs -r docker kill 2>/dev/null
       exit 0
     done
   ) &
@@ -593,6 +597,18 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
   fi
 
 done
+
+# A breach during the final iteration (or one that still exited 0) ends the
+# loop by deadline without passing the top-of-loop check, which would let the
+# run finish green with the host guardian's marker never surfaced.
+if [ -z "$EARLY_EXIT_REASON" ] && [ -s "$HOST_GUARDIAN_BREACH" ]; then
+  EARLY_EXIT_REASON="host_protection_breach"
+  printf 'orchestrator host guardian fired during the final iteration; recording fail-closed exit\n'
+  head -1 "$HOST_GUARDIAN_BREACH" | tee "$OUTPUT_DIR/protection-breach.txt"
+  printf 'host_protection_breach: %s\n' "$(head -1 "$HOST_GUARDIAN_BREACH")" \
+    > "$OUTPUT_DIR/early-exit.txt"
+  FAILURES="$((FAILURES + 1))"
+fi
 
 FINISHED_AT="$(date +%s)"
 

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -345,6 +345,16 @@ run_bench_segment() {
   if [ "$status" -ne 0 ]; then
     BENCH_FAILURES="$((BENCH_FAILURES + 1))"
     printf '%s\n' "$status" > "$segment_dir/exit-code.txt"
+    # The segment's output goes to files that die with the VM when the run is
+    # lost — 30713818751's bench failed 100% silently for exactly that reason
+    # (missing DEPLOYER_KEY, visible only in a bench.log nobody ever saw).
+    printf 'bench segment %s failed (status %s); segment.log tail:\n' \
+      "$BENCH_SEGMENTS" "$status" >&2
+    tail -20 "$segment_dir/segment.log" >&2 || true
+    if [ -s "$segment_dir/bench.log" ]; then
+      printf 'bench.log tail:\n' >&2
+      tail -20 "$segment_dir/bench.log" >&2 || true
+    fi
   fi
 }
 
@@ -395,7 +405,59 @@ if [ -e "$FINALIZE_MARKER" ]; then
   DEADLINE=0
 fi
 
+# Orchestrator-level host guardian, independent of the whole test stack.
+#
+# The harness's protections live inside or under pytest: the in-process
+# ceiling dies with the pytest process, and the docker provider sets no
+# per-container memory limit. On run 30713818751 the kernel OOM killer shot
+# pytest itself (oom_score_adj 500) while the docker-provider node containers
+# — not pytest children — ran on uncapped and unwatched until the VM froze
+# and the runner was lost. This loop is a separate process of this script,
+# not of pytest, so it survives exactly that: on a sustained free-RAM floor
+# breach it SIGKILLs every node process and container, writes a breach
+# marker, and the iteration loop below fails the soak closed.
+HOST_GUARDIAN_BREACH="$OUTPUT_DIR/host-guardian-breach.txt"
+rm -f "$HOST_GUARDIAN_BREACH"
+HOST_GUARDIAN_PID=""
+if [ "$HOST_FREE_FLOOR_MB" -gt 0 ] && [ -r /proc/meminfo ]; then
+  (
+    over=0
+    while :; do
+      sleep 5
+      free_mb="$(awk '/^MemAvailable:/ {print int($2 / 1024)}' /proc/meminfo 2>/dev/null)"
+      [ -n "$free_mb" ] || continue
+      if [ "$free_mb" -ge "$HOST_FREE_FLOOR_MB" ]; then
+        over=0
+        continue
+      fi
+      over=$((over + 1))
+      [ "$over" -lt 3 ] && continue
+      printf 'orchestrator host guardian: host available RAM %sMB < floor %sMB for 3 consecutive samples (5s each); killed all node processes and containers to protect the host\n' \
+        "$free_mb" "$HOST_FREE_FLOOR_MB" > "$HOST_GUARDIAN_BREACH"
+      pkill -9 -f '/tmp/rnode' 2>/dev/null
+      docker ps -q --filter 'name=rnode.' 2>/dev/null | xargs -r docker kill 2>/dev/null
+      exit 0
+    done
+  ) &
+  HOST_GUARDIAN_PID=$!
+  trap '[ -n "$HOST_GUARDIAN_PID" ] && kill "$HOST_GUARDIAN_PID" 2>/dev/null' EXIT
+  printf 'orchestrator host guardian watching MemAvailable floor %sMB (pid %s)\n' \
+    "$HOST_FREE_FLOOR_MB" "$HOST_GUARDIAN_PID"
+fi
+
 while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  # The orchestrator guardian can fire outside a failing iteration — during a
+  # bench segment, or after an iteration that still exited 0. Never start new
+  # work once the host has been defended.
+  if [ -s "$HOST_GUARDIAN_BREACH" ]; then
+    EARLY_EXIT_REASON="host_protection_breach"
+    printf 'orchestrator host guardian fired; ending soak (fail-closed)\n'
+    head -1 "$HOST_GUARDIAN_BREACH" | tee "$OUTPUT_DIR/protection-breach.txt"
+    printf 'host_protection_breach: %s\n' "$(head -1 "$HOST_GUARDIAN_BREACH")" \
+      > "$OUTPUT_DIR/early-exit.txt"
+    FAILURES="$((FAILURES + 1))"
+    break
+  fi
   if [ -e "$SIGNAL_FILE" ]; then
     SIGNAL="$(tr -d '[:space:]' < "$SIGNAL_FILE" 2>/dev/null || true)"
     # Consumed either way: an unread signal re-fires on every later iteration
@@ -465,7 +527,55 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
     FAILURES="$((FAILURES + 1))"
     printf '%s\n' "$STATUS" > "$ITERATION_DIR/exit-code.txt"
     if [ -d "$SYSTEM_INTEGRATION_DIR/integration-tests/data" ]; then
-      cp -a "$SYSTEM_INTEGRATION_DIR/integration-tests/data" "$ITERATION_DIR/data"
+      # Evidence only — logs, CSVs, configs. A full `cp -a` drags the nodes'
+      # LMDB data along, which ran to a silent half-hour stall between
+      # iterations on run 30713818751 (19:16→19:45 with zero output) and
+      # would bloat the results artifact past uploadable size.
+      COPY_STARTED="$(date +%s)"
+      printf 'preserving failure evidence from integration-tests/data (iteration %s)\n' "$ITERATIONS"
+      mkdir -p "$ITERATION_DIR/data"
+      (cd "$SYSTEM_INTEGRATION_DIR/integration-tests/data" && \
+        find . -type f \( -name '*.log' -o -name '*.csv' -o -name '*.txt' \
+          -o -name '*.json' -o -name '*.conf' -o -name '*.toml' \) -print0 \
+        | tar --null -T - -cf -) \
+        | tar -xf - -C "$ITERATION_DIR/data" \
+        || printf 'failure-evidence copy incomplete (non-fatal)\n' >&2
+      printf 'failure evidence preserved in %ss\n' "$(( $(date +%s) - COPY_STARTED ))"
+    fi
+    # Fail closed on a host-protection breach. The guardian killing the nodes
+    # means the load does not fit under the configured ceiling/floor on this
+    # host; every further iteration reproduces the breach (30713818751 breached
+    # on all three iterations across both providers), and each one is another
+    # spin of a workload known to endanger the host. Preserve evidence above,
+    # then end the whole soak: the early-exit marker makes every remaining
+    # segment a no-op, and the job still reaches its completion marker so
+    # retry_within_window does not relaunch the same doomed run on a fresh VM.
+    #
+    # Three channels, most authoritative first: the orchestrator guardian's
+    # own marker, the harness monitor's marker file, and — for harness
+    # versions predating the marker — the breach message in the pytest log.
+    BREACH_LINE=""
+    if [ -s "$HOST_GUARDIAN_BREACH" ]; then
+      BREACH_LINE="$(head -1 "$HOST_GUARDIAN_BREACH")"
+    else
+      HARNESS_MARKER="$(find "$SYSTEM_INTEGRATION_DIR/integration-tests/data" \
+        -name host-protection-breach.txt -newer "$ITERATION_DIR/.started" 2>/dev/null \
+        | head -1 || true)"
+      if [ -n "$HARNESS_MARKER" ]; then
+        BREACH_LINE="$(head -1 "$HARNESS_MARKER")"
+      else
+        BREACH_LINE="$(grep -m1 -E \
+          'Host-protection guardian breach|Resource ceiling breached|host-protection watchdog killed' \
+          "$ITERATION_DIR/pytest.log" 2>/dev/null || true)"
+      fi
+    fi
+    if [ -n "$BREACH_LINE" ]; then
+      EARLY_EXIT_REASON="host_protection_breach"
+      printf 'host-protection breach in iteration %s; ending soak (fail-closed)\n' "$ITERATIONS"
+      printf '%s\n' "$BREACH_LINE" | tee "$OUTPUT_DIR/protection-breach.txt"
+      printf 'host_protection_breach: iteration %s: %s\n' "$ITERATIONS" "$BREACH_LINE" \
+        > "$OUTPUT_DIR/early-exit.txt"
+      break
     fi
     sleep 30
   fi
@@ -526,7 +636,36 @@ if command -v jq >/dev/null; then
   SOAK_BENCH_SEGMENTS="$BENCH_SEGMENTS" \
   SOAK_BENCH_FAILURES="$BENCH_FAILURES" \
     "$SCRIPT_DIR/bench/write-soak-summary.sh" \
-    || printf 'summary.json emission failed (non-fatal)\n' >&2
+    || {
+      # The full rollup failing must not leave the run without passive data:
+      # aggregate-perf-report.sh then emits started_at/elapsed_seconds as
+      # null, and Soak Checkpoint Publish rejects that checkpoint outright
+      # ("metadata does not match"). Fall back to the counters this script
+      # already holds — nulls for the sampled metrics, real values for the
+      # run identity and timing the publish contract validates.
+      printf 'summary.json emission failed; writing minimal fallback summary\n' >&2
+      jq -n \
+        --arg target_ref "$TARGET_REF" \
+        --arg target_sha "$TARGET_SHA" \
+        --arg version "$VERSION" \
+        --argjson started "$STARTED_AT" \
+        --argjson finished "$FINISHED_AT" \
+        --argjson requested "$DURATION_SECONDS" \
+        --argjson iterations "$ITERATIONS" \
+        --argjson failures "$FAILURES" \
+        --argjson bench_segments "$BENCH_SEGMENTS" \
+        --argjson bench_failures "$BENCH_FAILURES" \
+        '{target_ref: $target_ref, target_sha: $target_sha, version: $version,
+          started_at: $started, finished_at: $finished,
+          requested_seconds: $requested,
+          elapsed_seconds: ($finished - $started),
+          iterations: $iterations, failures: $failures,
+          failure_rate: (if $iterations > 0 then ($failures / $iterations) else 0 end),
+          bench_segments: $bench_segments, bench_failures: $bench_failures,
+          degraded: "full summary emission failed; sampled metrics missing"}' \
+        > "$OUTPUT_DIR/summary.json" \
+        || printf 'fallback summary emission failed too (non-fatal)\n' >&2
+    }
 fi
 
 if [ "$FAILURES" -ne 0 ]; then


### PR DESCRIPTION
…and dashboard paths

Post-mortem of weekend soak run 30713818751 (VM lost to kernel OOM after repeated guardian breaches):

- write-soak-summary.sh: rename jq variable $def — a jq keyword that jq 1.6 on the Ubuntu 22.04 runner rejects; add a jq-keyword lint to the summary test harness
- run-merge-recovery-soak.sh: end the whole soak on any host-protection breach (no retry, later segments no-op); add an orchestrator-level host guardian that survives pytest death and kills node processes/containers on memory-floor breach; make the failure-evidence copy selective and timed; emit a minimal fallback summary.json so checkpoints keep valid metadata; surface bench segment logs on failure
- run-bench-segment.sh: default DEPLOYER_KEY to the funded bootstrap fixture key from docker/.env (bench segments failed 100% silently)
- soak-checkpoint-publish.yml: pass --repo to gh run download (ran in a non-git cwd and misreported every failure as 'artifact not ready')
- merge-recovery-soak.yml: dashboard falls back to the newest checkpoint when the runner is lost (latest-* only, no history append); post-mortem job releases the reaper exemption so a dead VM is collected in ~30min
- docs: work log for this sweep plus the randomized-exercise planning log

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788220591&installation_model_id=426883&pr_number=190&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F190&signature=d57145bd97d0aad88c7ffc22cfab9f89c610e288cfd6aac23a19058bb192a486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->