### PR TITLE
fix(consensus): retain quorum during slow-peer recovery

### DIFF
--- a/casper/src/rust/api/block_report_api.rs
+++ b/casper/src/rust/api/block_report_api.rs
@@ -1,9 +1,9 @@
 // See casper/src/main/scala/coop/rchain/casper/api/BlockReportAPI.scala
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use block_storage::rust::key_value_block_store::KeyValueBlockStore;
-use dashmap::DashMap;
 use models::casper::{
     BlockEventInfo, DeployInfoWithEventData, ReportProto, SingleReport,
     SystemDeployInfoWithEventData,
@@ -11,9 +11,10 @@ use models::casper::{
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::protocol::casper_message::{BlockMessage, SystemDeployData};
 use prost::bytes::Bytes;
+use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 use rspace_plus_plus::rspace::reporting_transformer::ReportingTransformer;
 use shared::rust::store::key_value_typed_store::KeyValueTypedStore;
-use shared::rust::ByteString;
+use shared::rust::{env, ByteString};
 use tokio::sync::Semaphore;
 
 use crate::rust::api::block_api::BlockAPI;
@@ -22,6 +23,18 @@ use crate::rust::report_store::ReportStore;
 use crate::rust::reporting_casper::ReportingCasper;
 use crate::rust::reporting_proto_transformer::ReportingProtoTransformer;
 use crate::rust::safety_oracle::CliqueOracleImpl;
+use crate::rust::util::proto_util;
+
+const REPORT_CACHE_VERSION: &[u8] = b"v2:";
+const BLOCK_REPORT_QUEUE_TIMEOUT_MS_DEFAULT: u64 = 2_000;
+const BLOCK_REPORT_QUEUE_TIMEOUT_MS_ENV: &str = "F1R3_BLOCK_REPORT_QUEUE_TIMEOUT_MS";
+
+fn report_cache_key(block_hash: &BlockHash) -> ByteString {
+    let mut key = Vec::with_capacity(REPORT_CACHE_VERSION.len() + block_hash.len());
+    key.extend_from_slice(REPORT_CACHE_VERSION);
+    key.extend_from_slice(block_hash);
+    key
+}
 
 /// Domain-specific errors for BlockReportAPI operations
 #[derive(Debug, thiserror::Error)]
@@ -32,6 +45,10 @@ pub enum BlockReportError {
     ReadOnlyRequired,
     #[error("Block {0:?} not found")]
     BlockNotFound(BlockHash),
+    #[error("Block report pre-state is unavailable for block {0:?}")]
+    StateUnavailable(BlockHash),
+    #[error("Block reporter is busy; retry later")]
+    Busy,
     #[error("Failed to trace block: {0}")]
     ReplayFailed(String),
     #[error("Block info error: {0}")]
@@ -54,9 +71,8 @@ pub struct BlockReportAPI {
     block_store: KeyValueBlockStore,
     #[allow(dead_code)] // Part of constructor signature matching Scala, not directly used
     oracle: CliqueOracleImpl,
-    /// Thread-safe map of block hashes to semaphores for per-block locking
-    /// Equivalent to Scala's `blockLockMap: TrieMap[BlockHash, MetricsSemaphore[F]]`
-    block_lock_map: Arc<DashMap<BlockHash, Arc<Semaphore>>>,
+    block_report_semaphore: Arc<Semaphore>,
+    block_report_queue_timeout: Duration,
     /// Transformer for converting reporting events to protobuf format
     report_transformer: Arc<ReportingProtoTransformer>,
     /// When true, allows block reports on validator nodes (bypasses read-only check)
@@ -79,7 +95,14 @@ impl BlockReportAPI {
             engine_cell,
             block_store,
             oracle,
-            block_lock_map: Arc::new(DashMap::new()),
+            block_report_semaphore: Arc::new(Semaphore::new(1)),
+            block_report_queue_timeout: Duration::from_millis(
+                env::var_or(
+                    BLOCK_REPORT_QUEUE_TIMEOUT_MS_ENV,
+                    BLOCK_REPORT_QUEUE_TIMEOUT_MS_DEFAULT,
+                )
+                .max(1),
+            ),
             report_transformer: Arc::new(ReportingProtoTransformer::new()),
             dev_mode,
         }
@@ -122,27 +145,23 @@ impl BlockReportAPI {
         block: &BlockMessage,
         casper: &Arc<dyn crate::rust::casper::MultiParentCasper + Send + Sync>,
     ) -> ApiErr<BlockEventInfo> {
-        let block_hash = block.block_hash.clone();
-
-        let semaphore = self
-            .block_lock_map
-            .entry(block_hash.clone())
-            .or_insert_with(|| Arc::new(Semaphore::new(1)))
-            .clone();
-
         metrics::gauge!("block_report.lock.queue_size", "source" => "casper").increment(1.0);
-        let _permit = semaphore
-            .acquire()
-            .await
-            .map_err(|e| BlockReportError::SemaphoreError(e.to_string()))?;
+        let permit = tokio::time::timeout(
+            self.block_report_queue_timeout,
+            self.block_report_semaphore.acquire(),
+        )
+        .await;
         metrics::gauge!("block_report.lock.queue_size", "source" => "casper").decrement(1.0);
+        let _permit = match permit {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(error)) => return Err(BlockReportError::SemaphoreError(error.to_string())),
+            Err(_) => {
+                metrics::counter!("block_report.busy", "source" => "casper").increment(1);
+                return Err(BlockReportError::Busy);
+            }
+        };
 
-        let result = self.block_report_inner(force_replay, block, casper).await;
-
-        // Remove semaphore entry to prevent unbounded growth of the lock map
-        self.block_lock_map.remove(&block_hash);
-
-        result
+        self.block_report_inner(force_replay, block, casper).await
     }
 
     /// Inner block report logic (separated to ensure lock map cleanup on all paths)
@@ -152,7 +171,7 @@ impl BlockReportAPI {
         block: &BlockMessage,
         casper: &Arc<dyn crate::rust::casper::MultiParentCasper + Send + Sync>,
     ) -> ApiErr<BlockEventInfo> {
-        let block_hash_bytes: ByteString = block.block_hash.to_vec().into();
+        let block_hash_bytes = report_cache_key(&block.block_hash);
         let cached = self
             .report_store
             .get(&vec![block_hash_bytes.clone()])
@@ -162,6 +181,16 @@ impl BlockReportAPI {
             if !force_replay {
                 return Ok(cached_report.clone());
             }
+        }
+
+        let pre_state_hash = Blake2b256Hash::from_bytes_prost(&proto_util::pre_state_hash(block));
+        let has_pre_state = casper
+            .runtime_manager()
+            .has_root(&pre_state_hash)
+            .map_err(|error| BlockReportError::ReplayFailed(error.to_string()))?;
+        if !has_pre_state {
+            metrics::counter!("block_report.state_unavailable", "source" => "casper").increment(1);
+            return Err(BlockReportError::StateUnavailable(block.block_hash.clone()));
         }
 
         let report = self.replay_block(block, casper).await?;
@@ -198,6 +227,16 @@ impl BlockReportAPI {
 
         self.block_report_within_lock(force_replay, &block, &casper)
             .await
+    }
+
+    pub fn cached_block_report(&self, hash: &BlockHash) -> ApiErr<Option<BlockEventInfo>> {
+        let key = report_cache_key(hash);
+        let cached = self
+            .report_store
+            .get(&vec![key])
+            .map_err(|e| BlockReportError::StoreError(e.to_string()))?;
+
+        Ok(cached.into_iter().next().flatten())
     }
 
     /// Create system deploy report from replay results

--- a/casper/src/rust/reporting_casper.rs
+++ b/casper/src/rust/reporting_casper.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use block_storage::rust::dag::block_dag_key_value_storage::BlockDagKeyValueStorage;
-use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use models::rhoapi::{BindPattern, ListParWithRandom, Par, TaggedContinuation};
 use models::rust::casper::protocol::casper_message::{
     BlockMessage, ProcessedDeploy, ProcessedSystemDeploy, SystemDeployData,
@@ -65,7 +64,6 @@ impl ReportingCasper for NoopReportingCasper {
 /// Real implementation using RhoReporter
 pub struct RhoReporterCasper {
     rspace_store: RSpaceStore,
-    block_store: KeyValueBlockStore,
     block_dag_storage: BlockDagKeyValueStorage,
     external_services: rholang::rust::interpreter::external_services::ExternalServices,
 }
@@ -94,16 +92,6 @@ impl ReportingCasper for RhoReporterCasper {
             .block_dag_storage
             .get_representation()
             .map_err(|e| format!("Failed to get DAG representation: {}", e))?;
-
-        let genesis = self
-            .block_store
-            .get_approved_block()
-            .map_err(|e| format!("Failed to get approved block: {}", e))?;
-
-        let is_genesis = genesis
-            .as_ref()
-            .map(|g| block.block_hash == g.candidate.block.block_hash)
-            .unwrap_or(false);
 
         let invalid_blocks_set = dag.invalid_blocks();
 
@@ -135,7 +123,7 @@ impl ReportingCasper for RhoReporterCasper {
             &pre_state_hash,
             &block.body.deploys,
             &block.body.system_deploys,
-            !is_genesis,
+            with_cost_accounting(&block.header.parents_hash_list),
             &block_data,
             seen_invalid_blocks,
         )
@@ -249,16 +237,29 @@ pub fn noop() -> Arc<dyn ReportingCasper> { Arc::new(NoopReportingCasper) }
 /// Factory function to create rho reporter with real reporting capability
 pub fn rho_reporter(
     rspace_store: &RSpaceStore,
-    block_store: &KeyValueBlockStore,
     block_dag_storage: &BlockDagKeyValueStorage,
     external_services: rholang::rust::interpreter::external_services::ExternalServices,
 ) -> Arc<dyn ReportingCasper> {
     Arc::new(RhoReporterCasper {
         rspace_store: rspace_store.clone(),
-        block_store: block_store.clone(),
         block_dag_storage: block_dag_storage.clone(),
         external_services,
     })
+}
+
+fn with_cost_accounting(parent_hashes: &[prost::bytes::Bytes]) -> bool { !parent_hashes.is_empty() }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn genesis_deploys_are_not_cost_accounted() {
+        assert!(!with_cost_accounting(&[]));
+        assert!(with_cost_accounting(&[prost::bytes::Bytes::from_static(
+            b"parent",
+        )]));
+    }
 }
 
 /// ReportingRuntime wraps RhoRuntimeImpl with ReportingRspace to enable event collection

--- a/casper/src/rust/util/mergeable_channels_gc.rs
+++ b/casper/src/rust/util/mergeable_channels_gc.rs
@@ -4,6 +4,8 @@
 //! This is required for multi-parent mode where immediate deletion during finalization
 //! can cause data races.
 
+use std::collections::HashSet;
+
 use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
 use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use models::rust::block_hash::BlockHash;
@@ -26,12 +28,16 @@ pub async fn collect_garbage(
 ) -> Result<usize, KvStoreError> {
     let mut deleted_count = 0;
 
-    // Get all finalized blocks by traversing from genesis
-    // Note: This could be optimized by tracking pending GC blocks
     let finalized_blocks = get_finalized_blocks(dag)?;
+    let common_strict_ancestors = common_strict_main_chain_ancestors(dag);
 
     for block_hash in finalized_blocks {
-        if is_safe_to_delete(dag, &block_hash, casper_shard_conf)? {
+        if is_safe_to_delete(
+            dag,
+            &block_hash,
+            casper_shard_conf,
+            common_strict_ancestors.as_ref(),
+        )? {
             // Get block to access its state hash
             if let Some(block) = block_store.get(&block_hash)? {
                 let deleted = runtime_manager
@@ -71,6 +77,7 @@ fn is_safe_to_delete(
     dag: &KeyValueDagRepresentation,
     block_hash: &BlockHash,
     casper_shard_conf: &CasperShardConf,
+    common_strict_ancestors: Option<&HashSet<BlockHash>>,
 ) -> Result<bool, KvStoreError> {
     // 1. Check if block is finalized
     if !dag.is_finalized(block_hash) {
@@ -98,48 +105,89 @@ fn is_safe_to_delete(
         return Ok(false);
     }
 
-    let latest_message_hashes = dag.latest_message_hashes();
-
-    // For each validator's latest message, check if it's a descendant of any child (via main chain)
-    for (_, latest_msg_hash) in latest_message_hashes.iter() {
-        if latest_msg_hash == block_hash {
-            // Validator's latest is still this block
-            return Ok(false);
-        }
-
-        // Check if latest message is descendant of any child (via main chain)
-        let mut found_in_child_chain = false;
-        for child_hash_ref in children.iter() {
-            if dag.is_in_main_chain(child_hash_ref, latest_msg_hash)? {
-                found_in_child_chain = true;
-                break;
-            }
-        }
-
-        if !found_in_child_chain {
-            return Ok(false);
-        }
+    if common_strict_ancestors.is_some_and(|ancestors| !ancestors.contains(block_hash)) {
+        return Ok(false);
     }
 
     Ok(true)
 }
 
-/// Get all finalized blocks from the DAG.
-/// Note: This is a simple implementation that could be optimized.
-fn get_finalized_blocks(dag: &KeyValueDagRepresentation) -> Result<Vec<BlockHash>, KvStoreError> {
-    // Get all blocks via topo_sort and filter for finalized ones
-    let all_blocks = dag.topo_sort(0, None)?;
+fn common_strict_main_chain_ancestors(
+    dag: &KeyValueDagRepresentation,
+) -> Option<HashSet<BlockHash>> {
+    common_strict_ancestors(
+        dag.latest_message_hashes().values().cloned(),
+        |block_hash| dag.main_parent(block_hash),
+    )
+}
 
-    let finalized: Vec<BlockHash> = all_blocks
+fn common_strict_ancestors(
+    latest_messages: impl IntoIterator<Item = BlockHash>,
+    main_parent: impl Fn(&BlockHash) -> Option<BlockHash>,
+) -> Option<HashSet<BlockHash>> {
+    latest_messages
         .into_iter()
-        .flatten()
-        .filter(|hash| dag.is_finalized(hash))
-        .collect();
+        .map(|latest_message| {
+            let mut ancestors = HashSet::new();
+            let mut current = latest_message;
+            while let Some(parent) = main_parent(&current) {
+                if !ancestors.insert(parent.clone()) {
+                    break;
+                }
+                current = parent;
+            }
+            ancestors
+        })
+        .reduce(|common, ancestors| common.intersection(&ancestors).cloned().collect())
+}
 
-    Ok(finalized)
+fn get_finalized_blocks(dag: &KeyValueDagRepresentation) -> Result<Vec<BlockHash>, KvStoreError> {
+    Ok(dag.finalized_blocks_set.iter().cloned().collect())
 }
 
 #[cfg(test)]
 mod tests {
-    // Tests would go here
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn hash(value: &'static [u8]) -> BlockHash { BlockHash::from_static(value) }
+
+    #[test]
+    fn intersects_strict_main_chain_ancestors() {
+        let genesis = hash(b"genesis");
+        let common = hash(b"common");
+        let left = hash(b"left");
+        let right = hash(b"right");
+        let parents = HashMap::from([
+            (common.clone(), genesis.clone()),
+            (left.clone(), common.clone()),
+            (right.clone(), common.clone()),
+        ]);
+
+        let ancestors =
+            common_strict_ancestors([left, right], |block_hash| parents.get(block_hash).cloned());
+
+        assert_eq!(ancestors, Some(HashSet::from([common, genesis])));
+    }
+
+    #[test]
+    fn excludes_latest_messages_from_strict_ancestors() {
+        let genesis = hash(b"genesis");
+        let latest = hash(b"latest");
+        let parents = HashMap::from([(latest.clone(), genesis.clone())]);
+
+        let ancestors =
+            common_strict_ancestors([latest], |block_hash| parents.get(block_hash).cloned());
+
+        assert_eq!(ancestors, Some(HashSet::from([genesis])));
+    }
+
+    #[test]
+    fn returns_none_without_latest_messages() {
+        let latest_messages: [BlockHash; 0] = [];
+        let ancestors = common_strict_ancestors(latest_messages, |_| None);
+
+        assert_eq!(ancestors, None);
+    }
 }

--- a/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
+++ b/casper/tests/batch1/multi_parent_casper_reporting_spec.rs
@@ -56,7 +56,6 @@ async fn reporting_casper_should_behave_the_same_way_as_multi_parent_casper() {
 
     let reporter = reporting_casper::rho_reporter(
         &rspace_store,
-        &node.block_store,
         &node.block_dag_storage,
         ExternalServices::noop(),
     );

--- a/node/src/rust/api/deploy_grpc_service_v1.rs
+++ b/node/src/rust/api/deploy_grpc_service_v1.rs
@@ -150,12 +150,8 @@ impl DeployGrpcServiceV1Impl {
             Err(_) => return,
         };
 
-        match self
-            .block_report_api
-            .block_report(block_hash_bytes, false)
-            .await
-        {
-            Ok(report) => {
+        match self.block_report_api.cached_block_report(&block_hash_bytes) {
+            Ok(Some(report)) => {
                 let transfers_by_deploy =
                     crate::rust::web::block_info_enricher::extract_transfers_from_report(
                         &report,
@@ -168,7 +164,7 @@ impl DeployGrpcServiceV1Impl {
                     }
                 }
             }
-            Err(_) => {
+            Ok(None) | Err(_) => {
                 // Validators: transfers_available stays false (proto default),
                 // transfers stays empty Vec. Clients check transfers_available
                 // to distinguish "no transfers" from "unavailable."

--- a/node/src/rust/api/web_api.rs
+++ b/node/src/rust/api/web_api.rs
@@ -274,12 +274,8 @@ impl WebApiImpl {
                 return;
             }
         };
-        match self
-            .block_report_api
-            .block_report(block_hash_bytes, false)
-            .await
-        {
-            Ok(report) => {
+        match self.block_report_api.cached_block_report(&block_hash_bytes) {
+            Ok(Some(report)) => {
                 let transfers_by_deploy =
                     extract_transfers_from_report(&report, &self.transfer_unforgeable);
                 for deploy in deploys {
@@ -294,7 +290,7 @@ impl WebApiImpl {
                     );
                 }
             }
-            Err(_) => {
+            Ok(None) | Err(_) => {
                 for deploy in deploys {
                     deploy.transfers = None;
                 }

--- a/node/src/rust/instances/heartbeat_proposer.rs
+++ b/node/src/rust/instances/heartbeat_proposer.rs
@@ -521,7 +521,8 @@ async fn check_lfb_and_propose(
         std::cmp::max(pending_deploy_max_lag, advanced_deploy_recovery_max_lag);
     let idle_recovery_window_open =
         finality_progress.stalled && finality_progress.recovery_round_due;
-    let lag_recovery_leader = is_lag_recovery_leader(&snapshot, validator_identity);
+    let lag_recovery_leader =
+        is_lag_recovery_leader(&snapshot, validator_identity, last_finalized_block_number);
     let effective_frontier_chase_cap = effective_frontier_chase_cap(
         frontier_chase_max_lag,
         deploy_recovery_max_lag,
@@ -995,6 +996,7 @@ fn inspect_parent_updates(
 fn is_lag_recovery_leader(
     snapshot: &CasperSnapshot,
     validator_identity: &ValidatorIdentity,
+    last_finalized_block_number: i64,
 ) -> bool {
     let validators: Vec<Validator> = match snapshot.parents.first() {
         Some(parent) => parent
@@ -1010,16 +1012,22 @@ fn is_lag_recovery_leader(
         return true;
     }
 
-    select_lag_recovery_leader(validators, |validator| {
-        snapshot
-            .dag
-            .latest_message(validator)
-            .ok()
-            .flatten()
-            .map(|meta| meta.block_number)
-            .unwrap_or(0)
-    })
-    .is_none_or(|leader| leader == validator_identity.public_key.bytes)
+    let validator_latest_heights = validators
+        .into_iter()
+        .map(|validator| {
+            let latest_height = snapshot
+                .dag
+                .latest_message(&validator)
+                .ok()
+                .flatten()
+                .map(|meta| meta.block_number)
+                .unwrap_or(0);
+            (validator, latest_height)
+        })
+        .collect();
+
+    select_lag_recovery_leader(validator_latest_heights, last_finalized_block_number)
+        .is_none_or(|leader| leader == validator_identity.public_key.bytes)
 }
 
 fn effective_frontier_chase_cap(
@@ -1038,15 +1046,19 @@ fn effective_frontier_chase_cap(
 }
 
 fn select_lag_recovery_leader(
-    mut validators: Vec<Validator>,
-    latest_height: impl Fn(&Validator) -> i64,
+    validator_latest_heights: Vec<(Validator, i64)>,
+    last_finalized_block_number: i64,
 ) -> Option<Validator> {
-    validators.sort_by(|a, b| {
-        latest_height(b)
-            .cmp(&latest_height(a))
-            .then_with(|| a.cmp(b))
-    });
-    validators.into_iter().next()
+    let mut active: Vec<(Validator, i64)> = validator_latest_heights
+        .iter()
+        .filter(|(_, height)| *height > last_finalized_block_number)
+        .cloned()
+        .collect();
+    if active.is_empty() {
+        active = validator_latest_heights;
+    }
+    active.sort_by(|(a, a_height), (b, b_height)| b_height.cmp(a_height).then_with(|| a.cmp(b)));
+    active.into_iter().next().map(|(validator, _)| validator)
 }
 
 /// Unit tests for HeartbeatProposer configuration validation.
@@ -1081,12 +1093,7 @@ mod tests {
         let tied = Validator::from(vec![3]);
 
         let leader =
-            select_lag_recovery_leader(vec![paused.clone(), tied, advanced.clone()], |validator| {
-                match validator.as_ref() {
-                    [1] => 2,
-                    _ => 9,
-                }
-            });
+            select_lag_recovery_leader(vec![(paused, 2), (tied, 9), (advanced.clone(), 9)], 1);
 
         assert_eq!(leader, Some(advanced));
     }

--- a/node/src/rust/runtime/setup.rs
+++ b/node/src/rust/runtime/setup.rs
@@ -264,7 +264,6 @@ pub async fn setup_node_program<T: TransportLayer + Send + Sync + Clone + 'stati
                 .map_err(|e| CasperError::Other(format!("Failed to get rspace stores: {}", e)))?;
             reporting_casper::rho_reporter(
                 &rspace_stores,
-                &block_store,
                 &block_dag_storage,
                 rholang::rust::interpreter::external_services::ExternalServices::noop(),
             )
@@ -582,32 +581,63 @@ pub async fn setup_node_program<T: TransportLayer + Send + Sync + Clone + 'stati
     {
         use futures::StreamExt;
         use shared::rust::shared::f1r3fly_event::F1r3flyEvent;
+        use tokio::sync::mpsc::error::TrySendError;
 
-        let report_api = block_report_api.clone();
-        let transfer_unforgeable_for_events = transfer_unforgeable.clone();
-        let event_pub = event_publisher.clone();
         let is_ready_flag = is_ready.clone();
         let mut event_stream = event_publisher.consume();
+        let (report_tx, mut report_rx) =
+            tokio::sync::mpsc::channel::<shared::rust::shared::f1r3fly_event::BlockFinalised>(64);
+        let report_api = block_report_api.clone();
+        let transfer_unforgeable_for_reports = transfer_unforgeable.clone();
+        let event_pub_for_reports = event_publisher.clone();
+
+        tokio::spawn(async move {
+            while let Some(finalized) = report_rx.recv().await {
+                metrics::gauge!("block_report.prewarm_queue_depth", "source" => "node")
+                    .set(report_rx.len() as f64);
+                handle_block_finalized(
+                    report_api.clone(),
+                    transfer_unforgeable_for_reports.clone(),
+                    event_pub_for_reports.clone(),
+                    finalized.block_hash,
+                    finalized.block_number,
+                )
+                .await;
+            }
+        });
 
         tokio::spawn(async move {
             while let Some(event) = event_stream.next().await {
                 match &event {
-                    F1r3flyEvent::BlockFinalised(finalized) => {
-                        let api = report_api.clone();
-                        let unforgeable = transfer_unforgeable_for_events.clone();
-                        let publisher = event_pub.clone();
-                        let block_hash = finalized.block_hash.clone();
-                        let block_number = finalized.block_number;
-                        tokio::spawn(async move {
-                            handle_block_finalized(
-                                api,
-                                unforgeable,
-                                publisher,
-                                block_hash,
-                                block_number,
-                            )
-                            .await;
-                        });
+                    F1r3flyEvent::BlockFinalised(finalized)
+                        if is_node_read_only
+                            && is_ready_flag.load(std::sync::atomic::Ordering::Acquire) =>
+                    {
+                        match report_tx.try_send(finalized.clone()) {
+                            Ok(()) => {
+                                metrics::gauge!(
+                                    "block_report.prewarm_queue_depth",
+                                    "source" => "node"
+                                )
+                                .set((64 - report_tx.capacity()) as f64);
+                            }
+                            Err(TrySendError::Full(_)) => {
+                                metrics::counter!(
+                                    "block_report.prewarm_skipped",
+                                    "source" => "node",
+                                    "reason" => "queue_full"
+                                )
+                                .increment(1);
+                            }
+                            Err(TrySendError::Closed(_)) => {
+                                metrics::counter!(
+                                    "block_report.prewarm_skipped",
+                                    "source" => "node",
+                                    "reason" => "queue_closed"
+                                )
+                                .increment(1);
+                            }
+                        }
                     }
                     F1r3flyEvent::EnteredRunningState(_) => {
                         is_ready_flag.store(true, std::sync::atomic::Ordering::Release);

--- a/node/src/rust/web/reporting_routes.rs
+++ b/node/src/rust/web/reporting_routes.rs
@@ -93,6 +93,8 @@ pub async fn trace_handler(
             let status = match &e {
                 BlockReportError::BlockNotFound(_) => StatusCode::NOT_FOUND,
                 BlockReportError::ReadOnlyRequired => StatusCode::BAD_REQUEST,
+                BlockReportError::StateUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+                BlockReportError::Busy => StatusCode::SERVICE_UNAVAILABLE,
                 BlockReportError::CasperNotInitialized => StatusCode::INTERNAL_SERVER_ERROR,
                 BlockReportError::ReplayFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 BlockReportError::BlockInfoError(_) => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary

- Select recovery leadership from bonded validators that have advanced beyond the LFB before falling back to the full bonded set.
- Prefer the greatest observed validator height with a deterministic validator-key tie-break.
- Preserve block processing and finality when a low-stake notification recipient is paused.

## Regression coverage

Corresponds to F1R3FLY-io/system-integration#85:

`integration-tests/test/tests/custom/test_slow_peer_notification.py::test_slow_peer_does_not_block_block_processing`

The regression pauses the 1-stake validator, submits 16 deploys through the active 200-of-201 quorum, requires continued finalization, restores the peer, and verifies convergence.

## Validation

- This exact branch passed the slow-peer regression in 85.07 seconds; peak total shard memory was 2254 MB.
- Fourteen heartbeat-focused unit tests passed.
- Formatting and clippy with warnings denied passed.
- The final stacked tip passed all four stack regressions in 1000.19 seconds; peak total shard memory was 14338 MB.

## Dependency

Depends on #226. Stack order is #211, #224, #225, #226, then this PR. GitHub base remains `dev`.

Fix commit: `d30fb58f`.
