### PR TITLE
fix(node): clamp HTTP/2 frame size to the RFC 9113 legal range

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,10 @@ ignore = [
     "RUSTSEC-2021-0141", # dotenv (transitive via openai-api-rs)
     "RUSTSEC-2021-0153", # encoding (transitive via hocon -> nom)
     "RUSTSEC-2024-0436", # paste proc-macro (transitive via metrics)
+    "RUSTSEC-2026-0247", # bitmaps (transitive via imbl, the rspace++ hot-store
+                         # persistent map; repo archived 2026-05-03, advisory
+                         # published 2026-08. No safe upgrade; imbl itself is
+                         # maintained — revisit if imbl replaces the dep)
 
     # Feature-gated transitive deps, present only under --all-features (as CI runs
     # cargo-deny). All reach the graph through rholang's optional rust-bert (ML)

--- a/node/src/rust/api/grpc_package.rs
+++ b/node/src/rust/api/grpc_package.rs
@@ -19,6 +19,21 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 // Note: Deploy and Propose services are defined in the models crate
 // These would be imported from models::casper::v1::{deploy_service_v1_server, propose_service_v1_server}
 
+// RFC 9113 §6.5.2: SETTINGS_MAX_FRAME_SIZE must lie in [2^14, 2^24 - 1]. The
+// configured gRPC message size doubles as the frame-size hint here, but the two
+// are independent limits — the 16 MiB message-size default (2^24) is one past
+// the frame cap, and h2 rejects out-of-range values (issue #20). Clamp the
+// frame size only; the message size itself is enforced unclamped by the
+// per-service codecs.
+const HTTP2_FRAME_SIZE_MIN: u32 = 1 << 14;
+const HTTP2_FRAME_SIZE_MAX: u32 = (1 << 24) - 1;
+
+fn http2_frame_size(max_message_size: usize) -> u32 {
+    u32::try_from(max_message_size)
+        .unwrap_or(HTTP2_FRAME_SIZE_MAX)
+        .clamp(HTTP2_FRAME_SIZE_MIN, HTTP2_FRAME_SIZE_MAX)
+}
+
 /// Shared transport configuration for both the internal and external gRPC servers.
 fn configure_server(
     max_message_size: usize,
@@ -31,7 +46,7 @@ fn configure_server(
 ) -> TonicServer {
     TonicServer::builder()
         .tcp_keepalive(Some(tcp_keepalive_time))
-        .max_frame_size(Some(max_message_size as u32))
+        .max_frame_size(Some(http2_frame_size(max_message_size)))
         .http2_keepalive_interval(Some(keep_alive_time))
         .http2_keepalive_timeout(Some(keep_alive_timeout))
         .http2_adaptive_window(Some(true))
@@ -167,7 +182,94 @@ mod tests {
     use tonic::transport::server::TcpIncoming;
     use tonic::transport::Endpoint;
 
-    use super::{configure_server, FILE_DESCRIPTOR_SET};
+    use super::{
+        configure_server, http2_frame_size, FILE_DESCRIPTOR_SET, HTTP2_FRAME_SIZE_MAX,
+        HTTP2_FRAME_SIZE_MIN,
+    };
+
+    // The 16 MiB grpc_max_recv_message_size default is exactly one past the
+    // HTTP/2 frame-size cap (issue #20).
+    const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+    #[test]
+    fn frame_size_is_clamped_to_the_http2_range() {
+        assert_eq!(
+            http2_frame_size(DEFAULT_MAX_MESSAGE_SIZE),
+            HTTP2_FRAME_SIZE_MAX
+        );
+        assert_eq!(http2_frame_size(usize::MAX), HTTP2_FRAME_SIZE_MAX);
+        assert_eq!(http2_frame_size(0), HTTP2_FRAME_SIZE_MIN);
+        assert_eq!(http2_frame_size(1 << 20), 1 << 20);
+    }
+
+    /// Reads the server's initial SETTINGS frame off a raw HTTP/2 connection and
+    /// returns the advertised SETTINGS_MAX_FRAME_SIZE (0x5), if present.
+    async fn advertised_max_frame_size(addr: std::net::SocketAddr) -> Option<u32> {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut stream = tokio::net::TcpStream::connect(addr)
+            .await
+            .expect("tcp connect");
+        stream
+            .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+            .await
+            .expect("client preface");
+        stream
+            .write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0])
+            .await
+            .expect("empty client SETTINGS");
+
+        let mut header = [0u8; 9];
+        stream.read_exact(&mut header).await.expect("frame header");
+        let len = u32::from_be_bytes([0, header[0], header[1], header[2]]) as usize;
+        assert_eq!(header[3], 0x4, "first server frame must be SETTINGS");
+        let mut payload = vec![0u8; len];
+        stream.read_exact(&mut payload).await.expect("payload");
+        payload.chunks_exact(6).find_map(|s| {
+            (u16::from_be_bytes([s[0], s[1]]) == 0x5)
+                .then(|| u32::from_be_bytes([s[2], s[3], s[4], s[5]]))
+        })
+    }
+
+    /// The 16 MiB message-size default is one past the HTTP/2 frame-size cap
+    /// (RFC 9113 §6.5.2). Passed through unclamped, h2 asserts on the invalid
+    /// SETTINGS value (`DEFAULT_MAX_FRAME_SIZE <= val && val <= MAX_MAX_FRAME_SIZE`,
+    /// h2 frame/settings.rs) — panicking the serving task and resetting every
+    /// inbound connection (issue #20). The clamp must both keep the server
+    /// alive and make it advertise the capped value.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn default_message_size_advertises_clamped_frame_size() {
+        let incoming =
+            TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).expect("bind ephemeral port");
+        let addr = incoming.local_addr().expect("resolve bound address");
+
+        let reflection_service = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+            .build_v1()
+            .expect("build reflection service");
+
+        let router = configure_server(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            Duration::from_secs(10),
+            Duration::from_secs(5),
+            Duration::from_secs(10),
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            Duration::from_secs(5),
+        )
+        .add_service(reflection_service);
+
+        let server = tokio::spawn(async move { router.serve_with_incoming(incoming).await });
+
+        let advertised = advertised_max_frame_size(addr).await;
+        server.abort();
+
+        assert_eq!(
+            advertised,
+            Some(HTTP2_FRAME_SIZE_MAX),
+            "server must advertise the clamped frame size, not fall back to the 16 KiB default"
+        );
+    }
 
     const RESUMED_AFTER_COMPLETION: &str = "resumed after completion";
     const MAX_CONNECTION_AGE: Duration = Duration::from_millis(300);

--- a/node/src/rust/api/grpc_package.rs
+++ b/node/src/rust/api/grpc_package.rs
@@ -21,10 +21,11 @@ pub const FILE_DESCRIPTOR_SET: &[u8] =
 
 // RFC 9113 §6.5.2: SETTINGS_MAX_FRAME_SIZE must lie in [2^14, 2^24 - 1]. The
 // configured gRPC message size doubles as the frame-size hint here, but the two
-// are independent limits — the 16 MiB message-size default (2^24) is one past
-// the frame cap, and h2 rejects out-of-range values (issue #20). Clamp the
-// frame size only; the message size itself is enforced unclamped by the
-// per-service codecs.
+// are independent limits — a binary 16 MiB message size (2^24, the issue #20
+// value) is one past the frame cap, and h2 asserts on out-of-range values,
+// resetting every connection. The shipped default escapes only because
+// defaults.conf's "16M" parses as SI 16,000,000. Clamp the frame size only;
+// the message size itself is enforced unclamped by the per-service codecs.
 const HTTP2_FRAME_SIZE_MIN: u32 = 1 << 14;
 const HTTP2_FRAME_SIZE_MAX: u32 = (1 << 24) - 1;
 
@@ -187,14 +188,15 @@ mod tests {
         HTTP2_FRAME_SIZE_MIN,
     };
 
-    // The 16 MiB grpc_max_recv_message_size default is exactly one past the
-    // HTTP/2 frame-size cap (issue #20).
-    const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+    // Binary 16 MiB — the issue #20 configuration, exactly one past the HTTP/2
+    // frame-size cap. NOT the shipped default: defaults.conf's "16M" parses as
+    // SI 16,000,000, which sits just under the cap.
+    const ISSUE_20_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 
     #[test]
     fn frame_size_is_clamped_to_the_http2_range() {
         assert_eq!(
-            http2_frame_size(DEFAULT_MAX_MESSAGE_SIZE),
+            http2_frame_size(ISSUE_20_MESSAGE_SIZE),
             HTTP2_FRAME_SIZE_MAX
         );
         assert_eq!(http2_frame_size(usize::MAX), HTTP2_FRAME_SIZE_MAX);
@@ -231,14 +233,15 @@ mod tests {
         })
     }
 
-    /// The 16 MiB message-size default is one past the HTTP/2 frame-size cap
-    /// (RFC 9113 §6.5.2). Passed through unclamped, h2 asserts on the invalid
+    /// A binary 16 MiB message size — the issue #20 configuration — is one past
+    /// the HTTP/2 frame-size cap (RFC 9113 §6.5.2). Passed through unclamped,
+    /// h2 asserts on the invalid
     /// SETTINGS value (`DEFAULT_MAX_FRAME_SIZE <= val && val <= MAX_MAX_FRAME_SIZE`,
     /// h2 frame/settings.rs) — panicking the serving task and resetting every
     /// inbound connection (issue #20). The clamp must both keep the server
     /// alive and make it advertise the capped value.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn default_message_size_advertises_clamped_frame_size() {
+    async fn issue_20_message_size_advertises_clamped_frame_size() {
         let incoming =
             TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).expect("bind ephemeral port");
         let addr = incoming.local_addr().expect("resolve bound address");
@@ -249,7 +252,7 @@ mod tests {
             .expect("build reflection service");
 
         let router = configure_server(
-            DEFAULT_MAX_MESSAGE_SIZE,
+            ISSUE_20_MESSAGE_SIZE,
             Duration::from_secs(10),
             Duration::from_secs(5),
             Duration::from_secs(10),


### PR DESCRIPTION
## Summary

Fixes #20 — the configured `grpc-max-recv-message-size` was passed straight into tonic's `max_frame_size`, but HTTP/2's `SETTINGS_MAX_FRAME_SIZE` must lie in [2¹⁴, 2²⁴−1] (RFC 9113 §6.5.2). h2 asserts on out-of-range values, panicking the serving task and **resetting every inbound gRPC connection**.

- `http2_frame_size()` clamps the frame-size hint to the legal range (and handles >u32 sizes). The message size itself stays unclamped — frame size and message size are independent limits; the per-service codecs enforce the latter.

## Why production hasn't been burning

An accident of unit parsing: `defaults.conf`'s `16M` goes through `byte_unit` as **SI** 16,000,000 bytes — 777,215 under the cap. Any override in binary units (`16MiB`), a raw integer ≥ 2²⁴, or simply a larger size kills the entire gRPC API, one panic + connection reset per connection attempt. (Issue #20's reporter hit exactly this with the binary 16 MiB value; PR #195's rewrite of this file didn't touch the frame-size line.)

## Test evidence (verified red → green)

The obvious test (connect and succeed) **passes even on broken code** — tonic's lazy client masks the server-side panic. The regression test instead speaks raw HTTP/2: client preface + empty SETTINGS, then parses the server's own SETTINGS frame and asserts it advertises the clamped 16,777,215.

- **Red** (clamp removed): `h2-0.4.15/src/frame/settings.rs:91: assertion failed: DEFAULT_MAX_FRAME_SIZE <= val && val <= MAX_MAX_FRAME_SIZE` on the serving task, connection reset — the exact issue-#20 signature.
- **Green** (with clamp): server stays up and advertises `16777215`.
- Boundary unit tests: 16 MiB → cap, `usize::MAX` → cap, `0` → floor (2¹⁴), 1 MiB → passthrough.
- Full `node` lib suite + `fmt`/`clippy`/`deny` green.

## Note on deny.toml

Carries the same RUSTSEC-2026-0247 (`bitmaps` via `imbl`) ignore as #228: the advisory published 2026-08-10 and fails the pre-commit gate repo-wide; this branch is based on `dev`, which predates that entry. Identical text at the identical location, so #228 and this PR merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789007309&installation_model_id=426883&pr_number=229&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F229&signature=a647aaef83ded28968bb61aa0c36743395b0d4bad37d042f40796e596557698f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->