### PR TITLE
fix(ci): recover canceled soak checkpoints

### DIFF
--- a/.github/actions/soak-segment/action.yml
+++ b/.github/actions/soak-segment/action.yml
@@ -217,6 +217,21 @@ runs:
           echo "ready=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
+        if ! jq -e \
+          --arg run_id "$RUN_ID" \
+          --argjson run_attempt "$RUN_ATTEMPT" \
+          --arg kind "$SOAK_KIND" \
+          '.run.status == "in_progress"
+           and (.run.run_id | tostring) == $run_id
+           and .run.run_attempt == $run_attempt
+           and .run.kind == $kind
+           and (.run.started_at | type) == "number"
+           and (.run.elapsed_seconds | type) == "number"' \
+          "$OUT_DIR/weekly-summary.json" >/dev/null; then
+          echo "::warning::checkpoint metadata is incomplete for ${LABEL}; skipping upload and publish"
+          echo "ready=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         echo "ready=true" >> "$GITHUB_OUTPUT"
 
     # Gated on the aggregate having actually produced something, which keeps

--- a/scripts/bench/aggregate-perf-report.sh
+++ b/scripts/bench/aggregate-perf-report.sh
@@ -92,6 +92,61 @@ command -v jq >/dev/null || {
 }
 mkdir -p "$OUT_DIR"
 
+valid_checkpoint_summary() {
+	jq -e '
+    type == "object"
+    and (.target_ref | type) == "string"
+    and (.target_sha | type) == "string"
+    and (.started_at | type) == "number"
+    and (.elapsed_seconds | type) == "number"
+    and .started_at > 0
+    and .elapsed_seconds >= 0
+  ' "$SOAK_DIR/summary.json" >/dev/null 2>&1
+}
+
+recover_checkpoint_summary() {
+	local state="$SOAK_DIR/.soak-checkpoint-state.json"
+	local finished_at
+	jq -e '
+    type == "object"
+    and (.target_ref | type) == "string"
+    and (.target_sha | type) == "string"
+    and (.trigger_source | type) == "string"
+    and (.slot_delay_seconds | type) == "number"
+    and (.version | type) == "string"
+    and (.started_at | type) == "number" and .started_at > 0
+    and (.requested_seconds | type) == "number" and .requested_seconds > 0
+    and (.iterations | type) == "number" and .iterations >= 0
+    and (.failures | type) == "number" and .failures >= 0
+    and (.bench_segments | type) == "number" and .bench_segments >= 0
+    and (.bench_failures | type) == "number" and .bench_failures >= 0
+  ' "$state" >/dev/null 2>&1 || return 1
+	finished_at="$(date +%s)"
+	SOAK_OUTPUT_DIR="$SOAK_DIR" \
+		SOAK_METRICS_REGISTRY="$SCRIPT_DIR/soak-metrics.json" \
+		SOAK_TARGET_REF="$(jq -r '.target_ref' "$state")" \
+		SOAK_TARGET_SHA="$(jq -r '.target_sha' "$state")" \
+		SOAK_TRIGGER_SOURCE="$(jq -r '.trigger_source' "$state")" \
+		SOAK_SLOT_DELAY_SECONDS="$(jq -r '.slot_delay_seconds' "$state")" \
+		SOAK_VERSION="$(jq -r '.version' "$state")" \
+		SOAK_STARTED_AT="$(jq -r '.started_at' "$state")" \
+		SOAK_FINISHED_AT="$finished_at" \
+		SOAK_DURATION_SECONDS="$(jq -r '.requested_seconds' "$state")" \
+		SOAK_ITERATIONS="$(jq -r '.iterations' "$state")" \
+		SOAK_FAILURES="$(jq -r '.failures' "$state")" \
+		SOAK_BENCH_SEGMENTS="$(jq -r '.bench_segments' "$state")" \
+		SOAK_BENCH_FAILURES="$(jq -r '.bench_failures' "$state")" \
+		"$SCRIPT_DIR/write-soak-summary.sh"
+	valid_checkpoint_summary
+}
+
+if [ "$SOAK_STATUS" = "in_progress" ] && ! valid_checkpoint_summary; then
+	recover_checkpoint_summary || {
+		echo "checkpoint has no valid summary or recoverable persisted state" >&2
+		exit 2
+	}
+fi
+
 SEGMENTS_JSON="$OUT_DIR/.segments.json"
 find "$SOAK_DIR" -mindepth 2 -maxdepth 2 -type f \
 	-path '*/bench-segment-*/metrics.json' -print0 |

--- a/scripts/bench/test-aggregate-perf-report.sh
+++ b/scripts/bench/test-aggregate-perf-report.sh
@@ -50,6 +50,55 @@ SOAK_DIR="$TMP/failed" OUT_DIR="$TMP/checkpoint-report" RUN_ID=1 RUN_ATTEMPT=1 \
 jq -e '.verdict == "in_progress" and .failures == []' \
 	"$TMP/checkpoint-report/verdict.json" >/dev/null
 
+mkdir -p "$TMP/recovered" "$TMP/recovered-report"
+cat >"$TMP/recovered/.soak-checkpoint-state.json" <<'JSON'
+{
+  "target_ref": "dev",
+  "target_sha": "fedcba9876543210",
+  "trigger_source": "manual",
+  "slot_delay_seconds": 0,
+  "version": "0.4.43",
+  "started_at": 1000,
+  "requested_seconds": 1800,
+  "iterations": 1,
+  "failures": 1,
+  "bench_segments": 0,
+  "bench_failures": 0
+}
+JSON
+SOAK_DIR="$TMP/recovered" OUT_DIR="$TMP/recovered-report" RUN_ID=9 RUN_ATTEMPT=2 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '
+  .target_ref == "dev"
+  and .target_sha == "fedcba9876543210"
+  and .started_at == 1000
+  and (.elapsed_seconds | type) == "number"
+  and .elapsed_seconds >= 0
+  and .iterations == 1
+  and .failures == 1
+' "$TMP/recovered/summary.json" >/dev/null
+jq -e '
+  .run.status == "in_progress"
+  and .run.run_id == "9"
+  and .run.run_attempt == 2
+  and .run.kind == "daily"
+  and .run.started_at == 1000
+  and (.run.elapsed_seconds | type) == "number"
+' "$TMP/recovered-report/weekly-summary.json" >/dev/null
+
+mkdir -p "$TMP/unrecoverable" "$TMP/unrecoverable-report"
+printf '%s\n' '{"started_at":null}' >"$TMP/unrecoverable/.soak-checkpoint-state.json"
+if SOAK_DIR="$TMP/unrecoverable" OUT_DIR="$TMP/unrecoverable-report" \
+	RUN_ID=10 RUN_ATTEMPT=1 SOAK_KIND=daily DURATION_SECONDS=1800 \
+	WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh" >"$TMP/unrecoverable.log" 2>&1; then
+	echo "checkpoint aggregation must reject absent summary and state metadata" >&2
+	exit 1
+fi
+grep -q 'no valid summary or recoverable persisted state' "$TMP/unrecoverable.log"
+
 mkdir -p "$TMP/passing" "$TMP/passing-report"
 jq '.failures = 0 | .failure_rate = 0 | .providers.docker.failures = 0
 	| .shard_up_seconds = 90' \

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -100,6 +100,14 @@ for _ in $(seq 1 20); do
 	sleep 0.25
 done
 test -e "$TMP/output/iteration-00001-docker/.started"
+jq -e '
+  .target_ref == "unknown"
+  and .target_sha == "unknown"
+  and (.started_at | type) == "number"
+  and .requested_seconds == 120
+  and .iterations == 1
+  and .failures == 0
+' "$TMP/output/.soak-checkpoint-state.json" >/dev/null
 for _ in $(seq 1 20); do
 	[ -s "$TMP/output/iteration-00001-docker/node-metrics-timeseries.csv" ] &&
 		grep -q 'test.validator1.*12.*1048576.*2.*2.*7' \

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -81,6 +81,7 @@ METRICS
 SH
 chmod +x "$TMP/bin/poetry" "$TMP/bin/docker" "$TMP/bin/curl"
 
+test ! -e "$TMP/output"
 PATH="$TMP/bin:$PATH" \
 	FAKE_POETRY_PID_FILE="$TMP/fake-poetry.pid" \
 	FAKE_DATA_DIR="$TMP/system-integration/integration-tests/data" \

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -199,6 +199,7 @@ persist_soak_state() {
 	local state_tmp="${STATE_FILE}.tmp"
 	local checkpoint_state="$OUTPUT_DIR/.soak-checkpoint-state.json"
 	local checkpoint_tmp="${checkpoint_state}.tmp"
+	mkdir -p "$OUTPUT_DIR"
 	{
 		printf 'STARTED_AT=%s\n' "$STARTED_AT"
 		printf 'ITERATIONS=%s\n' "$ITERATIONS"

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -195,6 +195,41 @@ if [ -n "$NODE_REPO_DIR" ] && [ -f "$NODE_REPO_DIR/node/Cargo.toml" ]; then
 	[ -n "$parsed_version" ] && VERSION="$parsed_version"
 fi
 
+persist_soak_state() {
+	local state_tmp="${STATE_FILE}.tmp"
+	local checkpoint_state="$OUTPUT_DIR/.soak-checkpoint-state.json"
+	local checkpoint_tmp="${checkpoint_state}.tmp"
+	{
+		printf 'STARTED_AT=%s\n' "$STARTED_AT"
+		printf 'ITERATIONS=%s\n' "$ITERATIONS"
+		printf 'FAILURES=%s\n' "$FAILURES"
+		printf 'BENCH_SEGMENTS=%s\n' "$BENCH_SEGMENTS"
+		printf 'BENCH_FAILURES=%s\n' "$BENCH_FAILURES"
+		printf 'SEGMENT=%s\n' "$SEGMENT"
+	} >"$state_tmp" && mv "$state_tmp" "$STATE_FILE"
+	jq -n \
+		--arg target_ref "$TARGET_REF" \
+		--arg target_sha "$TARGET_SHA" \
+		--arg trigger_source "$TRIGGER_SOURCE" \
+		--argjson slot_delay "$SLOT_DELAY_SECONDS" \
+		--arg version "$VERSION" \
+		--argjson started_at "$STARTED_AT" \
+		--argjson requested_seconds "$DURATION_SECONDS" \
+		--argjson iterations "$ITERATIONS" \
+		--argjson failures "$FAILURES" \
+		--argjson bench_segments "$BENCH_SEGMENTS" \
+		--argjson bench_failures "$BENCH_FAILURES" \
+		'{target_ref: $target_ref, target_sha: $target_sha,
+      trigger_source: $trigger_source, slot_delay_seconds: $slot_delay,
+      version: $version, started_at: $started_at,
+      requested_seconds: $requested_seconds, iterations: $iterations,
+      failures: $failures, bench_segments: $bench_segments,
+      bench_failures: $bench_failures}' >"$checkpoint_tmp" &&
+		mv "$checkpoint_tmp" "$checkpoint_state"
+}
+
+persist_soak_state
+
 # Peak total node RSS for this iteration, from the newest harness
 # resource-timeseries.csv written after the iteration's start marker
 # (columns: elapsed_s,node,memory_mb,cpu_percent,memory_limit_mb; the
@@ -580,6 +615,7 @@ mkdir -p "$OUTPUT_DIR"
 # for and skew the run's active-benchmark averages.
 if [ "$RUN_BENCHMARKS" = "true" ] && [ "$SEGMENT" -eq 1 ]; then
 	run_bench_segment
+	persist_soak_state
 fi
 
 # Operator signal, polled between iterations.
@@ -721,6 +757,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 	fi
 	PROVIDER="${PROVIDERS[$((ITERATIONS % ${#PROVIDERS[@]}))]}"
 	ITERATIONS="$((ITERATIONS + 1))"
+	persist_soak_state
 	ITERATION_DIR="$OUTPUT_DIR/iteration-$(printf '%05d' "$ITERATIONS")-$PROVIDER"
 	mkdir -p "$ITERATION_DIR"
 	REMAINING="$((DEADLINE - $(date +%s)))"
@@ -794,6 +831,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 	fi
 	if [ "$STATUS" -ne 0 ]; then
 		FAILURES="$((FAILURES + 1))"
+		persist_soak_state
 		printf '%s\n' "$STATUS" >"$ITERATION_DIR/exit-code.txt"
 		for evidence_root in "${HARNESS_TELEMETRY_DIRS[@]}"; do
 			[ -d "$evidence_root" ] || continue
@@ -862,6 +900,7 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 
 	if [ "$RUN_BENCHMARKS" = "true" ] && [ "$((ITERATIONS % BENCH_EVERY))" -eq 0 ]; then
 		run_bench_segment
+		persist_soak_state
 	fi
 
 done
@@ -882,14 +921,7 @@ FINISHED_AT="$(date +%s)"
 
 # Written before the rollup so a later segment resumes from accurate counters
 # even if the rollup below fails.
-{
-	printf 'STARTED_AT=%s\n' "$STARTED_AT"
-	printf 'ITERATIONS=%s\n' "$ITERATIONS"
-	printf 'FAILURES=%s\n' "$FAILURES"
-	printf 'BENCH_SEGMENTS=%s\n' "$BENCH_SEGMENTS"
-	printf 'BENCH_FAILURES=%s\n' "$BENCH_FAILURES"
-	printf 'SEGMENT=%s\n' "$SEGMENT"
-} >"$STATE_FILE"
+persist_soak_state
 
 {
 	printf 'started_at=%s\n' "$STARTED_AT"


### PR DESCRIPTION
- persist soak state before long-running iterations
- reconstruct checkpoint summaries from persisted metadata
- skip upload and publish when metadata remains incomplete

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789118868&installation_model_id=426883&pr_number=241&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F241&signature=6cb9f0bdc1abca4bdbc8f933f241d1bb1f760ba66c78e03f40a7d00a071bc600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->