### PR TITLE
fix(ci): make soak cron a self-suppressing fallback for the OCI sche…

### DIFF
--- a/.github/scripts/test-soak-schedule-routing.sh
+++ b/.github/scripts/test-soak-schedule-routing.sh
@@ -36,7 +36,14 @@ cat >"$TMP/bin/gh" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
   *"/commits?"*) printf '1\n' ;;
-  *) printf '%s\n' '{"workflow_runs":[]}' ;;
+  *)
+    if [ -n "${FAKE_CLAIMED_SLOT:-}" ]; then
+      printf '{"workflow_runs":[{"id":123,"display_title":"Merge Recovery Soak [scheduled:%s]"}]}\n' \
+        "$FAKE_CLAIMED_SLOT"
+    else
+      printf '%s\n' '{"workflow_runs":[]}'
+    fi
+    ;;
 esac
 SH
 chmod +x "$TMP/bin/date" "$TMP/bin/gh"
@@ -48,6 +55,7 @@ run_gate() {
 	PATH="$TMP/bin:$PATH" \
 		FAKE_NOW_EPOCH="$((slot + 60))" \
 		FAKE_SLOT_EPOCH="$slot" \
+		FAKE_CLAIMED_SLOT="${FAKE_CLAIMED_SLOT:-}" \
 		FAKE_PACIFIC_WEEKDAY="$weekday" \
 		EVENT_NAME="$([ "$mode" = oci ] && printf workflow_dispatch || printf schedule)" \
 		EVENT_SCHEDULE="30 2 * * *" \
@@ -81,6 +89,14 @@ for mode in oci cron; do
 	grep -qx 'kind=daily' "$monday"
 	grep -qx 'run_benchmarks=false' "$monday"
 done
+
+# A cron delivery whose slot was already claimed by an OCI-dispatched run
+# must yield: the soak concurrency group cancels in-progress, so a late cron
+# would otherwise kill a soak hours into its run.
+claimed="$(FAKE_CLAIMED_SLOT=1785810600 run_gate cron 1 1785810600)"
+grep -qx 'should_run=false' "$claimed"
+# The unclaimed cron slot from the loop above must still have run.
+grep -qx 'should_run=true' "$TMP/output-oci-1"
 
 if PATH="$TMP/bin:$PATH" \
 	FAKE_NOW_EPOCH=1785551460 \

--- a/.github/scripts/test-soak-schedule-routing.sh
+++ b/.github/scripts/test-soak-schedule-routing.sh
@@ -36,13 +36,20 @@ cat >"$TMP/bin/gh" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
   *"/commits?"*) printf '1\n' ;;
-  *)
+  *"runs?event=workflow_dispatch"*)
+    if [ -n "${FAKE_CLAIM_QUERY_FAIL:-}" ]; then
+      exit 1
+    fi
     if [ -n "${FAKE_CLAIMED_SLOT:-}" ]; then
       printf '{"workflow_runs":[{"id":123,"display_title":"Merge Recovery Soak [scheduled:%s]","status":"%s","conclusion":%s}]}\n' \
         "$FAKE_CLAIMED_SLOT" "${FAKE_CLAIMED_STATUS:-in_progress}" "${FAKE_CLAIMED_CONCLUSION:-null}"
     else
       printf '%s\n' '{"workflow_runs":[]}'
     fi
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 1
     ;;
 esac
 SH
@@ -58,6 +65,7 @@ run_gate() {
 		FAKE_CLAIMED_SLOT="${FAKE_CLAIMED_SLOT:-}" \
 		FAKE_CLAIMED_STATUS="${FAKE_CLAIMED_STATUS:-}" \
 		FAKE_CLAIMED_CONCLUSION="${FAKE_CLAIMED_CONCLUSION:-}" \
+		FAKE_CLAIM_QUERY_FAIL="${FAKE_CLAIM_QUERY_FAIL:-}" \
 		FAKE_PACIFIC_WEEKDAY="$weekday" \
 		EVENT_NAME="$([ "$mode" = oci ] && printf workflow_dispatch || printf schedule)" \
 		EVENT_SCHEDULE="30 2 * * *" \
@@ -108,6 +116,9 @@ done_claim="$(FAKE_CLAIMED_SLOT=1785810600 FAKE_CLAIMED_STATUS=completed \
 grep -qx 'should_run=false' "$done_claim"
 # The unclaimed cron delivery from the loop above must still have run.
 grep -qx 'should_run=true' "$TMP/output-cron-1"
+# A failed claim query must fail OPEN: soak anyway rather than silently skip.
+open_fail="$(FAKE_CLAIM_QUERY_FAIL=1 run_gate cron 1 1785810600 query-fail)"
+grep -qx 'should_run=true' "$open_fail"
 
 if PATH="$TMP/bin:$PATH" \
 	FAKE_NOW_EPOCH=1785551460 \

--- a/.github/scripts/test-soak-schedule-routing.sh
+++ b/.github/scripts/test-soak-schedule-routing.sh
@@ -38,8 +38,8 @@ case "$*" in
   *"/commits?"*) printf '1\n' ;;
   *)
     if [ -n "${FAKE_CLAIMED_SLOT:-}" ]; then
-      printf '{"workflow_runs":[{"id":123,"display_title":"Merge Recovery Soak [scheduled:%s]"}]}\n' \
-        "$FAKE_CLAIMED_SLOT"
+      printf '{"workflow_runs":[{"id":123,"display_title":"Merge Recovery Soak [scheduled:%s]","status":"%s","conclusion":%s}]}\n' \
+        "$FAKE_CLAIMED_SLOT" "${FAKE_CLAIMED_STATUS:-in_progress}" "${FAKE_CLAIMED_CONCLUSION:-null}"
     else
       printf '%s\n' '{"workflow_runs":[]}'
     fi
@@ -49,13 +49,15 @@ SH
 chmod +x "$TMP/bin/date" "$TMP/bin/gh"
 
 run_gate() {
-	local mode="$1" weekday="$2" slot="$3" output
-	output="$TMP/output-$mode-$weekday"
+	local mode="$1" weekday="$2" slot="$3" tag="${4:-}" output
+	output="$TMP/output-$mode-$weekday${tag:+-$tag}"
 	: >"$output"
 	PATH="$TMP/bin:$PATH" \
 		FAKE_NOW_EPOCH="$((slot + 60))" \
 		FAKE_SLOT_EPOCH="$slot" \
 		FAKE_CLAIMED_SLOT="${FAKE_CLAIMED_SLOT:-}" \
+		FAKE_CLAIMED_STATUS="${FAKE_CLAIMED_STATUS:-}" \
+		FAKE_CLAIMED_CONCLUSION="${FAKE_CLAIMED_CONCLUSION:-}" \
 		FAKE_PACIFIC_WEEKDAY="$weekday" \
 		EVENT_NAME="$([ "$mode" = oci ] && printf workflow_dispatch || printf schedule)" \
 		EVENT_SCHEDULE="30 2 * * *" \
@@ -90,13 +92,22 @@ for mode in oci cron; do
 	grep -qx 'run_benchmarks=false' "$monday"
 done
 
-# A cron delivery whose slot was already claimed by an OCI-dispatched run
-# must yield: the soak concurrency group cancels in-progress, so a late cron
+# A cron delivery whose slot was claimed by a live OCI-dispatched run must
+# yield: the soak concurrency group cancels in-progress, so a late cron
 # would otherwise kill a soak hours into its run.
-claimed="$(FAKE_CLAIMED_SLOT=1785810600 run_gate cron 1 1785810600)"
+claimed="$(FAKE_CLAIMED_SLOT=1785810600 run_gate cron 1 1785810600 live-claim)"
 grep -qx 'should_run=false' "$claimed"
-# The unclaimed cron slot from the loop above must still have run.
-grep -qx 'should_run=true' "$TMP/output-oci-1"
+# A dispatch that failed or was cancelled left no soak running, so the cron
+# fallback must still soak the night rather than yield to a dead claim.
+dead_claim="$(FAKE_CLAIMED_SLOT=1785810600 FAKE_CLAIMED_STATUS=completed \
+	FAKE_CLAIMED_CONCLUSION='"failure"' run_gate cron 1 1785810600 dead-claim)"
+grep -qx 'should_run=true' "$dead_claim"
+# A completed successful dispatch keeps the claim (nothing left to soak).
+done_claim="$(FAKE_CLAIMED_SLOT=1785810600 FAKE_CLAIMED_STATUS=completed \
+	FAKE_CLAIMED_CONCLUSION='"success"' run_gate cron 1 1785810600 done-claim)"
+grep -qx 'should_run=false' "$done_claim"
+# The unclaimed cron delivery from the loop above must still have run.
+grep -qx 'should_run=true' "$TMP/output-cron-1"
 
 if PATH="$TMP/bin:$PATH" \
 	FAKE_NOW_EPOCH=1785551460 \

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -404,16 +404,34 @@ jobs:
             # failed at its own gate or was cancelled left no soak running,
             # and yielding to it would silently skip the night — the failure
             # this fallback exists to prevent.
+            #
+            # The claim is matched by display title, so any collaborator's
+            # dispatch that passes scheduled_slot_epoch can hold the slot.
+            # Accepted: such a run goes through this same gate and either
+            # soaks or, on failure, stops claiming under the status filter.
+            #
+            # per_page=100 without pagination leans on the API's newest-first
+            # ordering — the claiming dispatch is at most hours old and this
+            # workflow runs a handful of times per day, so page one holds it.
             if [ "$should_run" = "true" ]; then
               expected_title="Merge Recovery Soak [scheduled:${slot_epoch}]"
-              canonical_run="$(gh api \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null \
-                | jq -r --arg title "$expected_title" \
+              claim_runs="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null)" \
+                || claim_runs=""
+              if [ -z "$claim_runs" ]; then
+                # Fail-open must be observable: without this line a broken
+                # token looks identical to "no claim found", and a masked
+                # duplicate would surface only as a concurrency cancel.
+                echo "::warning::slot-claim query failed; failing open and soaking anyway"
+                canonical_run=""
+              else
+                canonical_run="$(jq -r --arg title "$expected_title" \
                   '[.workflow_runs[]
                     | select(.display_title == $title)
                     | select(.status != "completed" or .conclusion == "success")
-                    | .id] | min // empty' \
-                || true)"
+                    | .id] | min // empty' <<<"$claim_runs" 2>/dev/null \
+                  || { echo "::warning::slot-claim response unparseable; failing open and soaking anyway" >&2; printf ''; })"
+              fi
               if [ -n "$canonical_run" ]; then
                 should_run=false
                 duplicate_skip=true

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -400,11 +400,19 @@ jobs:
             # hours into its run. Fails OPEN like the idle check above: if the
             # query cannot be trusted, soak anyway — a duplicate start is
             # recoverable, a silently skipped soak is not.
+            # Only a live or successful dispatch claims the slot: one that
+            # failed at its own gate or was cancelled left no soak running,
+            # and yielding to it would silently skip the night — the failure
+            # this fallback exists to prevent.
             if [ "$should_run" = "true" ]; then
               expected_title="Merge Recovery Soak [scheduled:${slot_epoch}]"
               canonical_run="$(gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null \
-                | jq -r --arg title "$expected_title" '[.workflow_runs[] | select(.display_title == $title) | .id] | min // empty' \
+                | jq -r --arg title "$expected_title" \
+                  '[.workflow_runs[]
+                    | select(.display_title == $title)
+                    | select(.status != "completed" or .conclusion == "success")
+                    | .id] | min // empty' \
                 || true)"
               if [ -n "$canonical_run" ]; then
                 should_run=false

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -392,6 +392,26 @@ jobs:
               target_ref=master
               duration_seconds=216000
             fi
+            # The OCI Function scheduler dispatches this workflow at the exact
+            # slot instant; this cron survives as its late-delivered fallback.
+            # If a dispatch already claimed tonight's slot, running again would
+            # not merely duplicate it — the soak concurrency group cancels
+            # in-progress, so the hours-late cron would kill a soak already
+            # hours into its run. Fails OPEN like the idle check above: if the
+            # query cannot be trusted, soak anyway — a duplicate start is
+            # recoverable, a silently skipped soak is not.
+            if [ "$should_run" = "true" ]; then
+              expected_title="Merge Recovery Soak [scheduled:${slot_epoch}]"
+              canonical_run="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/merge-recovery-soak.yml/runs?event=workflow_dispatch&per_page=100" 2>/dev/null \
+                | jq -r --arg title "$expected_title" '[.workflow_runs[] | select(.display_title == $title) | .id] | min // empty' \
+                || true)"
+              if [ -n "$canonical_run" ]; then
+                should_run=false
+                duplicate_skip=true
+                echo "slot already claimed by OCI-dispatched run $canonical_run; cron fallback yields"
+              fi
+            fi
           fi
           kind=daily
           if [ "$duration_seconds" = "216000" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,5 @@ MC_TE.out
 
 *~
 docs/discoveries/*.md
+.tmp/
+docs/work-logs/*.md

--- a/oci/soak-scheduler/Dockerfile
+++ b/oci/soak-scheduler/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/oracle/oci-cli@sha256:12ba572de6290354255e9d7ed0d387a428230a0a5b2b8969603ca8008f71734a
 USER root
-RUN microdnf install -y bash curl jq openssl tzdata \
-    && microdnf clean all
+RUN dnf install -y bash curl jq openssl tzdata \
+    && dnf clean all
 COPY --from=fnproject/hotwrap@sha256:bf6303d7d216581c0e760f33dd74c3cdea83edad69f3d9614b7f573ba62c22b4 /hotwrap /hotwrap
 WORKDIR /function
 COPY --chown=oracle:oracle handler.sh ./

--- a/oci/soak-scheduler/README.md
+++ b/oci/soak-scheduler/README.md
@@ -51,7 +51,13 @@ Use this cutover order:
 2. Confirm `merge-recovery-soak.yml` on `master` accepts `scheduled_slot_epoch`.
 3. Run `scripts/oci/deploy-soak-scheduler.sh`.
 4. Invoke the eligible Function payload manually and complete the verification below.
-5. Confirm no GitHub `schedule` trigger remains enabled.
+5. Confirm the cron path's slot dedup is on `master`: the GitHub `schedule`
+   triggers stay enabled **permanently** as a late-delivered fallback. A cron
+   run whose slot was already claimed by an OCI-dispatched run suppresses
+   itself (the soak concurrency group cancels in-progress, so an undeduped
+   late cron would kill a soak hours into its run); if the Function ever dies
+   silently, the cron still soaks that night, hours late instead of not at
+   all.
 
 GitHub resolves `workflow_dispatch` from the configured `master` ref, so deploying before step 1 will fail against workflow inputs that do not yet exist.
 


### PR DESCRIPTION
Completes the OCI soak-scheduler cutover (PR #187's design, never deployed) and makes the GitHub cron a permanent, self-suppressing fallback instead of removing it.

## Why

The scheduler infrastructure from #187 was never stood up — zero Resource Scheduler schedules, no Function, zero `[scheduled:…]` runs ever — so soaks have been triggered by GitHub cron, delivered 2.5–3.5 hours late every night. Worse, the original cutover plan (remove the crons) hid a live-fire hazard: during any overlap the soak concurrency group (`cancel-in-progress: true`) means the hours-late cron would cancel the OCI-dispatched soak mid-run, every night.

## Changes

- **Cron slot dedup**: an eligible cron delivery yields when a live-or-successful dispatch titled `Merge Recovery Soak [scheduled:<slot>]` already claimed the slot. Dead claims (gate failures, cancellations) do not suppress the fallback; a failed claim query fails open with a visible `::warning::`. The crons stay enabled permanently — if the Function ever dies silently, the soak still happens, hours late instead of not at all.
- **Routing tests**: eight scenarios including live/dead/done claims, fail-open on query failure, and a fake `gh` that pins the exact query shape.
- **Scheduler image build fix**: `dnf` (Oracle Linux 8.10 base), not `microdnf`.
- **README**: cutover step 5 rewritten to the keep-cron design.

## Deployment status (already live)

Function `f1r3node-soak-scheduler`, both UTC schedules (02:30/03:30), Vault secret (GitHub App PEM), dynamic groups and IAM policies deployed to the `ci-runner` compartment; GitHub App validated (actions:write, metadata:read, this repo only); handler unit tests pass and the late-invocation guard verified live. First automatic dispatch: **02:30 UTC tomorrow** — this PR's dedup must be on `master` (scheduled runs execute master's workflow file) before then, or the late cron will cancel the Function's soak.

## Review resolutions

All multi-agent review findings are addressed — see the resolution table in the PR comments (critical claim-status filter in `47581f2b`, observability and query-shape hardening in `8c3c5c8a`).
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788405917&installation_model_id=426883&pr_number=196&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F196&signature=b97a19e680af171eeec0256e7947273547000f76f81f869e2452cbd98f727fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
