### PR TITLE
feat(dashboard): shard uptime bars and attached-tab design, wired end to end

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -14,6 +14,9 @@
     --text-primary: #0b0b0b; --text-secondary: #52514e; --text-muted: #8a887f;
     --grid: #e4e2dd; --series-1: #2a78d6; --series-2: #008300; --series-3: #e87ba4;
     --good: #008300; --serious: #c81e1e; --serious-bg: #fdeaea;
+    /* Sheet tint strength: the same perceptual whisper needs a stronger mix
+       on a dark surface than a light one. */
+    --tint: 6%;
   }
   @media (prefers-color-scheme: dark) {
     :root:where(:not([data-theme="light"])) body {
@@ -21,6 +24,7 @@
       --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #8a887f;
       --grid: #33322f; --series-1: #3987e5; --series-2: #008300; --series-3: #d55181;
       --good: #33a133; --serious: #f05252; --serious-bg: #3a1f1f;
+      --tint: 14%;
     }
   }
   :root[data-theme="dark"] body {
@@ -28,6 +32,7 @@
     --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #8a887f;
     --grid: #33322f; --series-1: #3987e5; --series-2: #008300; --series-3: #d55181;
     --good: #33a133; --serious: #f05252; --serious-bg: #3a1f1f;
+    --tint: 14%;
   }
   h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
   .sub { color: var(--text-secondary); margin: 0 0 1.25rem; }
@@ -37,26 +42,41 @@
      inside the bar so the panels stay siblings of them — that is what lets the
      buttons be positioned anywhere on the page. */
   .tabs { position: absolute; opacity: 0; pointer-events: none; }
-  .tabbar { display: flex; flex-wrap: wrap; gap: .75rem; margin: 0 0 1.5rem; }
+  /* The buttons are drawn as tabs physically attached to the panel below:
+     top-rounded, sitting on the panel's top border, with the active tab's
+     bottom edge cut away so button and panel read as one surface. That seam is
+     the visual statement that the panel's data belongs to the selected tab. */
+  .tabbar { display: flex; flex-wrap: wrap; gap: .5rem; align-items: flex-end; margin: 0; }
   .tabbar label {
     display: flex; flex-direction: column; gap: .15rem; min-width: 11rem;
+    position: relative; z-index: 1; margin-bottom: -1px;
     padding: .8rem 1.1rem; cursor: pointer; user-select: none;
     background: var(--surface-2); color: var(--text-secondary);
-    border: 1px solid var(--grid); border-radius: 10px;
-    box-shadow: 0 1px 2px rgba(0,0,0,.10), 0 3px 10px rgba(0,0,0,.07);
-    transition: transform .12s ease, box-shadow .12s ease, border-color .12s ease;
+    border: 1px solid var(--grid); border-radius: 10px 10px 0 0;
+    transition: box-shadow .12s ease, border-color .12s ease, background .12s ease;
   }
   .tabbar label:hover {
-    color: var(--text-primary); transform: translateY(-2px);
-    box-shadow: 0 3px 6px rgba(0,0,0,.14), 0 8px 20px rgba(0,0,0,.11);
+    color: var(--text-primary);
+    box-shadow: 0 -2px 6px rgba(0,0,0,.10);
   }
-  .tabbar label:active { transform: translateY(0); }
   .tab-title { font-weight: 700; font-size: 1.02rem; color: var(--text-primary); }
   .tab-hint { font-size: .82rem; color: var(--text-muted); }
   .tab-status { font-size: .82rem; font-weight: 600; margin-top: .2rem; color: var(--text-muted); }
   .tab-status.pass { color: var(--good); }
   .tab-status.regress { color: var(--serious); }
   .tab-status.running { color: var(--series-1); }
+  /* Shard uptime for the latest run, on the button between the verdict line
+     and the provenance line: the green share of the bar is time the shard was
+     up, the red remainder is time it was not. Collapses when the data is
+     absent, so runs that predate uptime emission show nothing rather than an
+     empty bar. */
+  .tab-uptime { display: flex; flex-direction: column; gap: .2rem; margin-top: .15rem; }
+  .tab-uptime:empty { display: none; }
+  .uptime-bar { display: flex; height: 6px; border-radius: 3px; overflow: hidden;
+                background: var(--serious); }
+  .uptime-bar i { display: block; height: 100%; background: var(--good); }
+  .uptime-text { font-size: .78rem; color: var(--text-secondary);
+                 font-variant-numeric: tabular-nums; }
   /* What was soaked, on the button itself: which commit, version and day a
      series last covered is the thing you want before deciding which tab to
      open, not after. Empty until the verdict loads, so the button never shows
@@ -72,20 +92,33 @@
      a passing Daily tab is green twice over. Kept deliberately — the accent
      rides on the border and ring while status stays in its own text, and
      `regress` red against a green accent is still unambiguous. */
-  .tabbar label[for="tab-weekend"] { --accent: var(--series-1); }
-  .tabbar label[for="tab-daily"] { --accent: var(--good); }
+  /* The sheet colour: surface with a whisper of the series accent mixed in.
+     Both the selected tab and its panel paint this same colour, so the tint
+     follows the selection (blue sheet for Weekend, green for Daily) while the
+     tab-to-panel seam stays invisible. Browsers without color-mix fall back
+     to the untinted surface — the tint is a cue, not a load-bearing signal. */
+  .tabbar label[for="tab-weekend"], #panel-weekend { --accent: var(--series-1); }
+  .tabbar label[for="tab-daily"], #panel-daily { --accent: var(--good); }
+  .tabbar label, .panel { --sheet: var(--surface-1); }
+  @supports (background: color-mix(in srgb, red 4%, white)) {
+    .tabbar label, .panel { --sheet: color-mix(in srgb, var(--accent) var(--tint), var(--surface-1)); }
+  }
   /* Always visible, not just when selected, so the colour is a property of the
-     series rather than of the selection. */
-  .tabbar label { border-left-width: 3px; border-left-color: var(--accent); }
+     series rather than of the selection. The accent moves to the tab's top
+     edge — the natural accent position for a tab attached below. */
+  .tabbar label { border-top-width: 3px; border-top-color: var(--accent); }
   .running-note { background: var(--surface-2); border-left: 3px solid var(--series-1);
                   border-radius: 4px; padding: .6rem .9rem; margin-bottom: 1.25rem;
                   color: var(--text-secondary); }
-  /* The selected tab is raised and accented; without this the group reads as
-     four equal cards rather than a choice with one active member. */
+  /* The selected tab merges with the panel: its background becomes the panel
+     background and its bottom border is painted over the panel's top border,
+     so the two form one continuous surface — the inactive tab stays visibly
+     "behind" the sheet. */
   #tab-weekend:checked ~ .tabbar label[for="tab-weekend"],
   #tab-daily:checked ~ .tabbar label[for="tab-daily"] {
-    border-color: var(--accent); background: var(--surface-1);
-    box-shadow: 0 0 0 1px var(--accent), 0 4px 8px rgba(0,0,0,.16), 0 10px 24px rgba(0,0,0,.12);
+    background: var(--sheet); color: var(--text-primary);
+    border-color: var(--grid); border-top-color: var(--accent);
+    border-bottom-color: var(--sheet);
   }
   #tab-weekend:focus-visible ~ .tabbar label[for="tab-weekend"],
   #tab-daily:focus-visible ~ .tabbar label[for="tab-daily"] {
@@ -93,11 +126,14 @@
   }
   @media (prefers-reduced-motion: reduce) {
     .tabbar label { transition: none; }
-    .tabbar label:hover { transform: none; }
   }
   .panel { display: none; }
   #tab-weekend:checked ~ #panel-weekend,
-  #tab-daily:checked ~ #panel-daily { display: block; }
+  #tab-daily:checked ~ #panel-daily {
+    display: block;
+    border: 1px solid var(--grid); border-radius: 0 10px 10px 10px;
+    background: var(--sheet); padding: 1.25rem; margin-bottom: 1.5rem;
+  }
 
   .panel-head { display: flex; flex-wrap: wrap; align-items: center; gap: .75rem; margin-bottom: 1rem; }
   .panel-head .meta { color: var(--text-secondary); }
@@ -149,23 +185,25 @@
 <input class="tabs" type="radio" name="soak-tab" id="tab-weekend" checked>
 <input class="tabs" type="radio" name="soak-tab" id="tab-daily">
 
+<h1>Merge-recovery soak benchmarks</h1>
+<p class="sub">Continuous soak of the merge-recovery suite against a live shard.</p>
+
 <div class="tabbar" role="group" aria-label="Soak series">
   <label for="tab-weekend">
     <span class="tab-title">Weekend</span>
     <span class="tab-hint">60h · master</span>
     <span class="tab-status" id="status-weekend">loading…</span>
+    <span class="tab-uptime" id="uptime-weekend"></span>
     <span class="tab-provenance" id="provenance-weekend"></span>
   </label>
   <label for="tab-daily">
     <span class="tab-title">Daily</span>
     <span class="tab-hint">22h · dev</span>
     <span class="tab-status" id="status-daily">loading…</span>
+    <span class="tab-uptime" id="uptime-daily"></span>
     <span class="tab-provenance" id="provenance-daily"></span>
   </label>
 </div>
-
-<h1>Merge-recovery soak benchmarks</h1>
-<p class="sub">Continuous soak of the merge-recovery suite against a live shard.</p>
 
 <div class="panel" id="panel-weekend">
   <div class="panel-head">
@@ -351,6 +389,28 @@
     el.textContent = r ? provenanceParts(r).join(" · ") : "";
   }
 
+  // Shard uptime for the latest run, between the verdict and provenance lines.
+  // Green share of the bar = time the shard was up; red remainder = time it
+  // was not (bring-up churn, watchdog kills, restarts). The denominator is the
+  // elapsed time for a mid-run checkpoint and the full window for a completed
+  // run. Runs recorded before the soak emitted shard_up_seconds render
+  // nothing — the element collapses rather than showing a bar with no data.
+  function renderUptime(el, verdict) {
+    el.innerHTML = "";
+    const r = (verdict && verdict.run) || null;
+    if (!r) return;
+    const up = r.shard_up_seconds;
+    const span = verdict.verdict === "in_progress" ? r.elapsed_seconds : r.duration_seconds;
+    if (typeof up !== "number" || typeof span !== "number" || span <= 0) return;
+    const ratio = Math.min(Math.max(up / span, 0), 1);
+    const pct = (ratio * 100).toFixed(ratio >= 0.995 && ratio < 1 ? 1 : 0);
+    const hrs = s => (s / 3600).toFixed(s >= 36000 ? 0 : 1);
+    el.innerHTML =
+      `<span class="uptime-bar" role="img" aria-label="shard uptime ${pct}%">` +
+      `<i style="width:${(ratio * 100).toFixed(2)}%"></i></span>` +
+      `<span class="uptime-text">uptime ${pct}% · ${hrs(up)}h of ${hrs(span)}h</span>`;
+  }
+
   // Rendered only when non-empty, so the strip's presence is itself the signal.
   function renderFailures(el, verdict) {
     const f = (verdict && Array.isArray(verdict.failures)) ? verdict.failures : [];
@@ -466,6 +526,7 @@
     const history = Array.isArray(historyRaw) ? historyRaw : [];
 
     renderStatus(document.getElementById("status-" + def.key), verdict, history.length);
+    renderUptime(document.getElementById("uptime-" + def.key), verdict);
     renderProvenance(document.getElementById("provenance-" + def.key), verdict);
     renderProgress(document.getElementById("progress-" + def.key), verdict);
     renderFailures(document.getElementById("failures-" + def.key), verdict);

--- a/.github/dashboard/preview.rs
+++ b/.github/dashboard/preview.rs
@@ -85,6 +85,7 @@ struct Run {
     // dash-instead-of-"unknown" fallback needs exercising locally.
     version: String,
     duration: u64,
+    up_seconds: u64,
     iterations: u64,
     failure_rate: f64,
     iters_per_hour: f64,
@@ -107,10 +108,11 @@ impl Run {
         format!(
             concat!(
                 r#"{{"date": "{}T07:30:00Z", "run_id": "{}", "target_sha": "{}", "#,
-                r#""target_ref": "{}", "version": "{}", "kind": "{}", "duration_seconds": {}}}"#
+                r#""target_ref": "{}", "version": "{}", "kind": "{}", "duration_seconds": {}, "#,
+                r#""shard_up_seconds": {}}}"#
             ),
             self.date, self.run_id, self.sha, self.target_ref, self.version, self.kind,
-            self.duration
+            self.duration, self.up_seconds
         )
     }
 
@@ -189,10 +191,12 @@ fn series(
 
         // One deliberately regressed run per series, so the failure styling is
         // exercised by the default fixture instead of needing a hand edit.
-        let (f, p, too_far_ahead) = if bad == Some(i) {
-            (fr + 0.06, p95 * 1.28, 5 + (rng.unif(0.0, 4.0) as u64))
+        // The regressed run also loses a visible slice of shard uptime, so the
+        // tab button's green/red uptime bar shows both of its states locally.
+        let (f, p, too_far_ahead, up_frac) = if bad == Some(i) {
+            (fr + 0.06, p95 * 1.28, 5 + (rng.unif(0.0, 4.0) as u64), rng.unif(0.55, 0.72))
         } else {
-            (fr, p95, 0)
+            (fr, p95, 0, rng.unif(0.965, 0.999))
         };
 
         let it = ((iph * hours) as u64).max(1);
@@ -212,6 +216,7 @@ fn series(
                 format!("0.4.{}", 18 + i)
             },
             duration,
+            up_seconds: (duration as f64 * up_frac) as u64,
             iterations: it,
             failure_rate: f,
             iters_per_hour: iph,
@@ -266,7 +271,11 @@ fn seed_sample(data: &Path) -> std::io::Result<()> {
         3.4,
         0.015,
         48.0,
-        Some(13),
+        // The regressed fixture is the LAST daily run: latest-verdict-daily is
+        // hand-written as "regress" from that run, so the Daily tab button's
+        // uptime bar shows the red-slice state while Weekend shows near-full
+        // green — both button states are exercised by the default fixture.
+        Some(15),
         false,
     );
 

--- a/scripts/bench/aggregate-perf-report.sh
+++ b/scripts/bench/aggregate-perf-report.sh
@@ -157,7 +157,12 @@ jq -n \
         protection_breach: $protection_breach,
         # Seconds actually soaked so far, against the run
         # budget — lets the dashboard show progress on a checkpoint.
-        elapsed_seconds: ($passive.elapsed_seconds // null)
+        elapsed_seconds: ($passive.elapsed_seconds // null),
+        # Shard uptime (summed wall-clock of iterations that completed their
+        # full cycle; see write-soak-summary.sh). Optional by construction:
+        # runs that predate the field carry null and the dashboard uptime
+        # bar collapses rather than rendering a bar with no data.
+        shard_up_seconds: ($passive.shard_up_seconds // null)
       },
       passive: (if $passive == null then null else {
         iterations: $passive.iterations,

--- a/scripts/bench/test-aggregate-perf-report.sh
+++ b/scripts/bench/test-aggregate-perf-report.sh
@@ -38,6 +38,7 @@ jq -e '
   .verdict == "regress"
   and .bootstrap == true
   and (.failures | any(test("1 passive soak iteration\\(s\\) failed")))
+  and .run.shard_up_seconds == null
 ' "$TMP/failed-report/verdict.json" >/dev/null
 
 mkdir -p "$TMP/checkpoint-report"
@@ -49,12 +50,14 @@ jq -e '.verdict == "in_progress" and .failures == []' \
 	"$TMP/checkpoint-report/verdict.json" >/dev/null
 
 mkdir -p "$TMP/passing" "$TMP/passing-report"
-jq '.failures = 0 | .failure_rate = 0 | .providers.docker.failures = 0' \
+jq '.failures = 0 | .failure_rate = 0 | .providers.docker.failures = 0
+	| .shard_up_seconds = 90' \
 	"$TMP/failed/summary.json" >"$TMP/passing/summary.json"
 SOAK_DIR="$TMP/passing" OUT_DIR="$TMP/passing-report" RUN_ID=2 RUN_ATTEMPT=1 \
 	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
 	"$ROOT/scripts/bench/aggregate-perf-report.sh"
-jq -e '.verdict == "pass" and .bootstrap == true and .failures == []' \
+jq -e '.verdict == "pass" and .bootstrap == true and .failures == []
+	and .run.shard_up_seconds == 90' \
 	"$TMP/passing-report/verdict.json" >/dev/null
 
 mkdir -p "$TMP/segments/bench-segment-00001/bench" "$TMP/segments-report"

--- a/scripts/bench/test-write-soak-summary.sh
+++ b/scripts/bench/test-write-soak-summary.sh
@@ -33,6 +33,7 @@ jq -e '
   and .elapsed_seconds == 180
   and .iterations == 2
   and .failures == 2
+  and .shard_up_seconds == 0
   and .rss_peak_mb == 15580
   and .providers.docker.failures == 1
   and .providers.subprocess.failures == 1
@@ -48,9 +49,19 @@ write_summary "$EMPTY" 0 0
 jq -e '
   .rss_peak_mb == null
   and .cpu_peak_pct == null
+  and .shard_up_seconds == 0
   and .tracked_metrics == {}
   and .iteration_metrics == []
 ' "$EMPTY/summary.json" >/dev/null
+
+# Shard uptime counts only completed-cycle iterations: the ok iteration
+# contributes its duration, the failed one contributes nothing.
+MIXED="$TMP/mixed"
+mkdir -p "$MIXED/iteration-00001-docker" "$MIXED/iteration-00002-docker"
+printf '%s\n' '{"iteration":1,"provider":"docker","duration_s":60,"ok":true,"metrics":{}}' >"$MIXED/iteration-00001-docker/metrics.json"
+printf '%s\n' '{"iteration":2,"provider":"docker","duration_s":120,"ok":false,"metrics":{}}' >"$MIXED/iteration-00002-docker/metrics.json"
+write_summary "$MIXED" 2 1
+jq -e '.shard_up_seconds == 60' "$MIXED/summary.json" >/dev/null
 
 SPARSE="$TMP/sparse"
 mkdir -p "$SPARSE/iteration-00001-docker"
@@ -59,6 +70,7 @@ write_summary "$SPARSE" 1 0
 jq -e '
   .rss_peak_mb == null
   and .cpu_peak_pct == null
+  and .shard_up_seconds == 0
   and .tracked_metrics.lfb_spread.p50 == null
   and .tracked_metrics.lfb_spread.p95 == null
   and .tracked_metrics.lfb_spread.max == null

--- a/scripts/bench/write-soak-summary.sh
+++ b/scripts/bench/write-soak-summary.sh
@@ -75,6 +75,13 @@ jq -n \
           finished_at: $finished,
           requested_seconds: $requested,
           elapsed_seconds: $elapsed,
+          # Shard uptime at iteration granularity: the summed wall-clock of
+          # iterations that completed their full bring-up -> load -> finalize
+          # cycle. A failed or watchdog-killed iteration contributes nothing —
+          # the shard was not reliably up for any of it — and inter-iteration
+          # gaps count as downtime. Feeds the dashboard uptime bar
+          # (run.shard_up_seconds vs duration/elapsed).
+          shard_up_seconds: ([$all[] | select(.ok? == true) | .duration_s? | select(type == "number")] | add // 0),
           iterations: $iterations,
           failures: $failures,
           failure_rate: (if $iterations > 0 then ($failures / $iterations) else 0 end),


### PR DESCRIPTION
## Summary

Brings the soak dashboard in line with the reviewed demo design and wires the new uptime metric end to end (dashboard ← verdict/history ← summary ← per-iteration records).

### Dashboard (`.github/dashboard/index.html`)

- **Shard uptime on each series button**, between the verdict line and the provenance line: green share = time the shard was up, red remainder = downtime, with an `uptime N% · Xh of Yh` readout. Collapses entirely for runs that predate the field — history is never backfilled.
- **Real tabbed interface**: the Weekend/Daily buttons are now tabs physically attached to a bordered panel sheet; the selected tab merges into the panel so the seam states which series the data belongs to. Series accent moved to the tab's top edge.
- **Subtle selection tint**: the sheet carries a whisper of the series accent (blue Weekend, green Daily) via `color-mix`, theme-aware strength (6% light / 14% dark), falling back to the untinted surface where unsupported.
- Preview fixtures (`preview.rs`) emit `shard_up_seconds`; the regressed fixture is the last daily run so the default sample shows both the near-full-green and red-slice button states. Reviewed against live data via `scripts/preview-soak-dashboard.sh`.

### Producer (`scripts/bench/`)

- `write-soak-summary.sh`: `summary.json` gains `shard_up_seconds` — the summed wall-clock of iterations that completed their full bring-up → load → finalize cycle. Failed or watchdog-killed iterations contribute nothing; inter-iteration gaps count as downtime, so a breach-aborted run (e.g. run 31238147584) reads as mostly red.
- `aggregate-perf-report.sh`: the `run` block passes the field through to `verdict.json`/history entries for final and `in_progress` checkpoint publishes alike; `null` for old summaries. No new data files, so the three publishing workflows' carry-forward lists are untouched.
- Tests extended in both suites (zero-uptime, mixed, sparse, empty; null/value passthrough) — all soak bench suites pass, including the driver's fail-closed tests.

## Sequencing

Slots after #199 in the merge order: docker-iteration uptime data is only as good as the per-node monitoring the `989fc2af` pin restores. Deploys to the published Pages dashboard automatically on the next dev→master promotion (the Pages workflow triggers on master pushes touching `.github/dashboard/**`); real uptime bars appear with the first soak run after that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788824959&installation_model_id=426883&pr_number=214&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F214&signature=667ccb844c3ba1abe896a800fae7e0150ce16a5a191a30849d379b4b2fe82f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->