### PR TITLE
fix(ci): raise SOAK_RSS_CEILING_MB to 20480 (workload envelope, not regression)

### DIFF
--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -80,7 +80,15 @@ env:
   # 16693MB, over the old ceiling), so 14336 was below the workload, not a
   # regression guard. SOAK_HOST_FREE_FLOOR_MB remains the host-thrash guard.
   SOAK_RSS_CEILING_MB: "20480"
-  SOAK_HOST_FREE_FLOOR_MB: "12288"
+  # 2026-08-10 (PR #217 review): lowered 12288 -> 8192 alongside the ceiling
+  # raise. On the 32GB soak host, 20480 + 12288 = 32768 meant available RAM
+  # crossed the floor before total RSS could reach the ceiling, so on
+  # floor-enforced (subprocess-provider) iterations the less-attributable
+  # floor kill would fire below the measured 16.7-19.3GB workload envelope.
+  # 8192 keeps ~3GB of real swap-thrash margin at that envelope (19.3GB
+  # nodes + ~4GB OS/harness overhead -> ~9.5GB free) while letting the
+  # workload reach the RSS ceiling that names the component it kills.
+  SOAK_HOST_FREE_FLOOR_MB: "8192"
   # THIRD pin site. The other two — .github/oci-validation.env and
   # _integration-pipeline.yml — are held identical by build_base's drift check;
   # this one is outside that check and rotted unnoticed as a result. It sat at

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -72,7 +72,14 @@ permissions:
 
 env:
   DOCKER_IMAGE_NAME: f1r3flyindustries/f1r3fly-rust
-  SOAK_RSS_CEILING_MB: "14336"
+  # 2026-08-09: raised 14336 -> 20480 after the weekend-soak breaches (runs
+  # 31331480002 / 31332864501). Attribution before raising: local A/B of
+  # pre- vs post-merge master showed no node-code memory change, and the
+  # green-vs-failed harness pins carry an empty test_load diff — the 6-node
+  # shard's real envelope is 16.7-19.3GB (the last GREEN run already peaked
+  # 16693MB, over the old ceiling), so 14336 was below the workload, not a
+  # regression guard. SOAK_HOST_FREE_FLOOR_MB remains the host-thrash guard.
+  SOAK_RSS_CEILING_MB: "20480"
   SOAK_HOST_FREE_FLOOR_MB: "12288"
   # THIRD pin site. The other two — .github/oci-validation.env and
   # _integration-pipeline.yml — are held identical by build_base's drift check;


### PR DESCRIPTION
## Summary
- Raises the merge-recovery-soak total-RSS watchdog ceiling from 14336MB to 20480MB on the 32GB soak host. `SOAK_HOST_FREE_FLOOR_MB` (12288) remains the actual host swap-thrash guard.

## Why this is not papering over a regression
The weekend soak on post-merge `master` (runs [31331480002](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/31331480002) and auto-retry [31332864501](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/31332864501)) breached the ceiling at t=316s (`total node RSS 18853MB > 14336MB`). Per-component attribution before touching the ceiling:

1. **Node code exonerated** — local A/B of `test_load.py::test_deploy_throughput_and_finalization` on images built from pre-merge (`691c52b9`) vs post-merge (`eb4030c2`) master, same harness (system-integration `62f752f`), same host, identical 40-min duration, watchdog disabled: total peak 8077MB vs 7872MB — post-merge marginally lower, no per-node divergence.
2. **Harness exonerated** — diff between the green run's system-integration pin (`66de4f95`) and the failed runs' pin (`62f752f4`) is empty for `test_load.py`, `conftest.py`, and `compose.py`: the load profile did not change.
3. **The ceiling was below the workload all along** — the last green soak (run [30906818259](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/30906818259), 2026-08-04, dev@`691c52b9`) itself peaked at **16693MB total**, over the old ceiling; it passed only because the peak was not sustained for 2 consecutive watchdog samples. Measured envelope of the 6-node shard under test_load: 16.7–19.3GB, with heavy per-validator variance (failed run's validator3 hit 5157MB vs 3.2–3.7GB siblings).

## Test plan
- [x] Local A/B measurement runs on both images (tables above)
- [x] Pre-push gate: full release test suite, 11/11 crates green
- [ ] After merge: re-dispatch the weekend soak (`target_ref=master`, `duration=weekend-60h`) and confirm it clears the 316s breach point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956475&installation_model_id=426883&pr_number=217&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F217&signature=0c3f3ab3005a4ab9d0710863113cd5a359e96a937bdfd7e45785e48672f7b5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->