### PR TITLE
fix(ci): bump SYSTEM_INTEGRATION_REF to 62f752f4 — barrier polls readonly only

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=989fc2af8edd842216d41de7a07ccd3e154ae432
+SYSTEM_INTEGRATION_REF=62f752f48f895be598b25d1281768f66e577e126

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: 989fc2af8edd842216d41de7a07ccd3e154ae432
+  SYSTEM_INTEGRATION_REF: 62f752f48f895be598b25d1281768f66e577e126
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -124,7 +124,7 @@ env:
   # by grep: main already contained the string __RUNNER_LABELS__, the cloud-init
   # template placeholder, long before the override existed. Grepping would have
   # said yes against a launcher that ignores the variable.
-  SYSTEM_INTEGRATION_REF: 989fc2af8edd842216d41de7a07ccd3e154ae432
+  SYSTEM_INTEGRATION_REF: 62f752f48f895be598b25d1281768f66e577e126
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"


### PR DESCRIPTION
## Summary

Un-reds dev's Heavy Pipeline. The registry-visibility barrier that arrived with the `989fc2af` pin polled **all** shard nodes with `registry_query` — an exploratory deploy, which the node serves **only on read-only nodes** (`casper/src/rust/api/block_api.rs:192` rejects it elsewhere). Boot is first in the node list, so the barrier timed out deterministically on every slot (run 31284483534), failing both bridge-admin tests while the node itself was healthy.

Evidence the node side is sound in that same run:
- Boot's log shows `Exploratory deploy can only be executed on read-only node` every 3s at exactly the barrier's poll cadence.
- The bridge deploy's merge rejections occurred **after** the test had already failed — unrelated to the timeout.
- validator1 logged `Prepare user deploys: 1 recovered from rejected-deploy buffer` — #212's recovery working as designed.

## Change

3-site `SYSTEM_INTEGRATION_REF` bump `989fc2af → 62f752f4` (`oci-validation.env`, `_integration-pipeline.yml`, `merge-recovery-soak.yml`). system-integration `62f752f4` scopes the barrier to `[shared_shard.readonly]` — the canonical-state vantage — leaving the all-nodes finalization wait unchanged. Bump range is test-side only (the barrier fix plus SI #93's unit-test drift-guard anchoring). The SHA is on SI branch `fix/wait_for_registry_visible`; SI merges are merge commits, so it joins main's ancestry when that PR lands — pairing note: merge the SI PR before or alongside this one.

## What this run proves

This PR's Heavy Pipeline is the first pairing of the fixed barrier with the #212-fixed node: bridge-admin tests green here validates the whole detector-plus-fix chain and restores dev CI ahead of the #214/#211/#210 merges and the dev→master promotion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788827571&installation_model_id=426883&pr_number=215&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F215&signature=3dbc32019caf8135263b83205637ac7bd42fc4acd29bcd7785848571bc627714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->