### PR TITLE
chore(ci): bump system-integration pin to per-core monitor merge

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=a0c6fba626e4db8310180d0a90a213314424dd92
+SYSTEM_INTEGRATION_REF=755301662e4f86ffb55f51077b88f32212a1f3ed

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: a0c6fba626e4db8310180d0a90a213314424dd92
+  SYSTEM_INTEGRATION_REF: 755301662e4f86ffb55f51077b88f32212a1f3ed
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -153,7 +153,14 @@ env:
   # for) plus the RUNNER_MEM_GB_OVERRIDE launch knob. Verified by content
   # at the SHA: state.env AMD64_MEM_GB=48, override present in
   # launch-runner.sh.
-  SYSTEM_INTEGRATION_REF: a0c6fba626e4db8310180d0a90a213314424dd92
+  #
+  # 2026-08-11: bumped to the SI PR #103 merge — the harness monitor's
+  # per-core CPU sampling (resource-percore-timeseries.csv), which the
+  # driver's per-core extractor folds into the dashboard CPU grid. Verified
+  # by ancestry (a0c6fba6 is an ancestor, so the 48GB default and
+  # RUNNER_LABELS override carry forward) and by content at the SHA
+  # (state.env AMD64_MEM_GB=48; resource_monitor.py emits the per-core CSV).
+  SYSTEM_INTEGRATION_REF: 755301662e4f86ffb55f51077b88f32212a1f3ed
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"


### PR DESCRIPTION
75530166 is SI PR #103 (per-core CPU sampling per node container, resource-percore-timeseries.csv) merged to system-integration dev. With this pin the soak harness emits the per-core telemetry that f1r3node PR #233's driver folds into the dashboard's node x core CPU grid. Both pin sites bumped together per the drift check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081084&installation_model_id=426883&pr_number=234&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F234&signature=62a2197b79ad25768c2107471a0c236cffdf42aced03e141631e8aadc1f2eca1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->