### PR TITLE
hotfix(soak): 64GB soak VM and CRLF-tolerant CPU extractors

### DIFF
--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -84,11 +84,18 @@ env:
   # hold the envelope + any safe floor — the orchestrator host guardian
   # killed at free 6524MB). Sizing invariant, learned twice (PR #217 review,
   # then 31390673884): ceiling + ~7GB host overhead + floor <= MemTotal,
-  # else the floor fires before this attributable ceiling can. Here:
-  # 28672 + ~7168 + 8192 = ~44GB <= 48GB. 28672 is ~1.5x the measured
-  # envelope — silent on legitimate load, catches a real leak ~9GB before
-  # the floor or the kernel OOM killer get involved.
-  SOAK_RSS_CEILING_MB: "28672"
+  # else the floor fires before this attributable ceiling can.
+  #
+  # 2026-08-11: 28672 -> 45056 with the 64GB soak VM
+  # (RUNNER_MEM_GB_OVERRIDE below). The #197 wedge fix (#228) unmasked the
+  # workload's true footprint: smoke run 31547587950 breached at 36008MB
+  # instant RSS while fully healthy (1200 deploys/300s, 0 errors, tip-LFB
+  # lag 0), matching the 31-37GB envelope measured in the local A/B that
+  # exonerated the merge. The old ceiling was 1.5x the wedge-suppressed
+  # envelope, not the real one. 45056 is ~1.25x the observed 36GB peak —
+  # silent on legitimate load, catches a real leak ~9GB before the floor —
+  # and the invariant holds on 64GB: 45056 + ~7168 + 8192 = ~59GB <= 64GB.
+  SOAK_RSS_CEILING_MB: "45056"
   # 2026-08-10 (PR #217 review): lowered 12288 -> 8192 alongside the ceiling
   # raise — on the then-32GB host, 20480 + 12288 = 32768 meant available RAM
   # crossed the floor before total RSS could reach the ceiling, so the
@@ -718,6 +725,16 @@ jobs:
           # particular is the one whose absence actually breaks routing, and it
           # must stay in step with the soak job's runs-on below.
           RUNNER_LABELS: self-hosted,linux,x64,f1r3fly-rust-soak,oracle-cloud
+          # 64GB for the soak VM only (fleet default stays AMD64_MEM_GB=48).
+          # The #197 wedge fix unmasked the workload's true footprint: smoke
+          # run 31547587950 (2026-08-11) breached at 36008MB instant RSS
+          # while fully healthy — 1200 deploys/300s, 0 errors, tip-LFB lag 0.
+          # 48GB cannot hold that envelope plus any invariant-respecting
+          # guard (max ceiling there is ~33GB, below the observed peak), so
+          # the launch knob SI PR #99 added is used here. Keep in step with
+          # SOAK_RSS_CEILING_MB above — the sizing invariant is
+          # ceiling + ~7GB host overhead + floor <= this VM's MemTotal.
+          RUNNER_MEM_GB_OVERRIDE: "64"
         shell: bash -e {0}
         run: system-integration/ci/oci-runners/launch-runner.sh amd64
 

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -29,7 +29,11 @@ CSV
 # __system__ row is host state and must not become a grid node, and the
 # non-numeric core id is a malformed row that must be rejected — the grid
 # assertion below proves both filters.
-cat >"$FAKE_ARCHIVE_DIR/session/resource-percore-timeseries.csv" <<'CSV'
+# CRLF endings on purpose: the harness writes this CSV with Python
+# csv.writer, whose default line terminator is \r\n — cpu_percent is the
+# LAST column, so without CR-stripping every row fails the numeric check
+# (smoke run 31547587950 published an all-fallback grid exactly this way).
+cat <<'CSV' | sed 's/$/\r/' >"$FAKE_ARCHIVE_DIR/session/resource-percore-timeseries.csv"
 elapsed_s,node,core,cpu_percent
 1.0,rnode.test.validator1,0,7.5
 1.0,rnode.test.validator1,1,42.0

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -254,7 +254,8 @@ iteration_cpu_peak_per_node_percent() {
 		printf '{}'
 		return 0
 	}
-	LC_ALL=C awk -F, 'NR > 1 && $2 != "__system__" && $4 ~ /^[0-9]+([.][0-9]+)?$/ {
+	LC_ALL=C awk -F, 'NR > 1 { sub(/\r$/, "") }
+	         NR > 1 && $2 != "__system__" && $4 ~ /^[0-9]+([.][0-9]+)?$/ {
 	           n = $2; sub(/^rnode\.[^.]*\./, "", n)
 	           if (!(n in peak) || $4 + 0 > peak[n]) peak[n] = $4 + 0 }
 	         END { printf "{"; sep = ""
@@ -284,7 +285,16 @@ iteration_cpu_peak_per_node_core_percent() {
 	# distort the grid, not just add noise). Core ids are bare CPU indices
 	# per the telemetry contract — anything non-numeric is a malformed row,
 	# rejected rather than sanitized into a phantom core.
-	LC_ALL=C awk -F, 'NR > 1 && $2 != "__system__" && $3 ~ /^[0-9]+$/ &&
+	#
+	# The leading sub() strips a CR before the fields are tested: the harness
+	# writes this CSV with Python csv.writer, whose default line terminator
+	# is \r\n, so cpu_percent — the LAST column — arrives as "1.5\r" and
+	# would fail the numeric check on every row (smoke run 31547587950
+	# published an all-fallback grid exactly this way). The per-node
+	# extractor above gets the same guard for symmetry, though its CSV
+	# carries a 5th column that happened to absorb the CR.
+	LC_ALL=C awk -F, 'NR > 1 { sub(/\r$/, "") }
+	         NR > 1 && $2 != "__system__" && $3 ~ /^[0-9]+$/ &&
 	           $4 ~ /^[0-9]+([.][0-9]+)?$/ {
 	           n = $2; sub(/^rnode\.[^.]*\./, "", n)
 	           cell = n SUBSEP $3


### PR DESCRIPTION
Smoke run 31547587950 (first soak of the merged #228/#232/#233 stack) surfaced both:

- The #197 wedge fix unmasked the workload's true footprint: 36008MB instant RSS while fully healthy (1200 deploys/300s, 0 errors, tip-LFB lag 0), matching the 31-37GB local A/B envelope. 48GB cannot hold that plus any invariant-respecting guard, so the soak launch now sets RUNNER_MEM_GB_OVERRIDE=64 (SI PR #99's knob) and the ceiling moves 28672 -> 45056 (~1.25x observed; 45056 + ~7168 + 8192 <= 64GB).

- The per-core grid published all-fallback rows because the harness writes resource-percore-timeseries.csv with Python csv.writer's \r\n line endings: cpu_percent is the LAST column, so every row's value carried a trailing CR and failed the numeric check (0/5689 rows). Both JSON extractors now strip the CR before field tests, and the driver test fixture uses CRLF endings to pin the regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789089872&installation_model_id=426883&pr_number=236&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F236&signature=d01c28f1fdc90e15b51ac9e42a22bf681e8afc14f7b78d7622d912778c5a5af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->