### PR TITLE
fix(ci): gate unreleased system-integration regressions

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=755301662e4f86ffb55f51077b88f32212a1f3ed
+SYSTEM_INTEGRATION_REF=483d7d4f1aa51d87c3eb3064531b630a36257639

--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -14,4 +14,4 @@
 # .github/workflows/_integration-pipeline.yml — a reusable workflow cannot
 # source this file at env-resolution time, so the pin is duplicated there.
 # Bump both in the same commit.
-SYSTEM_INTEGRATION_REF=483d7d4f1aa51d87c3eb3064531b630a36257639
+SYSTEM_INTEGRATION_REF=fe91755ed16774a5f56f33da9712f7df1f52ca9d

--- a/.github/scripts/read-system-integration-node-capabilities.sh
+++ b/.github/scripts/read-system-integration-node-capabilities.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+capabilities_file=${1:-.github/system-integration-node-capabilities.txt}
+seen='|'
+
+while IFS= read -r capability || [ -n "$capability" ]; do
+	capability=${capability%$'\r'}
+	case "$capability" in
+	'' | \#*) continue ;;
+	esac
+	if [[ ! "$capability" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+		printf 'invalid system-integration node capability: %s\n' "$capability" >&2
+		exit 1
+	fi
+	case "$seen" in
+	*"|$capability|"*)
+		printf 'duplicate system-integration node capability: %s\n' "$capability" >&2
+		exit 1
+		;;
+	esac
+	seen="${seen}${capability}|"
+	printf '%s\n' "$capability"
+done <"$capabilities_file"

--- a/.github/scripts/test-system-integration-node-capabilities.sh
+++ b/.github/scripts/test-system-integration-node-capabilities.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+READER="$ROOT/.github/scripts/read-system-integration-node-capabilities.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+expect_failure() {
+	if "$READER" "$1" >"$TMP/stdout" 2>"$TMP/stderr"; then
+		printf 'expected capability validation to fail for %s\n' "$1" >&2
+		exit 1
+	fi
+}
+
+: >"$TMP/empty"
+test -z "$("$READER" "$TMP/empty")"
+
+cat >"$TMP/valid" <<'EOF'
+# released node behavior
+expired-deploy-admission
+observer-missing-block-retry
+EOF
+printf '%s\n' expired-deploy-admission observer-missing-block-retry >"$TMP/expected"
+"$READER" "$TMP/valid" >"$TMP/actual"
+cmp "$TMP/expected" "$TMP/actual"
+
+printf '%s\n' 'Invalid-Capability' >"$TMP/invalid"
+expect_failure "$TMP/invalid"
+
+printf '%s\n' duplicate-capability duplicate-capability >"$TMP/duplicate"
+expect_failure "$TMP/duplicate"
+
+expect_failure "$TMP/missing"
+
+for workflow in \
+	"$ROOT/.github/workflows/_integration-pipeline.yml" \
+	"$ROOT/.github/workflows/reusable-oci-validation.yml"; do
+	grep -Fq 'read-system-integration-node-capabilities.sh' "$workflow"
+	grep -Fq '"${NODE_CAPABILITY_ARGS[@]}"' "$workflow"
+done
+
+"$READER" "$ROOT/.github/system-integration-node-capabilities.txt" >/dev/null
+
+expected_ref=$(grep '^SYSTEM_INTEGRATION_REF=' "$ROOT/.github/oci-validation.env" | cut -d= -f2-)
+for workflow in \
+	"$ROOT/.github/workflows/_integration-pipeline.yml" \
+	"$ROOT/.github/workflows/merge-recovery-soak.yml"; do
+	actual_ref=$(grep -E '^[[:space:]]*SYSTEM_INTEGRATION_REF:' "$workflow" | head -1 | sed -E 's/^[^:]*:[[:space:]]*//; s/[[:space:]]*(#.*)?$//; s/"//g')
+	test "$actual_ref" = "$expected_ref"
+done
+
+printf 'system-integration node capability contract checks passed\n'

--- a/.github/scripts/test-system-integration-node-capabilities.sh
+++ b/.github/scripts/test-system-integration-node-capabilities.sh
@@ -36,8 +36,13 @@ expect_failure "$TMP/missing"
 for workflow in \
 	"$ROOT/.github/workflows/_integration-pipeline.yml" \
 	"$ROOT/.github/workflows/reusable-oci-validation.yml"; do
-	grep -Fq 'read-system-integration-node-capabilities.sh' "$workflow"
+	grep -Fq 'NODE_CAPABILITIES=$(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh"' "$workflow"
+	grep -Fq 'done <<< "$NODE_CAPABILITIES"' "$workflow"
 	grep -Fq '"${NODE_CAPABILITY_ARGS[@]}"' "$workflow"
+	if grep -Fq 'done < <(bash' "$workflow"; then
+		printf 'capability reader failure is masked by process substitution in %s\n' "$workflow" >&2
+		exit 1
+	fi
 done
 
 "$READER" "$ROOT/.github/system-integration-node-capabilities.txt" >/dev/null

--- a/.github/system-integration-node-capabilities.txt
+++ b/.github/system-integration-node-capabilities.txt
@@ -1,0 +1,3 @@
+concurrent-bridge-lock-accounting
+finality-stall-recovery
+slow-peer-notification-quorum

--- a/.github/system-integration-node-capabilities.txt
+++ b/.github/system-integration-node-capabilities.txt
@@ -2,6 +2,5 @@
 # capability-gated tests at SYSTEM_INTEGRATION_REF. Add a kebab-case identifier
 # only when its behavior is present on the target branch; the reader rejects
 # malformed and duplicate entries before pytest starts.
-concurrent-bridge-lock-accounting
 finality-stall-recovery
 slow-peer-notification-quorum

--- a/.github/system-integration-node-capabilities.txt
+++ b/.github/system-integration-node-capabilities.txt
@@ -1,3 +1,7 @@
+# Node behaviors implemented by the current f1r3node baseline and required by
+# capability-gated tests at SYSTEM_INTEGRATION_REF. Add a kebab-case identifier
+# only when its behavior is present on the target branch; the reader rejects
+# malformed and duplicate entries before pytest starts.
 concurrent-bridge-lock-accounting
 finality-stall-recovery
 slow-peer-notification-quorum

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: 755301662e4f86ffb55f51077b88f32212a1f3ed
+  SYSTEM_INTEGRATION_REF: 483d7d4f1aa51d87c3eb3064531b630a36257639
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -512,6 +512,10 @@ jobs:
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SCALE_FLAG="--timeout-scale=1.5"
           fi
+          NODE_CAPABILITY_ARGS=()
+          while IFS= read -r capability; do
+            [ -z "$capability" ] || NODE_CAPABILITY_ARGS+=("--node-capability=$capability")
+          done < <(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
           poetry run pytest \
             integration-tests/test/tests/shared/ \
             integration-tests/test/tests/custom/ \
@@ -530,6 +534,7 @@ jobs:
             --deselect integration-tests/test/tests/custom/test_user_contract_concurrency.py \
             --deselect integration-tests/test/tests/custom/test_active_validator_cap.py \
             --provider=${{ matrix.provider }} \
+            "${NODE_CAPABILITY_ARGS[@]}" \
             -v --tb=short --instafail --maxfail=10 \
             -n 16 --dist=loadgroup --timeout=1200 $SCALE_FLAG
 

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -512,10 +512,11 @@ jobs:
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SCALE_FLAG="--timeout-scale=1.5"
           fi
+          NODE_CAPABILITIES=$(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
           NODE_CAPABILITY_ARGS=()
           while IFS= read -r capability; do
             [ -z "$capability" ] || NODE_CAPABILITY_ARGS+=("--node-capability=$capability")
-          done < <(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
+          done <<< "$NODE_CAPABILITIES"
           poetry run pytest \
             integration-tests/test/tests/shared/ \
             integration-tests/test/tests/custom/ \

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -44,7 +44,7 @@ env:
   # the old..new range in system-integration; never replace with a tag/branch.
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit.
-  SYSTEM_INTEGRATION_REF: 483d7d4f1aa51d87c3eb3064531b630a36257639
+  SYSTEM_INTEGRATION_REF: fe91755ed16774a5f56f33da9712f7df1f52ca9d
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           env_file=.github/oci-validation.env
           oci_yml=.github/workflows/oci-validation.yml
           pipe_yml=.github/workflows/_integration-pipeline.yml
+          soak_yml=.github/workflows/merge-recovery-soak.yml
 
           # value of a `KEY=value` line in a dotenv file
           envval() { grep -E "^$1=" "$2" | head -1 | cut -d= -f2- | sed -E 's/[[:space:]]*$//'; }
@@ -128,6 +129,9 @@ jobs:
           check "SYSTEM_INTEGRATION_REF (oci-validation.env vs _integration-pipeline.yml)" \
             "$(envval SYSTEM_INTEGRATION_REF "$env_file")" \
             "$(yval SYSTEM_INTEGRATION_REF "$pipe_yml")"
+          check "SYSTEM_INTEGRATION_REF (oci-validation.env vs merge-recovery-soak.yml)" \
+            "$(envval SYSTEM_INTEGRATION_REF "$env_file")" \
+            "$(yval SYSTEM_INTEGRATION_REF "$soak_yml")"
 
           for key in OCI_CLI_INSTALLER_URL OCI_CLI_INSTALLER_SHA256 OCI_CLI_INSTALLER_PY_SHA256 OCI_CLI_VERSION; do
             check "$key (oci-validation.yml vs _integration-pipeline.yml)" \
@@ -162,6 +166,10 @@ jobs:
       - name: Verify soak schedule routing
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/test-soak-schedule-routing.sh
+
+      - name: Verify system-integration node capability contract
+        shell: bash -euo pipefail {0}
+        run: bash .github/scripts/test-system-integration-node-capabilities.sh
 
       - name: Verify soak summary aggregation
         shell: bash -euo pipefail {0}

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -167,7 +167,7 @@ env:
   # by ancestry (a0c6fba6 is an ancestor, so the 48GB default and
   # RUNNER_LABELS override carry forward) and by content at the SHA
   # (state.env AMD64_MEM_GB=48; resource_monitor.py emits the per-core CSV).
-  SYSTEM_INTEGRATION_REF: 483d7d4f1aa51d87c3eb3064531b630a36257639
+  SYSTEM_INTEGRATION_REF: fe91755ed16774a5f56f33da9712f7df1f52ca9d
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -104,9 +104,9 @@ env:
   # of normal-operation clearance; both the pytest floor (subprocess
   # iterations) and the orchestrator host guardian (every iteration) use it.
   SOAK_HOST_FREE_FLOOR_MB: "8192"
-  # THIRD pin site. The other two — .github/oci-validation.env and
-  # _integration-pipeline.yml — are held identical by build_base's drift check;
-  # this one is outside that check and rotted unnoticed as a result. It sat at
+  # THIRD pin site. CI's pin-consistency check holds this identical to
+  # .github/oci-validation.env and _integration-pipeline.yml. Before that guard
+  # covered the soak pin, it rotted unnoticed and sat at
   # a50eeb19 while CI advanced to 06f2020c, and a50eeb19 predates
   # system-integration 81284fc, which added integration-tests/certs/validator4.
   # compose.py bind-mounts that path, so with no host file Docker created a

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -167,7 +167,7 @@ env:
   # by ancestry (a0c6fba6 is an ancestor, so the 48GB default and
   # RUNNER_LABELS override carry forward) and by content at the SHA
   # (state.env AMD64_MEM_GB=48; resource_monitor.py emits the per-core CSV).
-  SYSTEM_INTEGRATION_REF: 755301662e4f86ffb55f51077b88f32212a1f3ed
+  SYSTEM_INTEGRATION_REF: 483d7d4f1aa51d87c3eb3064531b630a36257639
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/.github/workflows/reusable-oci-validation.yml
+++ b/.github/workflows/reusable-oci-validation.yml
@@ -182,6 +182,10 @@ jobs:
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SCALE_FLAG="--timeout-scale=1.5"
           fi
+          NODE_CAPABILITY_ARGS=()
+          while IFS= read -r capability; do
+            [ -z "$capability" ] || NODE_CAPABILITY_ARGS+=("--node-capability=$capability")
+          done < <(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
           poetry run pytest \
             integration-tests/test/tests/shared/ \
             integration-tests/test/tests/custom/ \
@@ -197,6 +201,7 @@ jobs:
             --deselect integration-tests/test/tests/shared/test_contract_lifecycle.py \
             --deselect integration-tests/test/tests/custom/test_consensus_safety.py::test_epoch_transition_under_heartbeat \
             --provider=${{ matrix.provider }} \
+            "${NODE_CAPABILITY_ARGS[@]}" \
             -v --tb=short --instafail --maxfail=10 \
             -n auto --dist=loadgroup --timeout=1200 $SCALE_FLAG
 

--- a/.github/workflows/reusable-oci-validation.yml
+++ b/.github/workflows/reusable-oci-validation.yml
@@ -182,10 +182,11 @@ jobs:
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             SCALE_FLAG="--timeout-scale=1.5"
           fi
+          NODE_CAPABILITIES=$(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
           NODE_CAPABILITY_ARGS=()
           while IFS= read -r capability; do
             [ -z "$capability" ] || NODE_CAPABILITY_ARGS+=("--node-capability=$capability")
-          done < <(bash "$GITHUB_WORKSPACE/.github/scripts/read-system-integration-node-capabilities.sh" "$GITHUB_WORKSPACE/.github/system-integration-node-capabilities.txt")
+          done <<< "$NODE_CAPABILITIES"
           poetry run pytest \
             integration-tests/test/tests/shared/ \
             integration-tests/test/tests/custom/ \


### PR DESCRIPTION
## Summary

- introduce a validated manifest of node capabilities implemented by the branch under test
- pass those capabilities to the pinned system-integration pytest suite
- skip forward regression tests until their corresponding node behavior is available
- enforce capability parsing and all three system-integration pin sites in required CI checks

## Why

Advancing the system-integration pin for per-core telemetry also exposed forward-looking regression tests whose node fixes had not yet reached the target branch. That made unrelated PRs fail deterministically. This change makes compatibility explicit: baseline-supported regressions run, unreleased regressions skip, and malformed capability declarations fail closed.

## Synchronized dependency

This PR is synchronized with F1R3FLY-io/system-integration#105:
https://github.com/F1R3FLY-io/system-integration/pull/105

The two PRs must be merged concurrently. This PR pins system-integration commit `fe91755ed16774a5f56f33da9712f7df1f52ca9d`; merging only this PR before that commit remains reachable from the trusted system-integration branch would break the immutable checkout contract, while merging only the system-integration PR without this consumer manifest would leave all capability-gated regressions disabled by default.

## Validation

- repository pre-commit checks
- repository pre-push checks: 15/15 passed
- workflow invariant and capability-contract tests
- system-integration capability unit tests and Ruff
- YAML diagnostics and diff checks
- verified six unreleased regressions skip and three baseline regressions remain enabled

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789130304&installation_model_id=426883&pr_number=242&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F242&signature=24c0ca1415f449400bc5e1b5d24b950248084621a9076def8af2baf1e67afee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->