### PR TITLE
fix(casper): keep merge-rejected deploys recoverable past finalized wins

### DIFF
--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -445,15 +445,22 @@ async fn prepare_user_deploys_with_policy(
 
     // Terminal purge: a rejected-buffer entry is dropped only once its sig is
     // canonically WON inside the FINALIZED ancestry (latest finalized
-    // disposition is a win). A win that is merely canonical-but-unfinalized
-    // can still be orphaned, so the entry must survive until finality — the
-    // buffer is the only re-proposable copy of merge-rejected work.
+    // disposition is a win) AND that finalized win sits strictly above every
+    // rejection visible from the current parents. A win that is merely
+    // canonical-but-unfinalized can still be orphaned, so the entry must
+    // survive until finality; symmetrically, a finalized win with a visible
+    // rejection at or above its height is not terminal — block finalization
+    // does not finalize effects, and the pending rejection can finalize and
+    // drop the win from canonical state (finalized-win blindness,
+    // finalized_win_pending_rejection_spec). The buffer is the only
+    // re-proposable copy of merge-rejected work.
     let finalized_won_buffered: Vec<Signed<DeployData>> = if buffered_deploys.is_empty() {
         Vec::new()
     } else {
-        let finalized_won = interpreter_util::canonical_won_sigs(
+        let finalized_won = interpreter_util::finalized_won_terminal_sigs(
             block_store,
-            std::slice::from_ref(&casper_snapshot.last_finalized_block),
+            &casper_snapshot.last_finalized_block,
+            &parent_hashes,
             buffer_scan_floor,
         )?;
         buffered_deploys

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -340,9 +340,29 @@ fn retain_pending_rejected_deploys_for_buffer(
         let state = statuses.get(&deploy.sig).map(|status| status.state);
         match state {
             None | Some(DeployFinalizationState::Pending) => true,
-            Some(DeployFinalizationState::Finalized) => finalized_dispositions
-                .get(&deploy.sig)
-                .is_none_or(|(win_height, won)| !won || *win_height <= rejecting_block_number),
+            Some(DeployFinalizationState::Finalized) => {
+                match finalized_dispositions.get(&deploy.sig) {
+                    Some((win_height, true)) => *win_height <= rejecting_block_number,
+                    disagreement => {
+                        // The resolver and the finalized-chain disposition scan
+                        // disagree: `Finalized` without a winning finalized
+                        // disposition (or none at all). Retaining is the safe
+                        // direction — the buffer holds the only re-proposable
+                        // copy — but the disagreement itself is the resolver's
+                        // known blindness to rejections above the LFB, so make
+                        // it visible rather than silent.
+                        tracing::warn!(
+                            target: "f1r3fly.casper.recovery",
+                            "RejectedDeployBuffer populate: resolver reports Finalized for {} but the \
+                             finalized-chain disposition is {:?} (rejecting block #{}); retaining",
+                            PrettyPrinter::build_string_bytes(&deploy.sig),
+                            disagreement,
+                            rejecting_block_number
+                        );
+                        true
+                    }
+                }
+            }
             Some(_) => false,
         }
     });

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -77,16 +77,16 @@ fn block_in_floor_merge_scope(
     Ok(!dag.is_dag_ancestor(hash, floor_hash)?)
 }
 
-fn canonical_disposition_sigs(
+/// BFS-walk the closure of `parents` down to `earliest_block_number`,
+/// returning each sig's latest disposition as `sig -> (height, won)`.
+/// A win and a rejection never share a height (a merge sits one block above
+/// its siblings), so the highest-block disposition is the latest; a
+/// same-height tie prefers REJECTION so a keep-one loser stays re-proposable.
+fn canonical_dispositions(
     block_store: &KeyValueBlockStore,
     parents: &[BlockHash],
     earliest_block_number: i64,
-    target_won: bool,
-) -> Result<HashSet<Bytes>, CasperError> {
-    // sig -> (highest block_number observed, won at that height?). A win and a
-    // rejection never share a height (a merge sits one block above its siblings),
-    // so the highest-block disposition is the latest; a same-height tie prefers
-    // REJECTION so a keep-one loser stays re-proposable.
+) -> Result<HashMap<Bytes, (i64, bool)>, CasperError> {
     let mut disposition: HashMap<Bytes, (i64, bool)> = HashMap::new();
     let mut visited: HashSet<BlockHash> = HashSet::new();
     let mut queue: VecDeque<BlockHash> = parents.iter().cloned().collect();
@@ -111,9 +111,93 @@ fn canonical_disposition_sigs(
             queue.push_back(p.clone());
         }
     }
-    Ok(disposition
+    Ok(disposition)
+}
+
+fn canonical_disposition_sigs(
+    block_store: &KeyValueBlockStore,
+    parents: &[BlockHash],
+    earliest_block_number: i64,
+    target_won: bool,
+) -> Result<HashSet<Bytes>, CasperError> {
+    Ok(
+        canonical_dispositions(block_store, parents, earliest_block_number)?
+            .into_iter()
+            .filter_map(|(sig, (_, won))| (won == target_won).then_some(sig))
+            .collect(),
+    )
+}
+
+/// BFS-walk the closure of `parents` down to `earliest_block_number`,
+/// returning each rejected sig's HIGHEST rejection height. Unlike
+/// `canonical_dispositions`, a later win does not mask the rejection —
+/// callers use this to ask "is there any rejection at or above height H?",
+/// which the latest-disposition map cannot answer once a higher win exists.
+fn max_visible_rejection_heights(
+    block_store: &KeyValueBlockStore,
+    parents: &[BlockHash],
+    earliest_block_number: i64,
+) -> Result<HashMap<Bytes, i64>, CasperError> {
+    let mut latest: HashMap<Bytes, i64> = HashMap::new();
+    let mut visited: HashSet<BlockHash> = HashSet::new();
+    let mut queue: VecDeque<BlockHash> = parents.iter().cloned().collect();
+    while let Some(hash) = queue.pop_front() {
+        if !visited.insert(hash.clone()) {
+            continue;
+        }
+        let Some(block) = block_store.get(&hash)? else {
+            continue;
+        };
+        let bn = block.body.state.block_number;
+        if bn < earliest_block_number {
+            continue;
+        }
+        for rd in &block.body.rejected_deploys {
+            latest
+                .entry(rd.sig.clone())
+                .and_modify(|height| *height = (*height).max(bn))
+                .or_insert(bn);
+        }
+        for p in &block.header.parents_hash_list {
+            queue.push_back(p.clone());
+        }
+    }
+    Ok(latest)
+}
+
+/// Sigs whose rejected-buffer entry is TERMINAL: the latest disposition in
+/// the FINALIZED ancestry is a win, AND that finalized win sits strictly
+/// above every rejection visible from `visible_parents`. Block finalization
+/// does not finalize a deploy's effects — a conflict-set merge above the
+/// LFB can still reject a deploy whose winning block already finalized, and
+/// once that rejecting block finalizes, canonical state has dropped the
+/// deploy. A finalized win therefore only terminates recovery once no
+/// visible rejection at or above its height can overturn it. (Walking the
+/// finalized chain alone — the pre-fix behavior — is blind to exactly that
+/// pending rejection; regression: finalized_win_pending_rejection_spec,
+/// root-caused from integration run 31150220859.)
+pub fn finalized_won_terminal_sigs(
+    block_store: &KeyValueBlockStore,
+    last_finalized_block: &BlockHash,
+    visible_parents: &[BlockHash],
+    earliest_block_number: i64,
+) -> Result<HashSet<Bytes>, CasperError> {
+    let finalized = canonical_dispositions(
+        block_store,
+        std::slice::from_ref(last_finalized_block),
+        earliest_block_number,
+    )?;
+    let visible_rejections =
+        max_visible_rejection_heights(block_store, visible_parents, earliest_block_number)?;
+    Ok(finalized
         .into_iter()
-        .filter_map(|(sig, (_, won))| (won == target_won).then_some(sig))
+        .filter_map(|(sig, (win_height, won))| {
+            let terminal = won
+                && visible_rejections
+                    .get(&sig)
+                    .is_none_or(|rejection_height| win_height > *rejection_height);
+            terminal.then_some(sig)
+        })
         .collect())
 }
 
@@ -215,6 +299,7 @@ fn retain_pending_rejected_deploys_for_buffer(
     block_store: &KeyValueBlockStore,
     deploy_lifespan: i64,
     deploys: &mut Vec<Signed<DeployData>>,
+    rejecting_block_number: i64,
 ) -> Result<usize, CasperError> {
     if deploys.is_empty() {
         return Ok(0);
@@ -229,12 +314,37 @@ fn retain_pending_rejected_deploys_for_buffer(
                     err
                 ))
             })?;
+
+    // `Finalized` is not terminal by itself: the resolver scans only the
+    // finalized chain, so it cannot see the rejection this populate call is
+    // servicing. A finalized win only settles the sig when it sits strictly
+    // ABOVE the rejecting block — otherwise the pending rejection can
+    // finalize and drop the win's effects from canonical state, and the
+    // buffer holds the only re-proposable copy (regression:
+    // finalized_win_pending_rejection_spec). A win above the rejection
+    // (late validation of an already-recovered rejection) stays terminal.
+    let scan_floor = deploys
+        .iter()
+        .map(|d| d.data.valid_after_block_number)
+        .min()
+        .unwrap_or(rejecting_block_number)
+        .min(rejecting_block_number);
+    let finalized_dispositions = canonical_dispositions(
+        block_store,
+        std::slice::from_ref(&dag.last_finalized_block()),
+        scan_floor,
+    )?;
+
     let before = deploys.len();
     deploys.retain(|deploy| {
-        statuses
-            .get(&deploy.sig)
-            .map(|status| status.state == DeployFinalizationState::Pending)
-            .unwrap_or(true)
+        let state = statuses.get(&deploy.sig).map(|status| status.state);
+        match state {
+            None | Some(DeployFinalizationState::Pending) => true,
+            Some(DeployFinalizationState::Finalized) => finalized_dispositions
+                .get(&deploy.sig)
+                .is_none_or(|(win_height, won)| !won || *win_height <= rejecting_block_number),
+            Some(_) => false,
+        }
     });
     Ok(before - deploys.len())
 }
@@ -1335,6 +1445,7 @@ pub async fn compute_parents_post_state(
                         block_store,
                         s.on_chain_state.shard_conf.deploy_lifespan,
                         &mut deploys_to_buffer,
+                        max_parent_block_number.saturating_add(1),
                     ) {
                         Ok(skipped) if skipped > 0 => {
                             tracing::info!(
@@ -2104,13 +2215,26 @@ mod backstop_tests {
         let mut dag = dag_storage.get_representation().expect("dag");
         dag.last_finalized_block_hash = finalized_block.block_hash.clone();
 
+        // Rejection below the finalized win (late validation of an
+        // already-recovered rejection): the finalized sig is terminal.
         let mut deploys = vec![finalized.clone(), pending.clone()];
         let skipped =
-            retain_pending_rejected_deploys_for_buffer(&dag, &block_store, 50, &mut deploys)
+            retain_pending_rejected_deploys_for_buffer(&dag, &block_store, 50, &mut deploys, 0)
                 .expect("retain pending");
 
         assert_eq!(skipped, 1);
         assert_eq!(deploys.len(), 1);
         assert_eq!(deploys[0].sig, pending.sig);
+
+        // Rejection ABOVE the finalized win: `Finalized` is not terminal —
+        // the pending rejection can finalize and drop the win's effects, so
+        // the deploy must stay buffered (finalized-win blindness fix).
+        let mut deploys = vec![finalized.clone(), pending.clone()];
+        let skipped =
+            retain_pending_rejected_deploys_for_buffer(&dag, &block_store, 50, &mut deploys, 2)
+                .expect("retain pending with rejection above win");
+
+        assert_eq!(skipped, 0);
+        assert_eq!(deploys.len(), 2);
     }
 }

--- a/casper/tests/batch2/finalized_win_pending_rejection_spec.rs
+++ b/casper/tests/batch2/finalized_win_pending_rejection_spec.rs
@@ -1,0 +1,269 @@
+// Regression for the finalized-win blindness in rejected-deploy recovery
+// (root-caused from integration run 31150220859, test_bridge_api_real_deploy):
+// a deploy whose winning inclusion block has FINALIZED can still be
+// conflict-rejected by a later multi-parent merge sitting ABOVE the LFB.
+// Block finalization does not finalize a deploy's effects — once the
+// rejecting block finalizes, canonical state has dropped the deploy, so
+// the recovery pipeline must keep it re-proposable. Two sites instead
+// treat "finalized canonical win" as terminal while being unable to see
+// the pending rejection above the LFB:
+//
+//   1. `retain_pending_rejected_deploys_for_buffer` (populate filter):
+//      `deploy_finalization_status::resolve_batch` scans only the
+//      finalized chain, reports `Finalized` from the win, and populate
+//      skips the deploy — even though the populate call exists precisely
+//      because a merge just rejected it.
+//   2. The terminal purge in `block_creator::prepare_user_deploys`:
+//      `canonical_won_sigs` is walked from `last_finalized_block` only,
+//      so the in-scope rejection is invisible and the buffer entry is
+//      dropped as "finalized canonical win".
+//
+// Conflict generator and DAG choreography mirror `recovery_cycle_spec`:
+// two same-key deploys whose combined precharge over-drains the shared
+// vault; `conflict_set_merger::fold_rejection` deterministically rejects
+// the lex-larger sig, which is routed to validator 0's block_a.
+
+use casper::rust::util::construct_deploy;
+use models::rust::casper::protocol::casper_message::BlockMessage;
+use prost::bytes::Bytes;
+use serial_test::serial;
+
+use crate::helper::test_node::TestNode;
+use crate::util::genesis_builder::{GenesisBuilder, GenesisContext};
+
+struct TestContext {
+    genesis: GenesisContext,
+}
+
+impl TestContext {
+    async fn new() -> Self {
+        let genesis = GenesisBuilder::new()
+            .build_genesis_with_parameters(None)
+            .await
+            .unwrap();
+
+        Self { genesis }
+    }
+}
+
+/// Same conflict shape as `recovery_cycle_spec`: trivial body, conflict
+/// comes from the system-level precharge against the shared source vault.
+const CONFLICT_RHO: &str = r#"
+Nil
+"#;
+const PHLO_LIMIT: i64 = 8;
+const PHLO_PRICE: i64 = 1_000_000;
+
+struct ConflictFixture {
+    nodes: Vec<TestNode>,
+    shard_id: String,
+    block_a: BlockMessage,
+    rejected_sig: Bytes,
+}
+
+/// Build the sibling-conflict DAG up to (but not including) the merge:
+/// block_a on validator 0 carries the lex-larger (to-be-rejected) deploy,
+/// block_b on validator 1 the survivor; both validators see both blocks.
+async fn build_conflict_siblings(ctx: &TestContext) -> ConflictFixture {
+    let shard_id = ctx.genesis.genesis_block.shard_id.clone();
+
+    let mut nodes = TestNode::create_network(ctx.genesis.clone(), 2, None, None, None, None)
+        .await
+        .expect("create_network(2)");
+    for node in nodes.iter_mut() {
+        node.allow_empty_blocks = true;
+    }
+
+    let deploy_x = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            CONFLICT_RHO.to_string(),
+            Some(PHLO_LIMIT),
+            Some(PHLO_PRICE),
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            None,
+            Some(shard_id.clone()),
+        )
+        .expect("build deploy_x")
+    };
+    let deploy_y = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            CONFLICT_RHO.to_string(),
+            Some(PHLO_LIMIT),
+            Some(PHLO_PRICE),
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            None,
+            Some(shard_id.clone()),
+        )
+        .expect("build deploy_y")
+    };
+
+    let (deploy_a, deploy_b) = if deploy_x.sig >= deploy_y.sig {
+        (deploy_x, deploy_y)
+    } else {
+        (deploy_y, deploy_x)
+    };
+    let rejected_sig: Bytes = deploy_a.sig.clone();
+    assert!(
+        deploy_a.sig > deploy_b.sig,
+        "deploy_a must hold the lex-larger sig so the merge rejection is deterministic"
+    );
+
+    let block_a = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&deploy_a))
+        .await
+        .expect("validator 0 proposes block_a");
+    let block_b = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&deploy_b))
+        .await
+        .expect("validator 1 proposes block_b");
+    assert_ne!(block_a.block_hash, block_b.block_hash);
+
+    {
+        let (a, b) = nodes.split_at_mut(1);
+        a[0].sync_with_one(&mut b[0]).await.expect("sync 0 -> 1");
+    }
+    {
+        let (a, b) = nodes.split_at_mut(1);
+        b[0].sync_with_one(&mut a[0]).await.expect("sync 1 -> 0");
+    }
+
+    ConflictFixture {
+        nodes,
+        shard_id,
+        block_a,
+        rejected_sig,
+    }
+}
+
+/// Validator 1 proposes the merge over [block_a, block_b]; the fixture's
+/// lex-larger deploy must be in its `rejected_deploys`.
+async fn propose_rejecting_merge(fixture: &mut ConflictFixture, nonce: i32) -> BlockMessage {
+    let marker_deploy = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(nonce, None, Some(fixture.shard_id.clone()))
+            .expect("build marker deploy")
+    };
+    let merge_block = fixture.nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&marker_deploy))
+        .await
+        .expect("validator 1 proposes merge over [block_a, block_b]");
+    assert!(
+        merge_block
+            .body
+            .rejected_deploys
+            .iter()
+            .any(|rd| rd.sig == fixture.rejected_sig),
+        "merge block must conflict-reject the lex-larger sig {}",
+        hex::encode(&fixture.rejected_sig)
+    );
+    merge_block
+}
+
+fn buffer_contains(node: &TestNode, sig: &Bytes) -> bool {
+    node.rejected_deploy_buffer
+        .lock()
+        .expect("buffer lock")
+        .contains_sig(sig)
+        .expect("buffer.contains_sig")
+}
+
+/// Site 1 — populate filter. The winning block finalizes BEFORE the
+/// rejecting merge arrives. When validator 0 validates the merge, the
+/// populate path must still buffer the rejected deploy: the rejection sits
+/// above the LFB, so the "Finalized" the resolver reports from the win is
+/// not a terminal disposition — it is exactly the state this rejection is
+/// about to overturn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn populate_buffers_rejected_deploy_whose_win_block_already_finalized() {
+    let ctx = TestContext::new().await;
+    let mut fixture = build_conflict_siblings(&ctx).await;
+
+    fixture.nodes[0]
+        .block_dag_storage
+        .record_directly_finalized(fixture.block_a.block_hash.clone(), 1.0, |_| async {
+            Ok(())
+        })
+        .await
+        .expect("finalize block_a (the win) before the rejecting merge is seen");
+
+    let merge_block = propose_rejecting_merge(&mut fixture, 0).await;
+
+    {
+        let (a, b) = fixture.nodes.split_at_mut(1);
+        a[0].sync_with_one(&mut b[0])
+            .await
+            .expect("sync merge_block 1 -> 0");
+    }
+    assert!(
+        fixture.nodes[0].contains(&merge_block.block_hash),
+        "validator 0 must validate the rejecting merge"
+    );
+
+    assert!(
+        buffer_contains(&fixture.nodes[0], &fixture.rejected_sig),
+        "populate must buffer sig {} despite its win block being finalized: \
+         the rejection above the LFB is pending, and once the rejecting block \
+         finalizes the deploy's effects are dropped from canonical state with \
+         no re-proposable copy",
+        hex::encode(&fixture.rejected_sig)
+    );
+}
+
+/// Site 2 — terminal purge. The deploy is buffered normally (win block
+/// not yet finalized when the rejection arrives, as in
+/// `recovery_cycle_spec`), and only THEN does the winning block finalize
+/// while the rejecting merge stays above the LFB. The next proposal's
+/// buffer scan must keep the entry: the in-scope rejection can still
+/// finalize and orphan the win's effects from canonical state.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn purge_keeps_buffered_deploy_with_pending_rejection_above_finalized_win() {
+    let ctx = TestContext::new().await;
+    let mut fixture = build_conflict_siblings(&ctx).await;
+
+    let merge_block = propose_rejecting_merge(&mut fixture, 0).await;
+
+    {
+        let (a, b) = fixture.nodes.split_at_mut(1);
+        a[0].sync_with_one(&mut b[0])
+            .await
+            .expect("sync merge_block 1 -> 0");
+    }
+    assert!(
+        buffer_contains(&fixture.nodes[0], &fixture.rejected_sig),
+        "precondition (proven by recovery_cycle_spec): with the win block \
+         unfinalized, populate buffers the rejected sig"
+    );
+
+    fixture.nodes[0]
+        .block_dag_storage
+        .record_directly_finalized(fixture.block_a.block_hash.clone(), 1.0, |_| async {
+            Ok(())
+        })
+        .await
+        .expect("finalize block_a (the win) while the rejection stays above the LFB");
+
+    let marker_deploy = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(1, None, Some(fixture.shard_id.clone()))
+            .expect("build post-finality marker deploy")
+    };
+    let next_block = fixture.nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&marker_deploy))
+        .await
+        .expect("validator 0 proposes with the win finalized and the rejection pending");
+
+    assert!(
+        buffer_contains(&fixture.nodes[0], &fixture.rejected_sig),
+        "the buffer entry for sig {} must survive the terminal purge while \
+         its rejection in {} is above the LFB: \"finalized canonical win\" is \
+         not terminal when a pending rejection can still overturn it \
+         (proposed block: {})",
+        hex::encode(&fixture.rejected_sig),
+        hex::encode(&merge_block.block_hash),
+        hex::encode(&next_block.block_hash)
+    );
+}

--- a/casper/tests/batch2/mod.rs
+++ b/casper/tests/batch2/mod.rs
@@ -1,6 +1,7 @@
 pub mod clique_oracle_test;
 pub mod dedup_orphan_recovery_spec;
 pub mod estimator_test;
+pub mod finalized_win_pending_rejection_spec;
 pub mod finalizer_test;
 pub mod limited_parent_depth_spec;
 pub mod lmdb_key_value_store_spec;


### PR DESCRIPTION
## Summary

A conflict-set merge above the LFB can reject a deploy whose winning block has **already finalized**. Block finalization does not finalize a deploy's *effects* — once the rejecting block finalizes, canonical state has dropped the deploy. Two recovery sites treated "finalized canonical win" as terminal while being structurally unable to see that pending rejection, so the deploy was abandoned with no re-proposable copy:

- **RejectedDeployBuffer populate filter** (`retain_pending_rejected_deploys_for_buffer`): `deploy_finalization_status::resolve_batch` scans only the finalized chain, reported `Finalized` from the win, and skipped the very deploy the merge had just rejected.
- **Terminal purge** (`block_creator::prepare_user_deploys`): `canonical_won_sigs` was walked from `last_finalized_block` only, so a rejection above the LFB was invisible and the buffer entry was purged as a "finalized canonical win".

## Fix

New rule at both sites: **a finalized win is terminal only when it sits strictly above every visible rejection.**

- `interpreter_util::finalized_won_terminal_sigs` — finalized-chain dispositions (`canonical_dispositions`) intersected with `max_visible_rejection_heights` over the proposal parents; a rejection at or above the win height blocks the purge. A rejection can no longer be masked by a later unfinalized win (heights, not latest-disposition).
- Populate filter takes the rejecting block's height: resolver-`Finalized` deploys are buffered when the win is at-or-below the rejection (the incident case), and still skipped when the win post-dates it (late validation of an already-recovered rejection). `Failed`/`Expired` remain terminal.
- The pre-existing "a canonical-but-unfinalized win must survive until finality" purge protection is preserved unchanged (covered by `recovery_cycle_spec`'s terminal-purge phase, still green).

## Provenance

Root-caused from Heavy Pipeline run 31150220859 (`test_bridge_admin.py::test_bridge_api_real_deploy`): bridge contract deploy `3045022100929b27…` finalized in block #6 on all nodes, then `DagMerger rejected 1 user deploys` during merges at ~05:30:49Z, followed by `RejectedDeployBuffer populate: skipped 1 terminal deploy(s)` and `Purged 1 rejected-buffer entr(y/ies) with finalized canonical wins before block #9` — the registry insert vanished from canonical state while the deploy still reported `FINALIZED`, and the subsequent registry lookup read an empty deployId channel. Test-side hardening landed separately in system-integration PRs #88/#90/#93.

## Regression coverage

`casper/tests/batch2/finalized_win_pending_rejection_spec.rs` — two deterministic tests (one per blind site) using `recovery_cycle_spec`'s conflict generator plus `record_directly_finalized` to order the win's finalization against the rejection:

- `populate_buffers_rejected_deploy_whose_win_block_already_finalized`
- `purge_keeps_buffered_deploy_with_pending_rejection_above_finalized_win`

Both **fail on pre-fix dev** (transcript in the branch history) and pass with the fix; a height-aware case was added to the populate unit test. Adjacent suites unaffected: `recovery_cycle` (incl. terminal purge after replay finalization), `recovery_repeat_deploy_misfire`, `dedup_orphan_recovery` — plus the full 11-crate release gate at push.

## Deferred follow-up

`deploy_finalization_status` still reports `FINALIZED` to API clients while a rejection is pending above the LFB (this is what misled the integration-test client in the incident). That is an API-visible semantics change and should be its own issue/PR.

## Related

- #150 contains the same pre-fix purge condition; its unextracted commits (`e08d8567`, `2c339cbb`) target adjacent recovery stalls and should rebase cleanly over this.

## Multi-review response (2026-08-08)

**Major (addressed):** *Silent retention on resolver/disposition disagreement.* The populate filter now `tracing::warn!`s when the resolver reports `Finalized` but the finalized-chain disposition scan finds no winning finalized disposition, before retaining. Retention was already the safe direction; the disagreement is the resolver's known LFB-blindness (the deferred follow-up), so it is now visible in logs instead of silent.

**Minors/suggestions — dispositions:**
- *`canonical_won_sigs` now dead?* — No: still used by the recovered-deploys eligibility filter later in `prepare_user_deploys` (parent-scope walk) and by the populate path's floor-won duplicate check. Left in place.
- *Duplicated BFS boilerplate / two-walk overlap in `finalized_won_terminal_sigs`* — acknowledged; both walks bound by the same lifespan floor on a once-per-proposal path already doing BFS work of the same order. A shared multi-collector walker is a reasonable follow-up refactor; not done here to keep the fix reviewable.
- *Unbounded populate scan floor* — the floor anchors to the candidates' `min(valid_after_block_number)` (and never above the rejecting block), so the walk is bounded by deploy lifespan in practice.
- *`Option::is_none_or` MSRV* — repo pins a nightly toolchain well past 1.82; no MSRV constraint applies.
- *Sleep-based deploy-timestamp uniqueness in the spec* — mirrors the established `recovery_cycle_spec` convention; kept for consistency with the sibling spec.

**Live confirmation of the bug class:** after the system-integration pin moved to `989fc2af`, PR #199's Heavy Pipeline failed both arm64 bridge-admin tests with the hardened visibility-barrier message ("effects were likely rejected by merge after block finalization") against a dev node without this fix — i.e., the detector now reproduces the incident deterministically in CI, and this PR is the unblocker for #199 going green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788742088&installation_model_id=426883&pr_number=212&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F212&signature=ff26e3a35841c1063c571c8b0a10a21546459a817d498180527fdc7e900bbf1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
