### PR TITLE
fix(casper): stop block-expired recovered deploys from wedging the proposer

### DIFF
--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -395,9 +395,15 @@ async fn prepare_user_deploys_with_policy(
         .collect();
     let earliest_block_number =
         block_number - casper_snapshot.on_chain_state.shard_conf.deploy_lifespan;
+    // Both expiry kinds are terminal for buffered work: a block-expired deploy can
+    // never again pass Validate::transaction_expiration, so holding it "recoverable"
+    // only re-offers it to a proposer that must reject it (issue #197).
     let expired_buffered: Vec<Signed<DeployData>> = buffered_deploys
         .iter()
-        .filter(|deploy| deploy.data.is_expired_at(current_time_millis))
+        .filter(|deploy| {
+            deploy.data.is_expired_at(current_time_millis)
+                || !not_expired_deploy(earliest_block_number, &deploy.data)
+        })
         .cloned()
         .collect();
     if !expired_buffered.is_empty() {
@@ -597,27 +603,26 @@ async fn prepare_user_deploys_with_policy(
         .collect();
     let block_expired_deploys: Vec<_> = unfinalized
         .iter()
-        .filter(|d| {
-            !recovered_sigs.contains(&d.sig)
-                && !casper_snapshot.rejected_in_scope.contains(&d.sig)
-                && !not_expired_deploy(earliest_block_number, &d.data)
-        })
+        .filter(|d| !not_expired_deploy(earliest_block_number, &d.data))
         .collect();
     let time_expired_deploys: Vec<_> = unfinalized
         .iter()
         .filter(|d| d.data.is_expired_at(current_time_millis))
         .collect();
 
-    // Filter valid deploys (not expired by block, not expired by time, and not future)
+    // Filter valid deploys (not expired by block, not expired by time, and not future).
+    // Block expiry applies to recovered and rejected-retry deploys too: validation
+    // (Validate::transaction_expiration) has no recovery carve-out, so a block-expired
+    // deploy admitted here can only yield a self-created block that fails its own
+    // validation with ContainsExpiredDeploy — and, because nothing purged the deploy,
+    // every subsequent propose rebuilt the same invalid block (the permanent
+    // finalization wedge of issue #197). Expiry is a chain-level invariant; recovery
+    // cannot outlive it.
     let valid: HashSet<Signed<DeployData>> = unfinalized
         .iter()
         .filter(|deploy| {
-            let rejected_ready_for_retry = casper_snapshot.rejected_in_scope.contains(&deploy.sig)
-                && !casper_snapshot.deploys_in_scope.contains(&deploy.sig);
             not_future_deploy(block_number, &deploy.data)
-                && (recovered_sigs.contains(&deploy.sig)
-                    || rejected_ready_for_retry
-                    || not_expired_deploy(earliest_block_number, &deploy.data))
+                && not_expired_deploy(earliest_block_number, &deploy.data)
                 && !deploy.data.is_expired_at(current_time_millis)
         })
         .cloned()
@@ -5963,8 +5968,11 @@ mod tests {
             .any(|deploy| deploy.sig == recovered.sig));
     }
 
+    // Inverted contract (issue #197): a block-expired recovered deploy must be
+    // excluded and purged, not selected — validation has no recovery carve-out,
+    // so selecting it could only wedge the proposer on its own invalid block.
     #[tokio::test]
-    async fn recovered_buffered_deploy_is_selected_after_block_expiry() {
+    async fn recovered_buffered_deploy_is_purged_after_block_expiry() {
         let mut kvm = InMemoryStoreManager::new();
         let deploy_storage = Arc::new(parking_lot::Mutex::new(
             KeyValueDeployStorage::new(&mut kvm)
@@ -6017,11 +6025,7 @@ mod tests {
         .await
         .expect("prepare deploys");
 
-        assert_eq!(prepared.deploys.len(), 1);
-        assert!(prepared
-            .deploys
-            .iter()
-            .any(|deploy| deploy.sig == recovered.sig));
+        assert!(prepared.deploys.is_empty());
     }
 
     // A canonical-but-unfinalized win purges only the ordinary-storage copy;

--- a/casper/src/rust/blocks/proposer/proposer.rs
+++ b/casper/src/rust/blocks/proposer/proposer.rs
@@ -241,7 +241,12 @@ where
                             ValidBlockProcessing::Left(invalid_reason) => {
                                 // Some self-validation failures are recoverable races in fast, multi-parent
                                 // proposing: parent selection can become stale, and safety checks can reject
-                                // the candidate by the time validation runs.
+                                // the candidate by the time validation runs. ContainsExpiredDeploy is in this
+                                // set as a wedge-breaker, not a race: deploy selection excludes block-expired
+                                // deploys, but any residual expiry disagreement with validation must cost one
+                                // skipped propose rather than the permanent BugError retry loop of issue #197
+                                // (the pool is unchanged on this path, so erroring here re-proposes the same
+                                // block forever).
                                 if matches!(
                                     invalid_reason,
                                     BlockError::Invalid(InvalidBlock::InvalidParents)
@@ -252,6 +257,7 @@ where
                                         | BlockError::Invalid(InvalidBlock::InvalidBondsCache)
                                         | BlockError::Invalid(InvalidBlock::InvalidRepeatDeploy)
                                         | BlockError::Invalid(InvalidBlock::NeglectedInvalidBlock)
+                                        | BlockError::Invalid(InvalidBlock::ContainsExpiredDeploy)
                                 ) {
                                     let recoverable_reason = match &invalid_reason {
                                         BlockError::Invalid(InvalidBlock::InvalidParents) => {
@@ -272,6 +278,9 @@ where
                                         BlockError::Invalid(
                                             InvalidBlock::NeglectedInvalidBlock,
                                         ) => "neglected_invalid_block",
+                                        BlockError::Invalid(
+                                            InvalidBlock::ContainsExpiredDeploy,
+                                        ) => "contains_expired_deploy",
                                         _ => "other",
                                     };
                                     metrics::counter!(

--- a/casper/tests/blocks/block_creator_spec.rs
+++ b/casper/tests/blocks/block_creator_spec.rs
@@ -635,8 +635,14 @@ async fn block_expired_deploy_in_unresolved_scope_is_removed_from_storage() {
         .contains(&deploy));
 }
 
+// Inverts the former block_expired_rejected_deploy_retries_after_source_leaves_scope
+// contract. The retry carve-out could never succeed: Validate::transaction_expiration
+// has no recovery exemption, so a block-expired retry only produced a self-created
+// block that failed its own validation, and — with the deploy never purged — the
+// proposer rebuilt the same invalid block on every heartbeat (issue #197's permanent
+// finalization wedge). Expiry is terminal for rejected-buffer work.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn block_expired_rejected_deploy_retries_after_source_leaves_scope() {
+async fn block_expired_rejected_deploy_is_purged_not_retried() {
     crate::init_logger();
 
     let validator_sk = DEFAULT_VALIDATOR_SKS[0].clone();
@@ -677,8 +683,12 @@ async fn block_expired_rejected_deploy_retries_after_source_leaves_scope() {
     .await
     .expect("prepare deploys");
 
-    assert_eq!(prepared.deploys.len(), 1);
-    assert!(prepared.deploys.contains(&deploy));
+    assert!(prepared.deploys.is_empty());
+    assert!(!deploy_storage
+        .lock()
+        .read_all()
+        .expect("read deploy storage")
+        .contains(&deploy));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1064,10 +1074,13 @@ async fn should_remove_expired_deploys_from_rejected_deploy_buffer() {
 
     {
         let buf = rejected_deploy_buffer.lock().unwrap();
+        // Inverted from "must remain" (issue #197): a block-expired buffered deploy can
+        // never pass Validate::transaction_expiration again, so retaining it only
+        // re-offers unproposable work — the fuel of the permanent propose wedge.
         assert!(
-            buf.contains_sig(&block_expired_deploy.sig)
+            !buf.contains_sig(&block_expired_deploy.sig)
                 .expect("Failed to query buffer for block-expired sig"),
-            "Block-expired recovered sig must remain in the rejected-deploy buffer"
+            "Block-expired sig must NOT remain in the rejected-deploy buffer after create"
         );
         assert!(
             !buf.contains_sig(&time_expired_deploy.sig)

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,10 @@ ignore = [
     "RUSTSEC-2021-0141", # dotenv (transitive via openai-api-rs)
     "RUSTSEC-2021-0153", # encoding (transitive via hocon -> nom)
     "RUSTSEC-2024-0436", # paste proc-macro (transitive via metrics)
+    "RUSTSEC-2026-0247", # bitmaps (transitive via imbl, the rspace++ hot-store
+                         # persistent map; repo archived 2026-05-03, advisory
+                         # published 2026-08. No safe upgrade; imbl itself is
+                         # maintained — revisit if imbl replaces the dep)
 
     # Feature-gated transitive deps, present only under --all-features (as CI runs
     # cargo-deny). All reach the graph through rholang's optional rust-bert (ML)


### PR DESCRIPTION
## Summary

Fixes #197 — the permanent finalization collapse under sustained deploy load (`ContainsExpiredDeploy` propose retry loop), reproduced in weekend-soak run [31404822218](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/31404822218) in 8/8 iterations (validators wedged at a fixed seqNum, finalization stalls up to 706 deploys, RSS ballooning to 31–37GB as work backed up). Full root-cause analysis: [#197 comment](https://github.com/F1R3FLY-io/f1r3node-rust/issues/197#issuecomment-5247848385).

**Root cause** — an expiry carve-out asymmetry: `block_creator`'s deploy selection admitted recovered / rejected-retry deploys past the `deploy_lifespan` window, but `Validate::transaction_expiration` has no recovery exemption. The proposer therefore built a block its own validation rejected, classified the failure as unrecoverable (`BugError`), never purged the deploy, and rebuilt the same invalid block on every heartbeat.

**Changes**

- `block_creator.rs` — block expiry now applies to recovered and rejected-retry deploys in selection; block-expired entries flow into the existing storage + rejected-buffer purge (their exclusion from that purge was the retention half of the wedge); the early buffered-deploy purge covers block expiry alongside time expiry.
- `proposer.rs` — `ContainsExpiredDeploy` reclassified as a recoverable self-validation failure: any residual expiry disagreement costs one skipped propose, never a permanent retry loop.
- `deny.toml` — accepts RUSTSEC-2026-0247 (`bitmaps` unmaintained, transitive via `imbl`); the advisory published today and blocks every commit repo-wide, so it rides in this commit by necessity.

## ⚠️ Reviewer attention: this PR inverts a designed contract

Three tests deliberately pinned the old behavior (block-expired recovered/rejected work is retried and retained):

- `block_expired_rejected_deploy_retries_after_source_leaves_scope` → now `…is_purged_not_retried`
- `recovered_buffered_deploy_is_selected_after_block_expiry` (inline) → now `…is_purged_after_block_expiry`
- `should_remove_expired_deploys_from_rejected_deploy_buffer`'s "block-expired sig must remain" assertion → inverted

The carve-out was intentional — but unimplementable: consensus validation makes expiry terminal regardless of recovery state, so the retry could only ever produce a self-rejected block. Merging this PR ratifies that the "recover past expiry" intent is abandoned, not merely refactored. If recovery-past-expiry is ever genuinely wanted, it requires a matching carve-out in `Validate::transaction_expiration` across all validators (a consensus change), not a creator-side one.

## Attribution notes

- The bug predates the 2026-08 dev→master merge: issue #197 was filed 2026-08-04 from the deploy-stress experiment, and a local pre/post-merge A/B showed identical behavior.
- No open PR addressed this: #208 covers admission-time expiry only (complementary — the wedged deploys were valid at admission and aged in the buffer); #224/#227 touch recovery dynamics, not the carve-out.

## Test plan

- [x] Full casper suite green: 247 lib + 828 integration tests, 0 failures
- [x] Recovery-related batch2 specs green (recovery_cycle, recovery_repeat_deploy_misfire, dedup_orphan_recovery, finalized_win_pending_rejection, multi_validator_recovery)
- [x] Pre-push gate: 11/11 crates, release mode
- [ ] Post-merge: re-dispatch the weekend soak (`target_ref=master` after promotion) — the definitive test is whether iterations survive past seqNum ~170 under sustained load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
