### PR TITLE
fix(soak): tidy dashboard & restore LFB convergence dashboard metrics

### DIFF
--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Weekend and daily F1R3FLY merge-recovery soak trends, verdicts, and run history.">
 <title>F1R3FLY soak benchmarks</title>
 <style>
   :root { color-scheme: light dark; }
@@ -17,6 +18,7 @@
        darker step that passes all six palette checks (validated: CVD worst
        adjacent ΔE 14.8, contrast ≥ 3:1 on #f1f0ee). */
     --grid: #e4e2dd; --series-1: #2a78d6; --series-2: #008300; --series-3: #d5588e;
+    --link: #005ea8;
     /* Neutral fill for 0% heatmap cells — must match zero_neutral in
        scripts/soak-charts (the SVGs bake it in; this var only paints the
        legend swatch beside them). */
@@ -29,19 +31,19 @@
   @media (prefers-color-scheme: dark) {
     :root:where(:not([data-theme="light"])) body {
       --surface-1: #1a1a19; --surface-2: #242423;
-      --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #8a887f;
-      --grid: #33322f; --series-1: #3987e5; --series-2: #008300; --series-3: #d55181;
-      --heat-zero: #33322f;
-      --good: #33a133; --serious: #f05252; --serious-bg: #3a1f1f;
+      --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #96948b;
+      --grid: #33322f; --series-1: #5799eb; --series-2: #008300; --series-3: #d55181;
+      --link: #72b0ff; --heat-zero: #33322f;
+      --good: #33a133; --serious: #ff6666; --serious-bg: #3a1f1f;
       --tint: 14%;
     }
   }
   :root[data-theme="dark"] body {
     --surface-1: #1a1a19; --surface-2: #242423;
-    --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #8a887f;
-    --grid: #33322f; --series-1: #3987e5; --series-2: #008300; --series-3: #d55181;
-    --heat-zero: #33322f;
-    --good: #33a133; --serious: #f05252; --serious-bg: #3a1f1f;
+    --text-primary: #ffffff; --text-secondary: #c3c2b7; --text-muted: #96948b;
+    --grid: #33322f; --series-1: #5799eb; --series-2: #008300; --series-3: #d55181;
+    --link: #72b0ff; --heat-zero: #33322f;
+    --good: #33a133; --serious: #ff6666; --serious-bg: #3a1f1f;
     --tint: 14%;
   }
   h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
@@ -56,9 +58,12 @@
      top-rounded, sitting on the panel's top border, with the active tab's
      bottom edge cut away so button and panel read as one surface. That seam is
      the visual statement that the panel's data belongs to the selected tab. */
-  .tabbar { display: flex; flex-wrap: wrap; gap: .5rem; align-items: flex-end; margin: 0; }
+  .tabbar {
+    display: grid; grid-template-columns: repeat(2, minmax(0, 12rem));
+    gap: .5rem; align-items: stretch; margin: 0;
+  }
   .tabbar label {
-    display: flex; flex-direction: column; gap: .15rem; min-width: 11rem;
+    display: flex; flex-direction: column; gap: .15rem; min-width: 0;
     position: relative; z-index: 1; margin-bottom: -1px;
     padding: .8rem 1.1rem; cursor: pointer; user-select: none;
     background: var(--surface-2); color: var(--text-secondary);
@@ -144,7 +149,8 @@
      stack single-column via the grid breakpoints. */
   @media (max-width: 640px) {
     body { padding: .75rem; }
-    .tabbar label { flex: 1 1 0; min-width: 0; padding: .6rem .7rem; }
+    .tabbar { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .tabbar label { padding: .6rem .7rem; }
     .tab-hint, .tab-provenance { font-size: .74rem; }
     #tab-weekend:checked ~ #panel-weekend,
     #tab-daily:checked ~ #panel-daily { padding: .85rem; }
@@ -201,14 +207,16 @@
   /* Every chart is a pre-rendered SVG pair from scripts/soak-charts with theme
      colors baked in; show the variant matching the active theme with the same
      three-state logic as the CSS vars above. */
+  .chart-image-link { display: block; border-radius: 4px; }
+  .chart-image-link:focus-visible { outline: 3px solid var(--link); outline-offset: 3px; }
   .chart-svg { display: block; width: 100%; height: auto; }
-  .chart-dark { display: none; }
+  .chart-dark-link { display: none; }
   @media (prefers-color-scheme: dark) {
-    :root:where(:not([data-theme="light"])) .chart-light { display: none; }
-    :root:where(:not([data-theme="light"])) .chart-dark { display: block; }
+    :root:where(:not([data-theme="light"])) .chart-light-link { display: none; }
+    :root:where(:not([data-theme="light"])) .chart-dark-link { display: block; }
   }
-  :root[data-theme="dark"] .chart-light { display: none; }
-  :root[data-theme="dark"] .chart-dark { display: block; }
+  :root[data-theme="dark"] .chart-light-link { display: none; }
+  :root[data-theme="dark"] .chart-dark-link { display: block; }
   /* The all-zero counter panel: the metric holds at its target, so it earns a
      number, not an empty chart. */
   .kpi-zero { margin: 1rem 0 0; font-size: 2.4rem; font-weight: 650;
@@ -216,18 +224,22 @@
   .kpi-zero .unit { font-size: .85rem; font-weight: 400; }
   .latest { color: var(--text-secondary); font-weight: 400; font-size: .85em;
             font-variant-numeric: tabular-nums; }
+  .chart-permalink { color: inherit; text-decoration: none; }
+  .chart-permalink:hover, .chart-permalink:focus-visible { text-decoration: underline; }
+  .chart-empty { color: var(--text-muted); min-height: 8rem; display: grid; place-items: center; }
   .table-wrap { overflow-x: auto; }
   table { border-collapse: collapse; width: 100%; margin-top: 1.5rem; }
   th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid var(--grid); white-space: nowrap; }
   th { color: var(--text-secondary); font-weight: 600; }
   td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
-  a { color: var(--series-1); }
+  a { color: var(--link); }
   .empty { color: var(--text-muted); padding: 2rem 0; }
 </style>
 </head>
 <body>
-<input class="tabs" type="radio" name="soak-tab" id="tab-weekend" checked>
-<input class="tabs" type="radio" name="soak-tab" id="tab-daily">
+<main>
+<input class="tabs" type="radio" name="soak-tab" id="tab-weekend" value="weekend" checked>
+<input class="tabs" type="radio" name="soak-tab" id="tab-daily" value="daily">
 
 <h1>Merge-recovery soak benchmarks</h1>
 <p class="sub">Continuous soak of the merge-recovery suite against a live shard.</p>
@@ -273,6 +285,7 @@
   <div class="table-wrap" id="table-daily"></div>
   <p class="sub" id="links-daily"></p>
 </div>
+</main>
 
 <script>
 (async function () {
@@ -335,6 +348,7 @@
         { name: "total", path: ["passive", "too_far_ahead_errors"], c: 0 },
       ] },
     { slug: "lfb-spread", title: "LFB convergence spread", unit: "blocks",
+      empty: "Awaiting the first emitted LFB convergence sample.",
       fmt: v => Math.round(v).toLocaleString(),
       series: [
         { name: "p95", path: ["passive", "tracked_metrics", "lfb_spread", "p95"], c: 1 },
@@ -343,14 +357,46 @@
   ];
 
   const g = (h, path) => path.reduce((o, k) => (o == null ? null : o[k]), h);
+  const element = (tag, className, text) => {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    if (text != null) el.textContent = text;
+    return el;
+  };
+  const addLink = (parent, href, text) => {
+    const link = element("a", "", text);
+    link.href = href;
+    parent.appendChild(link);
+    return link;
+  };
+  const fragmentFor = (seriesKey, slug) => `chart-${seriesKey}-${slug}`;
+  const seriesURL = (seriesKey, fragment = "") => {
+    const params = new URLSearchParams(location.search);
+    params.set("series", seriesKey);
+    return location.pathname + "?" + params.toString() + fragment;
+  };
 
-  // Every value that comes out of the fetched JSON goes through this before it
-  // reaches innerHTML, including SVG text. The data is CI-written today, so
-  // this is defence in depth — but the page is served from the repo's Pages
-  // origin, so anything that could rewrite the published JSON would otherwise
-  // get script execution there.
-  const ESCAPES = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
-  const esc = v => String(v == null ? "" : v).replace(/[&<>"']/g, c => ESCAPES[c]);
+  function selectedSeriesFromLocation() {
+    const requested = new URLSearchParams(location.search).get("series");
+    if (SERIES.some(series => series.key === requested)) return requested;
+    const match = location.hash.match(/^#chart-(weekend|daily)-/);
+    return match ? match[1] : "weekend";
+  }
+
+  function applySeriesFromLocation() {
+    document.getElementById("tab-" + selectedSeriesFromLocation()).checked = true;
+  }
+
+  applySeriesFromLocation();
+  for (const tab of document.querySelectorAll('input[name="soak-tab"]')) {
+    tab.addEventListener("change", () => {
+      if (!tab.checked) return;
+      const params = new URLSearchParams(location.search);
+      params.set("series", tab.value);
+      history.replaceState(null, "", location.pathname + "?" + params.toString());
+    });
+  }
+  window.addEventListener("popstate", applySeriesFromLocation);
 
   async function loadJSON(url) {
     try {
@@ -394,10 +440,11 @@
   // completed run, so a partial one would double-count the night once the run
   // finishes and publishes for real.
   function renderProgress(el, verdict) {
-    if (!verdict || verdict.verdict !== "in_progress") { el.innerHTML = ""; return; }
-    el.innerHTML = '<div class="running-note">A soak is in progress. The report below is a ' +
-      'mid-run checkpoint; the charts and table show completed runs only, and this one ' +
-      'joins them when it finishes.</div>';
+    el.replaceChildren();
+    if (!verdict || verdict.verdict !== "in_progress") return;
+    el.appendChild(element("div", "running-note",
+      "A soak is in progress. The report below is a mid-run checkpoint; the charts and table " +
+      "show completed runs only, and this one joins them when it finishes."));
   }
 
   // Only something shaped like a git object may become a commit URL — the same
@@ -405,10 +452,12 @@
   // otherwise steer the href off this repository.
   function shaCell(sha) {
     const s = String(sha == null ? "" : sha);
-    const short = esc(s.slice(0, 8)) || "-";
-    return /^[0-9a-f]{7,40}$/.test(s)
-      ? `<a href="${COMMIT_URL}${s}"><code>${short}</code></a>`
-      : `<code>${short}</code>`;
+    const code = element("code", "", s.slice(0, 8) || "-");
+    if (!/^[0-9a-f]{7,40}$/.test(s)) return code;
+    const link = element("a");
+    link.href = COMMIT_URL + s;
+    link.appendChild(code);
+    return link;
   }
 
   // What was soaked, rendered onto the tab button so it is legible before
@@ -463,7 +512,7 @@
   // run. Runs recorded before the soak emitted shard_up_seconds render
   // nothing — the element collapses rather than showing a bar with no data.
   function renderUptime(el, verdict) {
-    el.innerHTML = "";
+    el.replaceChildren();
     const r = (verdict && verdict.run) || null;
     if (!r) return;
     const up = r.shard_up_seconds;
@@ -472,18 +521,52 @@
     const ratio = Math.min(Math.max(up / span, 0), 1);
     const pct = (ratio * 100).toFixed(ratio >= 0.995 && ratio < 1 ? 1 : 0);
     const hrs = s => (s / 3600).toFixed(s >= 36000 ? 0 : 1);
-    el.innerHTML =
-      `<span class="uptime-bar" role="img" aria-label="shard uptime ${pct}%">` +
-      `<i style="width:${(ratio * 100).toFixed(2)}%"></i></span>` +
-      `<span class="uptime-text">uptime ${pct}% · ${hrs(up)}h of ${hrs(span)}h</span>`;
+    const bar = element("span", "uptime-bar");
+    bar.setAttribute("role", "img");
+    bar.setAttribute("aria-label", `shard uptime ${pct}%`);
+    const fill = document.createElement("i");
+    fill.style.width = `${(ratio * 100).toFixed(2)}%`;
+    bar.appendChild(fill);
+    el.append(bar, element("span", "uptime-text", `uptime ${pct}% · ${hrs(up)}h of ${hrs(span)}h`));
   }
 
   // Rendered only when non-empty, so the strip's presence is itself the signal.
   function renderFailures(el, verdict) {
-    const f = (verdict && Array.isArray(verdict.failures)) ? verdict.failures : [];
-    if (f.length === 0) { el.innerHTML = ""; return; }
-    el.innerHTML = '<div class="failures"><strong>Latest run regressed</strong><ul>' +
-      f.map(s => "<li>" + esc(s) + "</li>").join("") + "</ul></div>";
+    el.replaceChildren();
+    const failures = (verdict && Array.isArray(verdict.failures)) ? verdict.failures : [];
+    if (failures.length === 0) return;
+    const box = element("div", "failures");
+    box.appendChild(element("strong", "", "Latest run regressed"));
+    const list = document.createElement("ul");
+    for (const failure of failures) list.appendChild(element("li", "", failure));
+    box.appendChild(list);
+    el.appendChild(box);
+  }
+
+  function renderCaption(fig, seriesKey, slug, title, unit, latest = "") {
+    const id = fragmentFor(seriesKey, slug);
+    fig.id = id;
+    const caption = document.createElement("figcaption");
+    const permalink = element("a", "chart-permalink", title);
+    permalink.href = seriesURL(seriesKey, "#" + id);
+    permalink.title = `Link to ${title}`;
+    caption.append(permalink, " ", element("span", "unit", unit));
+    if (latest) caption.append(" ", element("span", "latest", `· latest ${latest}`));
+    fig.appendChild(caption);
+  }
+
+  function appendChartImage(fig, src, theme, alt) {
+    const link = element("a", `chart-image-link chart-${theme}-link`);
+    link.href = src;
+    link.target = "_blank";
+    link.rel = "noopener";
+    link.setAttribute("aria-label", `Open ${alt} at full size`);
+    const image = element("img", "chart-svg");
+    image.alt = alt;
+    image.src = src;
+    image.addEventListener("error", () => { fig.style.display = "none"; });
+    link.appendChild(image);
+    fig.appendChild(link);
   }
 
   // The failure map replaces the failure-rate line chart: for sparse failure
@@ -508,19 +591,20 @@
     const range = rates.length
       ? `${pct(Math.min(...rates))} – ${pct(Math.max(...rates))}`
       : "no failures recorded";
-    const fig = document.createElement("figure");
-    fig.className = "heatmap-figure";
-    fig.innerHTML =
-      `<figcaption>Failure map <span class="unit">failures / iteration</span></figcaption>` +
-      `<div class="legend"><span><i class="swatch swatch-cell" style="background:var(--heat-zero)"></i>0%</span>` +
-      `<span><i class="swatch swatch-cell heat-ramp"></i>${esc(range)}</span>` +
-      `<span class="unit">blank = did not run</span></div>` +
-      `<img class="chart-svg chart-light" alt="Failure heatmap: rate by category and date" ` +
-      `src="data/failure-heatmap-${esc(seriesKey)}-light.svg" ` +
-      `onerror="this.closest('figure').style.display='none'">` +
-      `<img class="chart-svg chart-dark" alt="Failure heatmap: rate by category and date" ` +
-      `src="data/failure-heatmap-${esc(seriesKey)}-dark.svg" ` +
-      `onerror="this.closest('figure').style.display='none'">`;
+    const fig = element("figure", "heatmap-figure");
+    renderCaption(fig, seriesKey, "failure-map", "Failure map", "failures / iteration");
+    const legend = element("div", "legend");
+    const zero = element("span");
+    const zeroSwatch = element("i", "swatch swatch-cell");
+    zeroSwatch.style.background = "var(--heat-zero)";
+    zero.append(zeroSwatch, "0%");
+    const ramp = element("span");
+    ramp.append(element("i", "swatch swatch-cell heat-ramp"), range);
+    legend.append(zero, ramp, element("span", "unit", "blank = did not run"));
+    fig.appendChild(legend);
+    const alt = "Failure heatmap: rate by category and date";
+    appendChartImage(fig, `data/failure-heatmap-${seriesKey}-light.svg`, "light", alt);
+    appendChartImage(fig, `data/failure-heatmap-${seriesKey}-dark.svg`, "dark", alt);
     container.appendChild(fig);
   }
 
@@ -530,21 +614,28 @@
         name: s.name, c: s.c,
         values: history.map(h => {
           const v = g(h, s.path);
-          return typeof v === "number" && isFinite(v) ? v : null;
+          return typeof v === "number" && Number.isFinite(v) ? v : null;
         }),
       })).filter(s => s.values.some(v => v !== null));
       const all = seriesData.flatMap(s => s.values).filter(v => v !== null);
-      // No data → no panel, mirroring the renderer, which emits no SVG then.
-      if (all.length === 0) continue;
-
       const fig = document.createElement("figure");
+      if (all.length === 0) {
+        if (!def.empty) continue;
+        renderCaption(fig, seriesKey, def.slug, def.title, def.unit);
+        fig.appendChild(element("p", "chart-empty", def.empty));
+        container.appendChild(fig);
+        continue;
+      }
+
       // All-zero counters are suppressed at the renderer, so a flat zero line
       // never poses as information; the number still deserves a surface,
       // because "no rejections, and we are watching" is the good news.
       if (def.zeroBadge && all.every(v => v === 0)) {
-        fig.innerHTML =
-          `<figcaption>${def.title} <span class="unit">${def.unit}</span></figcaption>` +
-          `<p class="kpi-zero">0<span class="unit">across ${all.length} run${all.length > 1 ? "s" : ""} · target 0</span></p>`;
+        renderCaption(fig, seriesKey, def.slug, def.title, def.unit);
+        const kpi = element("p", "kpi-zero", "0");
+        kpi.appendChild(element("span", "unit",
+          `across ${all.length} run${all.length > 1 ? "s" : ""} · target 0`));
+        fig.appendChild(kpi);
         container.appendChild(fig);
         continue;
       }
@@ -559,13 +650,21 @@
             return grid && typeof grid === "object" && Object.keys(grid).length > 0;
           })
         : false;
-      const legend = gridRun
-        ? '<div class="legend"><span><i class="swatch swatch-cell jet-ramp"></i>0% → hot</span>' +
-          '<span class="unit">cell = one core · labelled ≥ 100% (a full core)</span></div>'
-        : seriesData.length > 1
-        ? '<div class="legend">' + seriesData.map(s =>
-            `<span><i class="swatch" style="background:${S[s.c]}"></i>${s.name}</span>`).join("") + "</div>"
-        : "";
+      const legend = element("div", "legend");
+      if (gridRun) {
+        const scale = element("span");
+        scale.append(element("i", "swatch swatch-cell jet-ramp"), "0% → hot");
+        legend.append(scale,
+          element("span", "unit", "cell = one core · labelled ≥ 100% (a full core)"));
+      } else if (seriesData.length > 1) {
+        for (const series of seriesData) {
+          const item = element("span");
+          const swatch = element("i", "swatch");
+          swatch.style.background = S[series.c];
+          item.append(swatch, series.name);
+          legend.appendChild(item);
+        }
+      }
       // Selective direct label: single-series charts get the latest value in
       // the caption, so the current state reads at a glance. Multi-series
       // charts leave it to the legend and the table — one number per caption
@@ -573,48 +672,68 @@
       const latest = seriesData.length === 1
         ? seriesData[0].values.reduce((acc, v) => v !== null ? v : acc, null)
         : null;
-      const latestHtml = latest !== null
-        ? ` <span class="latest">· latest ${def.fmt(latest)}</span>` : "";
-      fig.innerHTML =
-        `<figcaption>${def.title} <span class="unit">${def.unit}</span>${latestHtml}</figcaption>` +
-        legend +
-        `<img class="chart-svg chart-light" alt="${def.title} chart" ` +
-        `src="data/chart-${def.slug}-${esc(seriesKey)}-light.svg" ` +
-        `onerror="this.closest('figure').style.display='none'">` +
-        `<img class="chart-svg chart-dark" alt="${def.title} chart" ` +
-        `src="data/chart-${def.slug}-${esc(seriesKey)}-dark.svg" ` +
-        `onerror="this.closest('figure').style.display='none'">`;
+      renderCaption(fig, seriesKey, def.slug, def.title, def.unit,
+        latest !== null ? def.fmt(latest) : "");
+      if (legend.childElementCount > 0) fig.appendChild(legend);
+      const alt = `${def.title} chart`;
+      appendChartImage(fig, `data/chart-${def.slug}-${seriesKey}-light.svg`, "light", alt);
+      appendChartImage(fig, `data/chart-${def.slug}-${seriesKey}-dark.svg`, "dark", alt);
       container.appendChild(fig);
     }
   }
 
   function renderTable(el, history) {
-    const rows = history.slice().reverse().map(h => {
+    el.replaceChildren();
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    const headRow = document.createElement("tr");
+    const columns = [
+      ["date", false], ["version", false], ["sha", false], ["trigger", false],
+      ["iters", true], ["fail rate", true], ["iters/h", true], ["RSS MB", true],
+      ["CPU %", true], ["final p50 ms", true], ["final p95 ms", true], ["final p99 ms", true],
+      ["bench p95 ms", true], ["too-far", true], ["LFB p95", true], ["LFB max", true], ["run", false],
+    ];
+    for (const [label, numeric] of columns) {
+      const th = element("th", numeric ? "num" : "", label);
+      headRow.appendChild(th);
+    }
+    head.appendChild(headRow);
+    table.appendChild(head);
+    const body = document.createElement("tbody");
+    const number = value => {
+      if (value == null) return "-";
+      if (typeof value === "number") return String(+value.toFixed(3));
+      return String(value);
+    };
+    for (let index = history.length - 1; index >= 0; index -= 1) {
+      const h = history[index];
       const p = h.passive || {}, a = h.active || {}, r = h.run || {};
-      // Only a bare run of digits can become a URL. Anything else is not a
-      // GitHub run id, and concatenating it would let a crafted value steer
-      // the href somewhere other than this repo's Actions.
-      const runLink = /^[0-9]+$/.test(String(r.run_id || ""))
-        ? `<a href="${RUNS_URL}${r.run_id}">log</a>` : "-";
-      const n = v => v == null ? "-" : (typeof v === "number" ? +v.toFixed(3) : esc(v));
-      // "unknown" is what pre-version runs carry; show a dash so the column
-      // reads as "not recorded" rather than as a version by that name.
-      const ver = r.version && r.version !== "unknown" ? `<code>${esc(r.version)}</code>` : "-";
-      // Same optional-by-construction stance as version: rows predating
-      // trigger emission show a dash, not a value pretending to be recorded.
-      const trig = triggerLabel(r);
-      return `<tr><td>${esc((r.date || "").slice(0, 10))}</td><td>${ver}</td><td>${shaCell(r.target_sha)}</td>` +
-        `<td>${trig ? esc(trig) : "-"}</td>` +
-        `<td class="num">${n(p.iterations)}</td><td class="num">${n(p.failure_rate)}</td>` +
-        `<td class="num">${n(p.iterations_per_hour)}</td><td class="num">${n(p.rss_peak_mb)}</td>` +
-        `<td class="num">${n(p.finalization_p95_ms)}</td><td class="num">${n(a && a.p95_ms)}</td>` +
-        `<td>${runLink}</td></tr>`;
-    }).join("");
-    el.innerHTML =
-      `<table><thead><tr><th>date</th><th>version</th><th>sha</th><th>trigger</th><th class="num">iters</th>` +
-      `<th class="num">fail rate</th><th class="num">iters/h</th><th class="num">RSS MB</th>` +
-      `<th class="num">final p95 ms</th><th class="num">bench p95 ms</th><th>run</th></tr></thead>` +
-      `<tbody>${rows}</tbody></table>`;
+      const lfb = g(h, ["passive", "tracked_metrics", "lfb_spread"]) || {};
+      const row = document.createElement("tr");
+      const cells = [
+        [(r.date || "").slice(0, 10), false],
+        [r.version && r.version !== "unknown" ? r.version : "-", false, "code"],
+        [shaCell(r.target_sha), false, "node"], [triggerLabel(r) || "-", false],
+        [p.iterations, true], [p.failure_rate, true], [p.iterations_per_hour, true],
+        [p.rss_peak_mb, true], [p.cpu_peak_pct, true], [p.finalization_p50_ms, true],
+        [p.finalization_p95_ms, true], [p.finalization_p99_ms, true], [a.p95_ms, true],
+        [p.too_far_ahead_errors, true], [lfb.p95, true], [lfb.max, true],
+      ];
+      for (const [value, numeric, kind] of cells) {
+        const td = element("td", numeric ? "num" : "");
+        if (kind === "node") td.appendChild(value);
+        else if (kind === "code") td.appendChild(element("code", "", value));
+        else td.textContent = number(value);
+        row.appendChild(td);
+      }
+      const runCell = document.createElement("td");
+      if (/^[0-9]+$/.test(String(r.run_id || ""))) addLink(runCell, RUNS_URL + r.run_id, "log");
+      else runCell.textContent = "-";
+      row.appendChild(runCell);
+      body.appendChild(row);
+    }
+    table.appendChild(body);
+    el.appendChild(table);
   }
 
   for (const def of SERIES) {
@@ -631,20 +750,26 @@
     // The tab button carries the commit as text; this is where it becomes
     // clickable, since a link inside the label would fight the radio toggle.
     const soakedSha = (verdict && verdict.run && verdict.run.target_sha) || "";
-    const commitLink = /^[0-9a-f]{7,40}$/.test(String(soakedSha))
-      ? ` · <a href="${COMMIT_URL}${soakedSha}">commit ${esc(soakedSha.slice(0, 8))}</a>` : "";
-    document.getElementById("links-" + def.key).innerHTML =
-      `<a href="${def.report}">latest report</a> · <a href="${def.history}">raw data</a>${commitLink}`;
+    const links = document.getElementById("links-" + def.key);
+    links.replaceChildren();
+    addLink(links, def.report, "latest report");
+    links.append(" · ");
+    addLink(links, def.history, "raw data");
+    if (/^[0-9a-f]{7,40}$/.test(String(soakedSha))) {
+      links.append(" · ");
+      addLink(links, COMMIT_URL + soakedSha, `commit ${soakedSha.slice(0, 8)}`);
+    }
 
     if (history.length === 0) {
-      document.getElementById("charts-" + def.key).innerHTML =
-        `<p class="empty">${def.empty}</p>`;
+      document.getElementById("charts-" + def.key).appendChild(element("p", "empty", def.empty));
       continue;
     }
     renderHeatmap(document.getElementById("charts-" + def.key), def.key, history);
     renderPanels(document.getElementById("charts-" + def.key), def.key, history);
     renderTable(document.getElementById("table-" + def.key), history);
   }
+  applySeriesFromLocation();
+  if (location.hash) document.getElementById(location.hash.slice(1))?.scrollIntoView();
 })();
 </script>
 </body>

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -48,6 +48,15 @@
   }
   h1 { font-size: 1.25rem; margin: 0 0 .25rem; }
   .sub { color: var(--text-secondary); margin: 0 0 1.25rem; }
+  /* Upper-left repo link: the dashboard is published detached from the repo
+     (GitHub Pages), so the page itself carries the way back to the source. */
+  .page-head { display: flex; align-items: center; gap: .55rem; }
+  .repo-link {
+    display: inline-flex; align-items: center; color: var(--link);
+    padding: .2rem; margin-left: -.2rem; border-radius: 6px;
+  }
+  .repo-link:hover, .repo-link:focus-visible { color: var(--text-primary); }
+  .repo-link svg { display: block; fill: currentColor; }
 
   /* Tabs are a radio group, so switching needs no JS and the bar keeps working
      even when a data fetch fails. The inputs live at body level rather than
@@ -241,7 +250,15 @@
 <input class="tabs" type="radio" name="soak-tab" id="tab-weekend" value="weekend" checked>
 <input class="tabs" type="radio" name="soak-tab" id="tab-daily" value="daily">
 
-<h1>Merge-recovery soak benchmarks</h1>
+<div class="page-head">
+  <a class="repo-link" href="https://github.com/F1R3FLY-io/f1r3node-rust"
+     aria-label="f1r3node-rust repository on GitHub" title="f1r3node-rust on GitHub">
+    <svg width="20" height="20" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"/>
+    </svg>
+  </a>
+  <h1>Merge-recovery soak benchmarks</h1>
+</div>
 <p class="sub">Continuous soak of the merge-recovery suite against a live shard.</p>
 
 <div class="tabbar" role="group" aria-label="Soak series">

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -430,13 +430,19 @@
     const v = verdict && typeof verdict.verdict === "string" ? verdict.verdict : null;
     // in_progress is a mid-run checkpoint, not a result. It has to be matched
     // before the pass/regress split, or "not pass" would read as a regression
-    // and show a red tab for a soak that is running perfectly well.
+    // and show a red tab for a soak that is running perfectly well. A
+    // checkpoint verdict does carry provisional failures, though — completed
+    // facts like failed iterations — and a run in that state must not wear
+    // the healthy blue: run 31563121791 sat behind a neutral "running" tab
+    // for 14 hours while every iteration failed.
     if (v === "in_progress") {
-      cls = "running";
+      const failing = Array.isArray(verdict.failures) && verdict.failures.length > 0;
+      cls = failing ? "regress" : "running";
       const r = verdict.run || {};
       const h = s => (typeof s === "number" && s > 0) ? Math.floor(s / 3600) : null;
       const done = h(r.elapsed_seconds), total = h(r.duration_seconds);
-      text = "running" + (done !== null && total !== null ? ` · ${done}h of ${total}h` : "");
+      text = "running" + (done !== null && total !== null ? ` · ${done}h of ${total}h` : "")
+        + (failing ? " — failing" : "");
     } else if (runs === 0) {
       text = "no runs yet";
     } else if (v === null) {
@@ -553,7 +559,10 @@
     const failures = (verdict && Array.isArray(verdict.failures)) ? verdict.failures : [];
     if (failures.length === 0) return;
     const box = element("div", "failures");
-    box.appendChild(element("strong", "", "Latest run regressed"));
+    // A mid-run checkpoint with failures is a run going wrong, not a
+    // finished regression — say which one it is.
+    box.appendChild(element("strong", "",
+      verdict.verdict === "in_progress" ? "Run in progress is failing" : "Latest run regressed"));
     const list = document.createElement("ul");
     for (const failure of failures) list.appendChild(element("li", "", failure));
     box.appendChild(list);

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # F1R3node Rust
 
-[![Soak · master](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-soak.json)](https://f1r3fly-io.github.io/f1r3node-rust/)
-[![Soak · dev](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-soak-daily.json)](https://f1r3fly-io.github.io/f1r3node-rust/)
-[![Stability](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-stability.json)](https://f1r3fly-io.github.io/f1r3node-rust/)
-[![Performance](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-perf.json)](https://f1r3fly-io.github.io/f1r3node-rust/)
+[![Soak · master](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-soak.json)](https://f1r3fly-io.github.io/f1r3node-rust/?series=weekend)
+[![Soak · dev](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-soak-daily.json)](https://f1r3fly-io.github.io/f1r3node-rust/?series=daily)
+[![Stability](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-stability.json)](https://f1r3fly-io.github.io/f1r3node-rust/?series=weekend)
+[![Performance](https://img.shields.io/endpoint?url=https%3A%2F%2Ff1r3fly-io.github.io%2Ff1r3node-rust%2Fdata%2Fbadge-perf.json)](https://f1r3fly-io.github.io/f1r3node-rust/?series=weekend)
 
 Pure Rust implementation of the F1R3FLY blockchain node.
 

--- a/docs/soak-benchmarks.md
+++ b/docs/soak-benchmarks.md
@@ -10,9 +10,9 @@ runs — see [Weekend vs daily](#weekend-vs-daily). Design history and decisions
 ## Where to look
 
 - **Trend dashboard** (charts, per-provider split, run links):
-  <https://f1r3fly-io.github.io/f1r3node-rust/> — two tabs, Weekend and Daily,
-  each showing its own verdict on the tab button so both series are readable
-  without clicking through.
+  [Weekend](https://f1r3fly-io.github.io/f1r3node-rust/?series=weekend) and
+  [Daily](https://f1r3fly-io.github.io/f1r3node-rust/?series=daily) — each tab
+  shows its own verdict, and every chart title and image is directly linkable.
 - **Weekly email alert**: plain-text summary with the verdict and dashboard
   links, sent via OCI Notifications when the soak concludes.
 - **Per-run detail**: the `merge-recovery-soak-*` artifact on the workflow run
@@ -76,7 +76,15 @@ charts on a temporal axis (throughput adds a low-opacity trend area); with only
 a few they render as value-labelled bars or points, because a two-point line
 chart is mostly empty axis. A panel with no recorded data emits nothing, and
 the too-far-ahead counter is suppressed while it is all-zero — the page shows a
-"0 · target 0" badge instead of a flat line.
+"0 · target 0" badge instead of a flat line. LFB spread is the exception to
+no-data suppression: its stable eighth slot remains visible with an awaiting-data
+message until the harness emits its first sample, preventing a missing upstream
+contract from masquerading as a seven-chart layout.
+
+Dashboard deep links use `?series=weekend` or `?series=daily`; chart permalinks
+add a stable fragment such as `#chart-weekend-lfb-spread`. The README badges use
+those series links, and clicking a chart image opens the corresponding SVG at
+full resolution.
 
 Peak CPU steps up through three representations as richer data appears, each
 the honest chart for what exists: an aggregate line chart with a dashed
@@ -311,10 +319,11 @@ per-run → dashboard pipeline:
   Charted as "Too-far-ahead errors".
 - **LFB convergence spread (p95 / max)** — the `lfb_spread` metric already
   declared in `scripts/bench/soak-metrics.json` (max−min last-finalized-block
-  across shard nodes) was captured per iteration but never reached the
-  dashboard: `summary.json` only rolled up the fixed passive fields, not the
-  registry's `SOAK_METRIC` output. `run-merge-recovery-soak.sh` now folds
-  every registry-declared metric into `summary.json.tracked_metrics`
+  across shard nodes) is read from the harness's structured `SOAK_METRIC`
+  output. During the transition, the driver also extracts the existing
+  `All-node LFBs at drain … (spread N blocks)` pytest line, so the dashboard
+  does not depend on synchronized deployment of both repositories.
+  `run-merge-recovery-soak.sh` now folds every registry-declared metric into `summary.json.tracked_metrics`
   generically (max/min aggregates fold with cross-iteration max/min, any other
   declared aggregate — p50, p95, ... — folds with the cross-iteration
   median), so declaring a new metric in `soak-metrics.json` is enough for it

--- a/scripts/bench/aggregate-perf-report.sh
+++ b/scripts/bench/aggregate-perf-report.sh
@@ -214,14 +214,21 @@ jq -n \
   | ($baseline.passive // null) as $bp
   | ($current.active) as $a
   | ($baseline.active // null) as $ba
+  # Failures that are completed facts even mid-run: a failed iteration stays
+  # failed and a guardian breach stays breached no matter how much of the
+  # window remains. These survive into checkpoint verdicts, unlike the
+  # completion-only signals below.
   | (
       []
-      | if $p == null
-          then . + ["no passive soak summary was produced (no data)"] else . end
       | if $p != null and (($p.failures // 0) > 0)
           then . + ["\($p.failures) passive soak iteration(s) failed"] else . end
       | if $protection_breach
           then . + ["host protection breach aborted the soak"] else . end
+    ) as $midrun_failures
+  | (
+      $midrun_failures
+      | if $p == null
+          then . + ["no passive soak summary was produced (no data)"] else . end
       | if $bp != null and $p != null and $p.failure_rate != null and $bp.failure_rate != null
            and $p.failure_rate > ($bp.failure_rate + $thresholds.failure_rate_max_increase_pts)
           then . + ["failure rate \($p.failure_rate) exceeds baseline \($bp.failure_rate) by more than \($thresholds.failure_rate_max_increase_pts * 100)pts"] else . end
@@ -242,15 +249,19 @@ jq -n \
           then . + ["active-segment throughput \($a.throughput)/s < baseline \($ba.throughput)/s -\($thresholds.active_throughput_warn_decrease_pct * 100)%"] else . end
     ) as $warnings
   | {
-      # A checkpoint reports progress, never a judgement. Failures and
-      # warnings are dropped rather than shown, because the only ones that
-      # could fire mid-run are "no data yet" artefacts of an incomplete run,
-      # and surfacing those would put a red strip on a healthy soak.
+      # A checkpoint reports progress, never a full judgement: baseline
+      # comparisons on a partial run measure the clock, and the no-data
+      # line is an artefact of a run that has not written a summary yet —
+      # both wait for completion. But $midrun_failures are completed facts,
+      # and hiding them left run 31563121791 showing a healthy "running"
+      # tab for 14 hours while every iteration failed. The verdict stays
+      # in_progress (a checkpoint is still not a release-gate result);
+      # consumers read .failures for the provisional state.
       verdict: (if $status == "in_progress" then "in_progress"
                 elif ($failures | length) > 0 then "regress" else "pass" end),
       status: $status,
       bootstrap: ($status != "in_progress" and $baseline == null),
-      failures: (if $status == "in_progress" then [] else $failures end),
+      failures: (if $status == "in_progress" then $midrun_failures else $failures end),
       warnings: (if $status == "in_progress" then [] else $warnings end),
       thresholds: $thresholds,
       run: $current.run,
@@ -284,15 +295,17 @@ jq \
     # from claiming a comparison it never made.
     message:
       (if .verdict == "in_progress"
-         then ((.run.elapsed_seconds | hours) as $e
-               | (.run.duration_seconds | hours) as $t
-               | if $e == null or $t == null then "in progress"
-                 else "\($e)h/\($t)h" end)
+         then (((.run.elapsed_seconds | hours) as $e
+                | (.run.duration_seconds | hours) as $t
+                | if $e == null or $t == null then "in progress"
+                  else "\($e)h/\($t)h" end)
+               + (if (.failures | length) > 0 then " · failing" else "" end))
        elif .verdict == "regress" then "regress"
        elif .bootstrap then "pass · no baseline"
        else "pass" end),
     color:
-      (if .verdict == "in_progress" then "lightgrey"
+      (if .verdict == "in_progress"
+         then (if (.failures | length) > 0 then "orange" else "lightgrey" end)
        elif .verdict == "regress" then "red"
        elif .bootstrap then "yellowgreen"
        else "brightgreen" end)

--- a/scripts/bench/test-aggregate-perf-report.sh
+++ b/scripts/bench/test-aggregate-perf-report.sh
@@ -131,6 +131,21 @@ jq -e '.color == "lightgrey" and (.message | contains("failing") | not)' \
 # The "no passive summary" line is a completion-only signal: a checkpoint
 # before the first summary write must not paint a healthy soak red.
 mkdir -p "$TMP/nodata" "$TMP/nodata-checkpoint-report"
+cat >"$TMP/nodata/.soak-checkpoint-state.json" <<'JSON'
+{
+  "target_ref": "dev",
+  "target_sha": "0123456789abcdef",
+  "trigger_source": "manual",
+  "slot_delay_seconds": 0,
+  "version": "0.4.43",
+  "started_at": 1000,
+  "requested_seconds": 1800,
+  "iterations": 0,
+  "failures": 0,
+  "bench_segments": 0,
+  "bench_failures": 0
+}
+JSON
 SOAK_DIR="$TMP/nodata" OUT_DIR="$TMP/nodata-checkpoint-report" RUN_ID=5 RUN_ATTEMPT=1 \
 	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
 	SOAK_STATUS=in_progress \

--- a/scripts/bench/test-aggregate-perf-report.sh
+++ b/scripts/bench/test-aggregate-perf-report.sh
@@ -42,13 +42,20 @@ jq -e '
   and .run.shard_up_seconds == null
 ' "$TMP/failed-report/verdict.json" >/dev/null
 
+# A checkpoint keeps the in_progress verdict but surfaces mid-run-valid
+# failures (completed iteration failures), and the badge turns orange.
 mkdir -p "$TMP/checkpoint-report"
 SOAK_DIR="$TMP/failed" OUT_DIR="$TMP/checkpoint-report" RUN_ID=1 RUN_ATTEMPT=1 \
 	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=1 \
 	SOAK_STATUS=in_progress \
 	"$ROOT/scripts/bench/aggregate-perf-report.sh"
-jq -e '.verdict == "in_progress" and .failures == []' \
-	"$TMP/checkpoint-report/verdict.json" >/dev/null
+jq -e '
+  .verdict == "in_progress"
+  and (.failures | any(test("1 passive soak iteration\\(s\\) failed")))
+  and .warnings == []
+' "$TMP/checkpoint-report/verdict.json" >/dev/null
+jq -e '.color == "orange" and (.message | endswith("· failing"))' \
+	"$TMP/checkpoint-report/badge.json" >/dev/null
 
 mkdir -p "$TMP/passing" "$TMP/passing-report"
 jq '.failures = 0 | .failure_rate = 0 | .providers.docker.failures = 0
@@ -60,6 +67,27 @@ SOAK_DIR="$TMP/passing" OUT_DIR="$TMP/passing-report" RUN_ID=2 RUN_ATTEMPT=1 \
 jq -e '.verdict == "pass" and .bootstrap == true and .failures == []
 	and .run.shard_up_seconds == 90' \
 	"$TMP/passing-report/verdict.json" >/dev/null
+
+# A healthy checkpoint stays clean: no failures, neutral badge.
+mkdir -p "$TMP/passing-checkpoint-report"
+SOAK_DIR="$TMP/passing" OUT_DIR="$TMP/passing-checkpoint-report" RUN_ID=2 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '.verdict == "in_progress" and .failures == []' \
+	"$TMP/passing-checkpoint-report/verdict.json" >/dev/null
+jq -e '.color == "lightgrey" and (.message | contains("failing") | not)' \
+	"$TMP/passing-checkpoint-report/badge.json" >/dev/null
+
+# The "no passive summary" line is a completion-only signal: a checkpoint
+# before the first summary write must not paint a healthy soak red.
+mkdir -p "$TMP/nodata" "$TMP/nodata-checkpoint-report"
+SOAK_DIR="$TMP/nodata" OUT_DIR="$TMP/nodata-checkpoint-report" RUN_ID=5 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '.verdict == "in_progress" and .failures == []' \
+	"$TMP/nodata-checkpoint-report/verdict.json" >/dev/null
 
 mkdir -p "$TMP/segments/bench-segment-00001/bench" "$TMP/segments-report"
 cp "$TMP/passing/summary.json" "$TMP/segments/summary.json"
@@ -100,5 +128,17 @@ jq -e '
   and .run.protection_breach == true
   and (.failures | any(. == "host protection breach aborted the soak"))
 ' "$TMP/breach-report/verdict.json" >/dev/null
+
+# A breach is a completed fact mid-run too: a checkpoint after the guardian
+# fired reports it instead of a neutral "running".
+mkdir -p "$TMP/breach-checkpoint-report"
+SOAK_DIR="$TMP/breach" OUT_DIR="$TMP/breach-checkpoint-report" RUN_ID=3 RUN_ATTEMPT=1 \
+	SOAK_KIND=daily DURATION_SECONDS=1800 WINDOW_SECONDS=79200 RETRY_ATTEMPT=0 \
+	SOAK_STATUS=in_progress \
+	"$ROOT/scripts/bench/aggregate-perf-report.sh"
+jq -e '
+  .verdict == "in_progress"
+  and (.failures | any(. == "host protection breach aborted the soak"))
+' "$TMP/breach-checkpoint-report/verdict.json" >/dev/null
 
 printf 'soak report verdict tests passed\n'

--- a/scripts/bench/test-run-merge-recovery-soak.sh
+++ b/scripts/bench/test-run-merge-recovery-soak.sh
@@ -54,6 +54,10 @@ proposal rejected: too far ahead of the last finalized block
 LOG
 cp "$FAKE_DATA_DIR/session/validator1.log" "$FAKE_ARCHIVE_DIR/session/validator1.log"
 printf 'fake pytest started\n'
+printf 'All-node LFBs at drain: {validator1: 12, validator2: 9} (spread 3 blocks)\n'
+if [ "${FAKE_EMIT_SOAK_METRIC:-false}" = "true" ]; then
+	printf 'SOAK_METRIC name=lfb_spread value=4 phase=drain\n'
+fi
 while :; do sleep 1; done
 SH
 cat >"$TMP/bin/docker" <<'SH'
@@ -148,6 +152,8 @@ jq -e '
   and .iteration_metrics[0].cpu_peak_per_node_pct == {"validator1": 10, "validator2": 20}
   and .iteration_metrics[0].cpu_peak_per_node_core_pct == {"validator1": {"0": 7.5, "1": 42}}
   and .iteration_metrics[0].too_far_ahead_errors == 1
+  and .iteration_metrics[0].metrics.lfb_spread == {p50: 3, p95: 3, max: 3, min: 3, samples: 1}
+  and .tracked_metrics.lfb_spread == {p50: 3, p95: 3, max: 3, samples: 1}
 ' "$TMP/output/summary.json" >/dev/null
 grep -q 'replay_cache_retained_bytes,1048576' \
 	"$TMP/output/iteration-00001-docker/node-metrics-timeseries.csv"
@@ -169,6 +175,7 @@ PATH="$TMP/bin:$PATH" \
 	FAKE_POETRY_PID_FILE="$TMP/fake-poetry-2.pid" \
 	FAKE_DATA_DIR="$TMP/si2/integration-tests/data" \
 	FAKE_ARCHIVE_DIR="$TMP/si2/integration-tests/log-archive" \
+	FAKE_EMIT_SOAK_METRIC=true \
 	SOAK_DURATION_SECONDS=6 \
 	SYSTEM_INTEGRATION_DIR="$TMP/si2" \
 	SOAK_OUTPUT_DIR="$TMP/output2" \
@@ -213,6 +220,8 @@ jq -e '
   and .iteration_metrics[0].rss_peak_mb == 768
   and .iteration_metrics[0].cpu_peak_per_node_pct == {"validator1": 10, "validator2": 20}
   and .iteration_metrics[0].cpu_peak_per_node_core_pct == {"validator1": {"0": 7.5, "1": 42}}
+  and .iteration_metrics[0].metrics.lfb_spread == {p50: 4, p95: 4, max: 4, min: 4, samples: 1}
+  and .tracked_metrics.lfb_spread == {p50: 4, p95: 4, max: 4, samples: 1}
 ' "$TMP/output2/summary.json" >/dev/null
 test -s "$TMP/fake-poetry-2.pid"
 ! kill -0 "$(cat "$TMP/fake-poetry-2.pid")" 2>/dev/null

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -443,6 +443,15 @@ iteration_too_far_ahead_errors() {
 		wc -l | tr -d ' '
 }
 
+iteration_lfb_spread() {
+	local iteration_dir="$1"
+	grep -oE 'All-node LFBs at drain:.*\(spread [0-9]+ blocks\)' \
+		"$iteration_dir/pytest.log" 2>/dev/null |
+		grep -oE 'spread [0-9]+ blocks' |
+		grep -oE '[0-9]+' |
+		tail -1 || true
+}
+
 # Parse the pytest terminal summary line ("== 1 failed, 64 passed, ... ==")
 # and emit a per-iteration metrics.json with resource + latency samples.
 # Metrics are additive: missing jq or an unparseable log must never fail
@@ -479,9 +488,18 @@ emit_iteration_metrics() {
 		"$iteration_dir/.started" \
 		"$(
 			IFS=:
-			printf '%s' "${HARNESS_TELEMETRY_DIRS[*]}"
+			printf '%s:%s' "${HARNESS_TELEMETRY_DIRS[*]}" "$iteration_dir"
 		)" 2>/dev/null || printf '{}')"
 	jq -e . >/dev/null 2>&1 <<<"$registry_metrics" || registry_metrics='{}'
+	local lfb_spread
+	if ! jq -e '.lfb_spread.samples > 0' >/dev/null 2>&1 <<<"$registry_metrics"; then
+		lfb_spread="$(iteration_lfb_spread "$iteration_dir")"
+		if [[ "$lfb_spread" =~ ^[0-9]+$ ]]; then
+			registry_metrics="$(jq -c --argjson value "$lfb_spread" \
+				'. + {lfb_spread: {p50: $value, p95: $value, max: $value, min: $value, samples: 1}}' \
+				<<<"$registry_metrics")"
+		fi
+	fi
 	jq -n \
 		--argjson metrics "$registry_metrics" \
 		--argjson iteration "$iteration" \

--- a/scripts/run-merge-recovery-soak.sh
+++ b/scripts/run-merge-recovery-soak.sh
@@ -519,13 +519,15 @@ emit_iteration_metrics() {
 	# bespoke extractors above, adding a metric here needs no code change: the
 	# harness emits a SOAK_METRIC line and the registry declares it. Fail-soft
 	# by the same contract — the collector yields {} rather than erroring.
-	local registry_metrics
+	local registry_metrics metric_log_roots root
+	metric_log_roots="$iteration_dir"
+	for root in "${HARNESS_TELEMETRY_DIRS[@]-}"; do
+		[ -n "$root" ] || continue
+		metric_log_roots="${metric_log_roots}:$root"
+	done
 	registry_metrics="$("$SCRIPT_DIR/bench/collect-soak-metrics.sh" \
-		"$iteration_dir/.started" \
-		"$(
-			IFS=:
-			printf '%s:%s' "${HARNESS_TELEMETRY_DIRS[*]}" "$iteration_dir"
-		)" 2>/dev/null || printf '{}')"
+		"$iteration_dir/.started" "$metric_log_roots" \
+		2>/dev/null || printf '{}')"
 	jq -e . >/dev/null 2>&1 <<<"$registry_metrics" || registry_metrics='{}'
 	local lfb_spread
 	if ! jq -e '.lfb_spread.samples > 0' >/dev/null 2>&1 <<<"$registry_metrics"; then

--- a/scripts/soak-charts/tests/cli.rs
+++ b/scripts/soak-charts/tests/cli.rs
@@ -109,7 +109,10 @@ fn manifest_tracks_rendered_panels_and_omits_all_zero_alert_panels() {
               "iterations": 20,
               "failures": 1,
               "iterations_per_hour": 12.5,
-              "too_far_ahead_errors": 0
+              "too_far_ahead_errors": 0,
+              "tracked_metrics": {
+                "lfb_spread": { "p95": 2, "max": 4 }
+              }
             }
           }
         ]"#,
@@ -127,6 +130,8 @@ fn manifest_tracks_rendered_panels_and_omits_all_zero_alert_panels() {
     assert!(files.contains(&"failure-heatmap-daily-dark.svg".to_string()));
     assert!(files.contains(&"chart-throughput-daily-light.svg".to_string()));
     assert!(files.contains(&"chart-throughput-daily-dark.svg".to_string()));
+    assert!(files.contains(&"chart-lfb-spread-daily-light.svg".to_string()));
+    assert!(files.contains(&"chart-lfb-spread-daily-dark.svg".to_string()));
     let throughput = fs::read_to_string(
         test_dir
             .path()


### PR DESCRIPTION
- collect structured and fallback LFB spread telemetry
- add dashboard deep links and a persistent LFB panel
- improve accessibility and end-to-end renderer coverage

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789139614&installation_model_id=426883&pr_number=247&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F247&signature=9aea1d4efd80deb9d69e98743b5002b6b90e4d293a525f39a6c7d34a157ca5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->