### PR TITLE
Hotfix/fix tla+ ci and soak verdict status for TLA+ gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,13 @@ jobs:
     timeout-minutes: 5
     if: >-
       !startsWith(github.event.head_commit.message, 'chore(release)')
+    permissions:
+      checks: write
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
     steps:
-      - name: Require latest weekend soak verdict to be pass
+      - name: Read latest weekend soak verdict
+        id: gate
         shell: bash -euo pipefail {0}
         env:
           OVERRIDE: ${{ contains(github.event.head_commit.message, '[soak-override]') }}
@@ -48,8 +53,16 @@ jobs:
           # Releases must not promote past a regressing weekend soak
           # (EPOCH-010 TASK-010-3). Maintainer override: include
           # [soak-override] in the release commit message.
+          #
+          # A regress HOLDS the release (the release job skips on
+          # proceed=false) without failing this job: soak state belongs to
+          # the README badges and the dashboard, not to the commit's build
+          # status, which must reflect build/test checks only. The hold is
+          # surfaced on the commit as a neutral `release-held` check run
+          # (next step) instead of a red X.
           if [ "$OVERRIDE" = "true" ]; then
             echo "::warning::Soak gate overridden via [soak-override] in commit message"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           verdict_json="$(curl -fsS --max-time 30 \
@@ -57,16 +70,48 @@ jobs:
             2>/dev/null || true)"
           if [ -z "$verdict_json" ]; then
             echo "::warning::No published soak verdict yet (dashboard bootstrap); allowing release"
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           verdict="$(printf '%s' "$verdict_json" | jq -r '.verdict // "unknown"')"
           date="$(printf '%s' "$verdict_json" | jq -r '.run.date // "unknown"')"
           echo "Latest weekend soak verdict: $verdict ($date)"
           if [ "$verdict" != "pass" ]; then
-            printf '%s' "$verdict_json" | jq -r '.failures[] | "FAIL: " + .'
-            echo "::error::Latest weekend soak regressed — release blocked. Fix the regression or use [soak-override] in the release commit message."
-            exit 1
+            printf '%s' "$verdict_json" | jq -r '.failures[]? | "FAIL: " + .'
+            echo "::warning::Latest weekend soak verdict is '$verdict' ($date) — release held. Fix the regression or use [soak-override] in the release commit message."
+            {
+              echo "held_summary<<HELD_EOF"
+              echo "Latest weekend soak verdict: \`$verdict\` ($date)."
+              echo ""
+              printf '%s' "$verdict_json" | jq -r '.failures[]? | "- " + .'
+              echo ""
+              echo "The release job was skipped; the build itself is unaffected. Fix the regression or include \`[soak-override]\` in the release commit message. Soak state and history: https://f1r3fly-io.github.io/f1r3node-rust/"
+              echo "HELD_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish neutral release-held check
+        if: steps.gate.outputs.proceed == 'false'
+        uses: actions/github-script@v7
+        env:
+          HELD_SUMMARY: ${{ steps.gate.outputs.held_summary }}
+        with:
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'release-held',
+              head_sha: context.sha,
+              status: 'completed',
+              conclusion: 'neutral',
+              output: {
+                title: 'Release held — weekend soak verdict is not pass',
+                summary: process.env.HELD_SUMMARY,
+              },
+            });
 
   release:
     name: Bump Version & Tag
@@ -75,7 +120,8 @@ jobs:
     environment: release-credentials
     timeout-minutes: 10
     if: >-
-      !startsWith(github.event.head_commit.message, 'chore(release)')
+      !startsWith(github.event.head_commit.message, 'chore(release)') &&
+      needs.soak_gate.outputs.proceed == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,30 +65,53 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          verdict_json="$(curl -fsS --max-time 30 \
+          # Randomized heredoc delimiter: the summary embeds strings from
+          # the fetched JSON, so a static delimiter would let a crafted
+          # line terminate the block early and inject further outputs.
+          delim="HELD_EOF_${RANDOM}${RANDOM}_$$"
+          hold() {
+            {
+              echo "held_summary<<$delim"
+              cat
+              echo ""
+              echo "The release job was skipped; the build itself is unaffected. Fix the regression or include \`[soak-override]\` in the release commit message. Soak state and history: https://f1r3fly-io.github.io/f1r3node-rust/"
+              echo "$delim"
+            } >> "$GITHUB_OUTPUT"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          }
+          body="$RUNNER_TEMP/latest-verdict.json"
+          http_code="$(curl -sS --max-time 30 --retry 3 --retry-delay 5 \
+            -o "$body" -w '%{http_code}' \
             "https://f1r3fly-io.github.io/f1r3node-rust/data/latest-verdict.json" \
-            2>/dev/null || true)"
-          if [ -z "$verdict_json" ]; then
+            2>/dev/null)" || http_code=000
+          if [ "$http_code" = "404" ]; then
             echo "::warning::No published soak verdict yet (dashboard bootstrap); allowing release"
             echo "proceed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          verdict="$(printf '%s' "$verdict_json" | jq -r '.verdict // "unknown"')"
-          date="$(printf '%s' "$verdict_json" | jq -r '.run.date // "unknown"')"
+          if [ "$http_code" != "200" ]; then
+            # Fail closed on an unverifiable verdict (network error, 5xx):
+            # holding a release on a transient fetch failure is recoverable;
+            # releasing past an unseen regress is not. Only a true 404
+            # (pre-bootstrap dashboard) allows the release through.
+            echo "::warning::Could not fetch soak verdict (HTTP $http_code) — release held rather than promoting past an unverifiable verdict. Re-run the workflow to retry."
+            hold <<EOF
+          Could not fetch the weekend soak verdict (HTTP $http_code); the release is held rather than promoted past an unverifiable verdict. Re-run the workflow to retry.
+          EOF
+            exit 0
+          fi
+          verdict_json="$(cat "$body")"
+          verdict="$(printf '%s' "$verdict_json" | jq -r '.verdict // "unknown"' 2>/dev/null || echo unknown)"
+          date="$(printf '%s' "$verdict_json" | jq -r '.run.date // "unknown"' 2>/dev/null || echo unknown)"
           echo "Latest weekend soak verdict: $verdict ($date)"
           if [ "$verdict" != "pass" ]; then
-            printf '%s' "$verdict_json" | jq -r '.failures[]? | "FAIL: " + .'
+            printf '%s' "$verdict_json" | jq -r '.failures[]? | "FAIL: " + .' 2>/dev/null || true
             echo "::warning::Latest weekend soak verdict is '$verdict' ($date) — release held. Fix the regression or use [soak-override] in the release commit message."
             {
-              echo "held_summary<<HELD_EOF"
               echo "Latest weekend soak verdict: \`$verdict\` ($date)."
               echo ""
-              printf '%s' "$verdict_json" | jq -r '.failures[]? | "- " + .'
-              echo ""
-              echo "The release job was skipped; the build itself is unaffected. Fix the regression or include \`[soak-override]\` in the release commit message. Soak state and history: https://f1r3fly-io.github.io/f1r3node-rust/"
-              echo "HELD_EOF"
-            } >> "$GITHUB_OUTPUT"
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
+              printf '%s' "$verdict_json" | jq -r '.failures[]? | "- " + .' 2>/dev/null || true
+            } | hold
             exit 0
           fi
           echo "proceed=true" >> "$GITHUB_OUTPUT"
@@ -100,18 +123,26 @@ jobs:
           HELD_SUMMARY: ${{ steps.gate.outputs.held_summary }}
         with:
           script: |
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'release-held',
-              head_sha: context.sha,
-              status: 'completed',
-              conclusion: 'neutral',
-              output: {
-                title: 'Release held — weekend soak verdict is not pass',
-                summary: process.env.HELD_SUMMARY,
-              },
-            });
+            // Publication is best-effort: a failed check-run API call must
+            // not fail this job, or the gate re-creates the red commit
+            // status the hold mechanism exists to avoid. The held state is
+            // still visible in the job log and the ::warning annotation.
+            try {
+              await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'release-held',
+                head_sha: context.sha,
+                status: 'completed',
+                conclusion: 'neutral',
+                output: {
+                  title: 'Release held by the weekend soak verdict gate',
+                  summary: process.env.HELD_SUMMARY,
+                },
+              });
+            } catch (error) {
+              core.warning(`Could not publish the release-held check run: ${error.message}`);
+            }
 
   release:
     name: Bump Version & Tag

--- a/docs/soak-benchmarks.md
+++ b/docs/soak-benchmarks.md
@@ -282,10 +282,18 @@ Thresholds live in one file: `scripts/bench/soak-gate-thresholds.json`
 the soak run**: failure rate +5pts, peak RSS +20%, finalization p95 +20%,
 throughput −20%. Active-segment metrics warn.
 
-**Releases are gated**: the `release.yml` workflow refuses to bump/tag on
-`master` while the latest published soak verdict is `regress`. Maintainer
-override: include `[soak-override]` in the release commit message (the gate
-logs a warning and proceeds).
+**Releases are gated**: while the latest published soak verdict is `regress`,
+the `release.yml` workflow holds the bump/tag without failing anything — the
+gate job stays green (soak state belongs to the badges and dashboard, not to
+the commit's build status), the release job is skipped, and the hold is
+surfaced as a neutral `release-held` check run on the commit plus a
+`::warning::` annotation on the gate job. A held release is quiet by design:
+no red ✗ appears; the release simply does not happen until the regression is
+fixed or overridden. The gate also holds when the verdict cannot be fetched
+(network error, 5xx, malformed JSON) — only a true 404 (pre-bootstrap
+dashboard) lets the release proceed. Maintainer override: include
+`[soak-override]` in the release commit message (the gate logs a warning and
+proceeds).
 
 ## Email subscription (OCI Notifications)
 

--- a/docs/theory/slashing/design/14-test-plan.md
+++ b/docs/theory/slashing/design/14-test-plan.md
@@ -849,8 +849,8 @@ to model-check the slashing subsystem; §14 references **40+** of
 them, including the Sage-promoted two-level invariants, the
 rewrite-introduced `Inv_RecordHasWitness`, and the authorized
 slash-flow invariants. Each bounded post-fix configuration is
-re-checked via `tlc` as part of CI. The exhaustive detector safety
-configuration is opt-in:
+re-checked via `tlc` as part of CI. The exhaustive-tier
+configurations are opt-in:
 
 ```bash
 # CI script lives on `analysis/slashing` (`scripts/ci/check-tla-invariants.sh`)
@@ -904,10 +904,17 @@ Specifically:
   `Inv_AcceptedProjectionCardinality`.
 
 A TLC violation immediately fails CI.
-`MC_EquivocationDetector_safety.cfg` is the exhaustive detector
-safety run; it is intentionally excluded from the default PR-gate
-script until the shorter frontier has stabilized, and is enabled by
-`RUN_EXHAUSTIVE_TLA=1`.
+The exhaustive tier — enabled by `RUN_EXHAUSTIVE_TLA=1` and
+intentionally excluded from the default gate — holds three
+configurations: `MC_EquivocationDetector_safety.cfg` (the exhaustive
+detector safety run), plus `MC_EquivocationDetector.cfg` and
+`MC_EquivocationDetectorEager_3v.cfg`, whose interleaved liveness
+passes exceed the 45-minute per-config CI cap (neither completed in
+any nightly run between the schedule's start on 2026-07-25 and their
+move to this tier). A liveness/safety split to return those two —
+`MC_EquivocationDetectorEager_3v` in particular, as the only
+three-validator detector model — to the nightly tier is tracked as
+follow-up.
 
 ### 14.6.1 Trace replay against the Rust harness
 
@@ -1096,8 +1103,10 @@ TLA_TOOLS_JAR="$HOME/.tla/tla2tools.jar" \
 bash scripts/ci/check-tla-invariants.sh
 ```
 
-The exhaustive detector safety check is intentionally opt-in because it can
-run for many hours:
+The exhaustive tier (the detector safety run plus the two
+cap-busting liveness configurations, `MC_EquivocationDetector` and
+`MC_EquivocationDetectorEager_3v`) is intentionally opt-in because it
+can run for many hours:
 
 ```sh
 RUN_EXHAUSTIVE_TLA=1 TLA_TOOLS_JAR="$HOME/.tla/tla2tools.jar" \

--- a/scripts/ci/check-tla-invariants.sh
+++ b/scripts/ci/check-tla-invariants.sh
@@ -4,8 +4,8 @@
 #
 # Reference: docs/theory/slashing/design/14-test-plan.md §14.6 / §14.9.
 # Invokes the TLA+ model checker (TLC) against each MC instance:
-#   • MC_EquivocationDetector{,_liveness}.tla / .cfg
-#   • MC_EquivocationDetectorEager{,_3v}.tla / .cfg
+#   • MC_EquivocationDetector_liveness.tla / .cfg
+#   • MC_EquivocationDetectorEager.tla / .cfg
 #   • MC_ConcurrentTracker{,_pre_fix}.tla / .cfg
 #   • MC_SlashFlow.tla / .cfg
 #   • MC_TwoLevelSlashing.tla / .cfg
@@ -18,9 +18,14 @@
 # are *expected* to violate their invariants and are skipped here (they
 # are the formal-side counter-examples, run manually for validation).
 #
-# MC_EquivocationDetector_safety is the exhaustive detector safety check.
-# It is intentionally opt-in because it can run for many hours; run it
-# with RUN_EXHAUSTIVE_TLA=1 after the shorter frontier has stabilized.
+# The exhaustive tier (RUN_EXHAUSTIVE_TLA=1) holds the configs whose state
+# spaces exceed the per-config wall-clock cap: MC_EquivocationDetector and
+# MC_EquivocationDetectorEager_3v hit the 45m cap on every nightly since
+# the schedule began (2026-07-25) — their interleaved liveness passes go
+# superlinear past ~100M states — alongside MC_EquivocationDetector_safety,
+# which can run for many hours. The nightly tier therefore gates on the
+# fast configs only; the heavy pair runs opt-in until it gets the
+# liveness/safety split that rescued MC_EquivocationDetector_liveness.
 
 set -euo pipefail
 
@@ -66,10 +71,8 @@ fi
 
 # Post-fix configs: each must TLC-clean.
 POST_FIX_CONFIGS=(
-    MC_EquivocationDetector
     MC_EquivocationDetector_liveness
     MC_EquivocationDetectorEager
-    MC_EquivocationDetectorEager_3v
     MC_ConcurrentTracker
     MC_SlashFlow
     MC_TwoLevelSlashing
@@ -79,7 +82,11 @@ POST_FIX_CONFIGS=(
 )
 
 if [[ "${RUN_EXHAUSTIVE_TLA:-0}" == "1" ]]; then
-    POST_FIX_CONFIGS+=(MC_EquivocationDetector_safety)
+    POST_FIX_CONFIGS+=(
+        MC_EquivocationDetector
+        MC_EquivocationDetectorEager_3v
+        MC_EquivocationDetector_safety
+    )
 fi
 
 cd "$TLA_DIR"


### PR DESCRIPTION
Expedited hotfix for two independent defects that keep the repository's top-level status red even when every build/test check passes. Soak state belongs to the README badges and the dashboard; the commit status above the file list should reflect build/test checks only.

## 1. Release soak gate painted a red ✗ on green builds

On every push to `master`, `release.yml`'s `soak_gate` job read the published weekend soak verdict and **failed the job** on `regress` — turning the commit status red even though all CI checks passed (observed on `3e119ee0`, where the verdict gate was the only failing check).

Now the gate **holds without failing**:

- On a `regress` verdict the job succeeds, emits `proceed=false`, and the release job skips. The held state is surfaced on the commit as a **neutral `release-held` check run** with the verdict, failure list, and dashboard link.
- Blocking semantics are unchanged: a regress still blocks the release; `[soak-override]` and the pre-bootstrap path still allow it.
- Hardened failure modes (from the multi-agent review): only a true HTTP 404 (dashboard bootstrap) allows the release through — network errors, 5xx, and malformed JSON **hold** the release rather than failing open or crashing the step; the `GITHUB_OUTPUT` heredoc uses a randomized delimiter so fetched JSON cannot inject outputs; check-run publication failures degrade to a warning instead of re-redding the job.

Validated with a stubbed-curl simulation of all six gate paths (pass, regress with delimiter-injection attempt, 404, network failure, malformed JSON, override during outage) — every path exits 0 with correct proceed/held outputs.

## 2. Nightly TLA+ job has never been green

All eleven nightly `slashing-tests` runs since the schedule began (2026-07-25) failed the same way: `MC_EquivocationDetector` and `MC_EquivocationDetectorEager_3v` hit the 45-minute per-config cap (their interleaved liveness passes go superlinear past ~100M states) while every other config passes in seconds to minutes.

`check-tla-invariants.sh` moves the two cap-busting configs to the opt-in `RUN_EXHAUSTIVE_TLA=1` tier alongside `MC_EquivocationDetector_safety`. The nightly gate now runs the 8 fast configs.

Verified via `workflow_dispatch` run [30931698777](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/30931698777): **all 8 configs clean in ~5½ minutes** — the first passing TLA+ invariant check since the schedule began. Follow-up (tracked): a liveness/safety split for the two heavy models (the pattern that lets `MC_EquivocationDetector_liveness` pass in 3 s) so they return to the nightly tier. Note the nightly workflow also has an independent pre-existing failure in the `cargo-mutants` job (canceled at its deadline every night); that is out of scope here and tracked separately.

## Merge notes

- Expedite path: dev → promote to master before the next nightly.
- PR #198 also touches `check-tla-invariants.sh` (area-namespaced entries, fail-on-missing). Small conflict expected when both reach dev; both sides' semantics should be kept — the reconciliation is planned on the #198 branch.
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788454572&installation_model_id=426883&pr_number=201&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F201&signature=1493a9e585d32b5cc41cbb5025f25f85f49e9db182e7b730539e1a410b097d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
