### PR TITLE
fix(casper): exactly-once at the merge

### DIFF
--- a/casper/src/rust/api/block_api.rs
+++ b/casper/src/rust/api/block_api.rs
@@ -1693,18 +1693,17 @@ impl BlockAPI {
                             .iter()
                             .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
                             .collect();
-                        let (merged_state_hash, _rejected, _rejected_slashes) =
-                            crate::rust::util::rholang::interpreter_util::compute_parents_post_state(
-                                casper.block_store(),
-                                parents.clone(),
-                                &snapshot,
-                                &runtime_manager,
-                                &latest_messages,
-                                Some(true), // disable_late_block_filtering = true for exploratory deploy
-                                None,       // exploratory deploy: no buffer populate needed
-                            )
-                            .await?;
-                        merged_state_hash
+                        crate::rust::util::rholang::interpreter_util::compute_parents_post_state(
+                            casper.block_store(),
+                            parents.clone(),
+                            &snapshot,
+                            &runtime_manager,
+                            &latest_messages,
+                            Some(true), // disable_late_block_filtering = true for exploratory deploy
+                            None,       // exploratory deploy: no buffer populate needed
+                        )
+                        .await?
+                        .state
                     };
 
                     tracing::warn!(

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -2758,8 +2758,6 @@ pub async fn create(
         v
     };
 
-    let has_user_or_dummy_deploys = !user_deploys.is_empty() || !dummy_deploys.is_empty();
-
     // Merge the parents once up front. Two reasons to do this before the
     // empty-block skip check below:
     //   1. To discover slashes that were rejected by cost-optimal merge
@@ -2793,7 +2791,71 @@ pub async fn create(
         "source" => CASPER_METRICS_SOURCE
     )
     .record(__merge_pre_t.elapsed().as_secs_f64());
-    let (_pre_state, _rejected_user_sigs, rejected_slashes) = merge_pre_info;
+    let rejected_slashes = merge_pre_info.rejected_slashes.clone();
+
+    // NEVER EXECUTE A DEPLOY WHOSE EFFECT IS ALREADY IN THE PRE-STATE.
+    //
+    // Selection ran BEFORE the parents were merged, so it cannot know what
+    // the block will actually be built on. Two independent mechanisms return
+    // a rejected deploy's work: recovery re-selects the deploy for fresh
+    // re-proposal, and a merge reinstates the original copy from scope.
+    // Neither can see the other, so both can deliver — and the second
+    // execution is not a harmless duplicate. The deploy's cells are keyed by
+    // a sig-derived rnd, so both executions write the SAME channel and
+    // neither consumes the other's datum: the cell ends up holding two
+    // values, the vault read trips the IntegerAdd single-value invariant,
+    // and the toxic-deploy quarantine then deletes the deploy from BOTH the
+    // pool and the buffer. A double-apply destroys the work rather than
+    // duplicating it.
+    //
+    // The test is the INVARIANT, not a route. Keying on how the effect
+    // arrived misses paths: `applied_from_scope` is empty on the
+    // short-circuit shapes (`single_parent`, `descendant_fast_path`, cache
+    // hit) where the effect arrives via a parent's post-state instead.
+    // Asking the pre-state directly is provenance-independent and therefore
+    // complete. `applied_from_scope` is still consulted first: it is exact
+    // and needs no I/O, so the state probe only runs for what it does not
+    // cover.
+    //
+    // Only the FRESH copy is dropped, never the merge's, so reinstatement
+    // stays intact. A false positive costs a round — the deploy stays in
+    // storage and in the buffer — so this is delay, never loss.
+    let user_deploys: HashSet<Signed<DeployData>> = {
+        let pre_state_hash =
+            rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash::from_bytes_prost(
+                &merge_pre_info.state,
+            );
+        let mut kept: HashSet<Signed<DeployData>> = HashSet::with_capacity(user_deploys.len());
+        let mut dropped: Vec<String> = Vec::new();
+        for deploy in user_deploys {
+            let already_applied = merge_pre_info.applied_from_scope.contains(&deploy.sig)
+                || interpreter_util::deploy_effect_in_state(
+                    &casper_snapshot.dag,
+                    block_store,
+                    runtime_manager,
+                    &pre_state_hash,
+                    &deploy.sig,
+                )?;
+            if already_applied {
+                dropped.push(hex::encode(&deploy.sig[..deploy.sig.len().min(8)]));
+            } else {
+                kept.insert(deploy);
+            }
+        }
+        if !dropped.is_empty() {
+            tracing::info!(
+                target: "f1r3fly.casper.recovery",
+                "Dropped {} selected deploy(s) from block #{}: their effects are already in the \
+                 pre-state this block executes against, so re-executing would double-apply; \
+                 sigs={:?}",
+                dropped.len(),
+                next_block_num,
+                dropped,
+            );
+        }
+        kept
+    };
+    let has_user_or_dummy_deploys = !user_deploys.is_empty() || !dummy_deploys.is_empty();
 
     // Union own slashes with merge-rejected slashes, dedup by
     // `invalid_block_hash`. Own detections take priority — any

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -563,11 +563,22 @@ pub fn merge(
     rejection_cost_f: impl Fn(&DeployChainIndex) -> u64,
     scope: Option<HashSet<BlockHash>>,
     disable_late_block_filtering: bool,
+    // True iff the sig's effect is already present in the BASE state. The
+    // dedup below seeds such sigs with an unbeatable freshest-copy
+    // sentinel so every scope copy drops: the settled copy lives in the
+    // base where scope-level dedup cannot see it, and without the seed the
+    // scope copy re-applies and doubles the deploy's cells.
+    sig_settled_in_base: &dyn Fn(&Bytes) -> Result<bool, CasperError>,
 ) -> Result<
     (
         Blake2b256Hash,
         Vec<(Bytes, BlockHash)>,
         Vec<(Bytes, BlockHash)>,
+        // User sigs whose chains this merge APPLIED from scope: their
+        // effects are in the returned state, so none of them may also be
+        // executed fresh on top of it. The merge is the only place this
+        // set is known.
+        HashSet<Bytes>,
     ),
     CasperError,
 > {
@@ -690,6 +701,10 @@ pub fn merge(
     // recovery path can re-propose them in a subsequent block.
     let mut collateral_lost_pairs: Vec<(Bytes, BlockHash)> = Vec::new();
 
+    // Memoized settled-in-base results, one probe per unique sig per merge.
+    let mut settled_checked: HashSet<Bytes> = HashSet::new();
+    let mut settled_sigs: HashSet<Bytes> = HashSet::new();
+
     // Deploy de-duplication. When the same deploy ID appears in chains from
     // multiple blocks in scope — for example, because a previously-rejected
     // deploy was re-proposed in a later block — keep the copy from the freshest
@@ -699,7 +714,34 @@ pub fn merge(
     // against a pre-state that the fresh execution replaces.
     if !actual_set_vec.is_empty() {
         // Find the freshest source for each deploy_id across all chains.
+        // A sig whose effect is already SETTLED IN THE BASE is seeded with
+        // an unbeatable sentinel: the base itself is the freshest "copy",
+        // so every scope copy is stale and its chain drops. The settled
+        // copy sits in the base where scope-level dedup cannot see it —
+        // without the seed the scope copy re-applies and doubles the
+        // per-deploy cells. (The sentinel hash is empty, which no real
+        // chain source can equal, so the retain below never keeps a
+        // settled copy and the collateral pass correctly treats settled
+        // sigs as not-lost.)
         let mut latest_for_deploy: HashMap<Bytes, (i64, BlockHash)> = HashMap::new();
+        for chain in &actual_set_vec {
+            for deploy in &chain.deploys_with_cost.0 {
+                if is_system_deploy_id(&deploy.deploy_id) {
+                    continue;
+                }
+                if settled_checked.insert(deploy.deploy_id.clone())
+                    && sig_settled_in_base(&deploy.deploy_id)?
+                {
+                    tracing::info!(
+                        "DagMerger dedup: sig {} already settled in the base; dropping all scope copies",
+                        hex::encode(&deploy.deploy_id[..8.min(deploy.deploy_id.len())]),
+                    );
+                    settled_sigs.insert(deploy.deploy_id.clone());
+                    latest_for_deploy
+                        .insert(deploy.deploy_id.clone(), (i64::MAX, BlockHash::new()));
+                }
+            }
+        }
         for chain in &actual_set_vec {
             for deploy in &chain.deploys_with_cost.0 {
                 let candidate = (chain.source_block_number, chain.source_block_hash.clone());
@@ -1463,6 +1505,19 @@ pub fn merge(
         }
     }
 
+    // The user sigs whose chains survived every rejection pass and are
+    // about to be APPLIED into the merged state. Returned to the caller:
+    // these effects are in the merged pre-state, so a deploy among them
+    // must not ALSO be executed fresh on top of it.
+    let applied_user_sigs: HashSet<Bytes> = resolved
+        .to_merge
+        .iter()
+        .flat_map(|branch| branch.0.iter())
+        .flat_map(|chain| chain.deploys_with_cost.0.iter())
+        .filter(|deploy| !is_system_deploy_id(&deploy.deploy_id))
+        .map(|deploy| deploy.deploy_id.clone())
+        .collect();
+
     // Channels where MORE THAN ONE accepted chain contributes datum adds:
     // only these can exhibit cross-writer accumulation, so only these are
     // subject to the base-empty single-value-cell overfill guard.
@@ -1589,7 +1644,12 @@ pub fn merge(
             n_rejected_slash = rejected_slashes.len());
     }
 
-    Ok((new_state, rejected_user_deploys, rejected_slashes))
+    Ok((
+        new_state,
+        rejected_user_deploys,
+        rejected_slashes,
+        applied_user_sigs,
+    ))
 }
 
 #[cfg(test)]

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -77,6 +77,100 @@ fn block_in_floor_merge_scope(
     Ok(!dag.is_dag_ancestor(hash, floor_hash)?)
 }
 
+/// True iff a deploy's SUCCESSFUL effect is already present in `base_state`
+/// — i.e. the deploy already executed in the lineage that state derives
+/// from. Applying (or re-executing) such a deploy again would double its
+/// per-deploy cells.
+///
+/// Signal: the deploy's own created number cells. Each carries a
+/// sig-derived rnd, so its channel NAME is unique to this deploy and stable
+/// across executions even when the VALUE is base-dependent — a match is
+/// false-positive-free even on shared channels. The check restricts to
+/// channels the deploy CREATED (absent in the executing block's pre-state);
+/// shared channels the pre-charge merely reads are excluded.
+///
+/// CONTRACT — the probe's blind spots, both deliberate:
+/// - A deploy that creates NO number cells is invisible here and always
+///   reads not-settled. Same-sig copies that meet in one merge scope are
+///   still deduped by the freshest-copy rule regardless; only a
+///   base-settled no-cell deploy re-entering via scope escapes both, and
+///   its duplicate effect is additive datums on multi-datum channels,
+///   never a single-value-cell violation.
+/// - A FAILED execution's created cells are not in any committed state, so
+///   the probe correctly reads not-settled: a failed run's charge landed
+///   but its effect did not, and re-execution is legitimate.
+pub(crate) fn deploy_effect_in_state(
+    dag: &KeyValueDagRepresentation,
+    block_store: &KeyValueBlockStore,
+    runtime_manager: &RuntimeManager,
+    base_state: &Blake2b256Hash,
+    sig: &Bytes,
+) -> Result<bool, CasperError> {
+    let Some(origin_hash) = dag
+        .lookup_by_deploy_id(&sig.to_vec())
+        .map_err(CasperError::KvStoreError)?
+    else {
+        return Ok(false);
+    };
+    let Some(origin) = block_store.get(&origin_hash)? else {
+        return Ok(false);
+    };
+    let Some(idx) = origin
+        .body
+        .deploys
+        .iter()
+        .position(|pd| pd.deploy.sig == *sig)
+    else {
+        return Ok(false);
+    };
+
+    let mergeable_chs = runtime_manager.load_mergeable_channels(
+        &origin.body.state.post_state_hash,
+        origin.sender.clone(),
+        origin.seq_num,
+    )?;
+    let Some(merge_chs) = mergeable_chs.get(idx) else {
+        return Ok(false);
+    };
+    if merge_chs.is_empty() {
+        return Ok(false);
+    }
+
+    let origin_pre = Blake2b256Hash::from_bytes_prost(&origin.body.state.pre_state_hash);
+    let origin_pre_reader = runtime_manager
+        .history_repo
+        .get_history_reader(&origin_pre)
+        .map_err(CasperError::HistoryError)?;
+    let base_reader = runtime_manager
+        .history_repo
+        .get_history_reader(base_state)
+        .map_err(CasperError::HistoryError)?;
+    for (ch, _) in merge_chs.iter() {
+        let created_by_deploy = origin_pre_reader
+            .get_data(ch)
+            .map_err(CasperError::HistoryError)?
+            .is_empty();
+        if !created_by_deploy {
+            continue;
+        }
+        let in_base = !base_reader
+            .get_data(ch)
+            .map_err(CasperError::HistoryError)?
+            .is_empty();
+        tracing::debug!(
+            target: "f1r3.trace.basecheck",
+            sig = %hex::encode(&sig[..sig.len().min(8)]),
+            channel = %hex::encode(&ch.bytes()[..6]),
+            in_base,
+            "base-check per-deploy created cell"
+        );
+        if in_base {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// BFS-walk the closure of `parents` down to `earliest_block_number`,
 /// returning each sig's latest disposition as `sig -> (height, won)`.
 /// A win and a rejection never share a height (a merge sits one block above
@@ -430,15 +524,18 @@ pub async fn validate_block_checkpoint(
     );
 
     match computed_parents_info {
-        Ok((computed_pre_state_hash, rejected_deploys, _rejected_slashes)) => {
+        Ok(merged) => {
+            let computed_pre_state_hash = merged.state.clone();
             let block_deploy_sigs: HashSet<_> = block
                 .body
                 .deploys
                 .iter()
                 .map(|pd| pd.deploy.sig.clone())
                 .collect();
-            let rejected_deploy_ids: HashSet<_> = rejected_deploys
+            let rejected_deploy_ids: HashSet<_> = merged
+                .rejected_user
                 .iter()
+                .map(|(sig, _)| sig)
                 .filter(|sig| !block_deploy_sigs.contains(*sig))
                 .cloned()
                 .collect();
@@ -810,7 +907,12 @@ pub async fn compute_deploys_checkpoint(
     )
     .await?;
     let parents_ms = parents_started.elapsed().as_millis();
-    let (pre_state_hash, rejected_deploys, _rejected_slashes) = computed_parents_info;
+    let pre_state_hash = computed_parents_info.state.clone();
+    let rejected_deploys: Vec<prost::bytes::Bytes> = computed_parents_info
+        .rejected_user
+        .iter()
+        .map(|(sig, _)| sig.clone())
+        .collect();
 
     // Compute state and bonds using one spawned runtime
     let compute_state_started = std::time::Instant::now();
@@ -948,14 +1050,8 @@ pub async fn compute_parents_post_state(
     latest_messages: &BTreeMap<Validator, BlockHash>,
     disable_late_block_filtering_override: Option<bool>,
     rejected_deploy_buffer: Option<&std::sync::Arc<std::sync::Mutex<block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer>>>,
-) -> Result<
-    (
-        StateHash,
-        Vec<Bytes>,
-        Vec<crate::rust::merging::rejected_slash::RejectedSlash>,
-    ),
-    CasperError,
-> {
+) -> Result<super::runtime_manager::MergedPreState, CasperError> {
+    use super::runtime_manager::MergedPreState;
     let total_started = std::time::Instant::now();
 
     // No entered span guard here: the function is async (it awaits floor
@@ -984,7 +1080,13 @@ pub async fn compute_parents_post_state(
                 post_state = %hex::encode(&state[..8.min(state.len())]),
                 "merge.step: exit compute_parents_post_state"
             );
-            Ok((state, Vec::new(), Vec::new()))
+            Ok(MergedPreState {
+                state,
+                rejected_user: Vec::new(),
+                rejected_slashes: Vec::new(),
+                applied_from_scope: HashSet::new(),
+                merge_base: None,
+            })
         }
 
         // For single parent, get its post state hash
@@ -1003,7 +1105,13 @@ pub async fn compute_parents_post_state(
                 post_state = %hex::encode(&state[..8.min(state.len())]),
                 "merge.step: exit compute_parents_post_state"
             );
-            Ok((state, Vec::new(), Vec::new()))
+            Ok(MergedPreState {
+                state,
+                rejected_user: Vec::new(),
+                rejected_slashes: Vec::new(),
+                applied_from_scope: HashSet::new(),
+                merge_base: None,
+            })
         }
 
         // Multiple parents - we might want to take some data from the parent with the most stake,
@@ -1048,7 +1156,13 @@ pub async fn compute_parents_post_state(
                         post_state = %hex::encode(&state[..8.min(state.len())]),
                         "merge.step: exit compute_parents_post_state"
                     );
-                    return Ok((state, Vec::new(), Vec::new()));
+                    return Ok(MergedPreState {
+                        state,
+                        rejected_user: Vec::new(),
+                        rejected_slashes: Vec::new(),
+                        applied_from_scope: HashSet::new(),
+                        merge_base: None,
+                    });
                 }
             }
 
@@ -1067,15 +1181,13 @@ pub async fn compute_parents_post_state(
                     .collect(),
                 disable_late_block_filtering,
             };
-            if let Some((cached_state, cached_rejected, cached_slashes)) =
-                runtime_manager.get_cached_parents_post_state(&cache_key)
-            {
+            if let Some(cached) = runtime_manager.get_cached_parents_post_state(&cache_key) {
                 tracing::debug!(
                     target: "f1r3fly.casper.compute_parents_post_state.cache",
                     "compute_parents_post_state cache hit: parents={}, rejected_deploys={}, rejected_slashes={}",
                     cache_key.sorted_parent_hashes.len(),
-                    cached_rejected.len(),
-                    cached_slashes.len()
+                    cached.rejected_user.len(),
+                    cached.rejected_slashes.len()
                 );
                 tracing::debug!(
                     target: "f1r3fly.casper.compute_parents_post_state.timing",
@@ -1088,12 +1200,12 @@ pub async fn compute_parents_post_state(
                     target: "f1r3fly.merge.step",
                     step = "compute_parents_post_state.CACHE_SKIP",
                     path = "cache_hit",
-                    post_state = %hex::encode(&cached_state[..8.min(cached_state.len())]),
-                    n_rejected = cached_rejected.len(),
-                    n_rejected_slash = cached_slashes.len(),
+                    post_state = %hex::encode(&cached.state[..8.min(cached.state.len())]),
+                    n_rejected = cached.rejected_user.len(),
+                    n_rejected_slash = cached.rejected_slashes.len(),
                     "merge.step: cache hit, merge skipped"
                 );
-                return Ok((cached_state, cached_rejected, cached_slashes));
+                return Ok(cached);
             }
             let cache_lookup_ms = cache_lookup_started.elapsed().as_millis();
 
@@ -1359,6 +1471,14 @@ pub async fn compute_parents_post_state(
                 "merge.step: dag_merger::merge begin"
             );
             let merge_started = std::time::Instant::now();
+            // Settled-sig probe for the merge dedup: a sig whose effect is
+            // already in the base's committed state has no legitimate scope
+            // copy — every one is a stale duplicate no rejection record
+            // covers. Memoization lives inside the merge (one probe per
+            // unique sig per merge call).
+            let sig_settled_in_base = |sig: &Bytes| -> Result<bool, CasperError> {
+                deploy_effect_in_state(&s.dag, block_store, runtime_manager, &floor_state, sig)
+            };
             let merger_result = dag_merger::merge(
                 &s.dag,
                 &floor_hash,
@@ -1371,10 +1491,12 @@ pub async fn compute_parents_post_state(
                 dag_merger::cost_optimal_rejection_alg(),
                 Some(visible_blocks.clone()),
                 disable_late_block_filtering,
+                &sig_settled_in_base,
             )?;
             let merge_ms = merge_started.elapsed().as_millis();
 
-            let (state, mut rejected_user_pairs, rejected_slash_pairs) = merger_result;
+            let (state, mut rejected_user_pairs, rejected_slash_pairs, applied_user_sigs) =
+                merger_result;
             let suppressed = suppress_rejected_pairs_with_later_visible_rejection(
                 block_store,
                 &visible_blocks,
@@ -1558,13 +1680,14 @@ pub async fn compute_parents_post_state(
                     out
                 };
 
-            // Strip block hashes; the cache and callers only need the deploy sigs.
-            let rejected: Vec<Bytes> = rejected_user_pairs
-                .into_iter()
-                .map(|(sig, _)| sig)
-                .collect();
-
             let computed_state = prost::bytes::Bytes::copy_from_slice(&state.bytes());
+            let merged = MergedPreState {
+                state: computed_state.clone(),
+                rejected_user: rejected_user_pairs,
+                rejected_slashes,
+                applied_from_scope: applied_user_sigs,
+                merge_base: Some(floor_hash.clone()),
+            };
             // The floor is a deterministic function of the block's justifications,
             // so the merged state is always cacheable (no snapshot-LFB fallback).
             tracing::debug!(
@@ -1572,18 +1695,12 @@ pub async fn compute_parents_post_state(
                 step = "compute_parents_post_state.CACHE_PUT",
                 path = "merged",
                 post_state = %hex::encode(&computed_state[..8.min(computed_state.len())]),
-                n_rejected = rejected.len(),
-                n_rejected_slash = rejected_slashes.len(),
+                n_rejected = merged.rejected_user.len(),
+                n_rejected_slash = merged.rejected_slashes.len(),
+                n_applied = merged.applied_from_scope.len(),
                 "merge.step: cache put merged parents-post-state"
             );
-            runtime_manager.put_cached_parents_post_state(
-                cache_key,
-                (
-                    computed_state.clone(),
-                    rejected.clone(),
-                    rejected_slashes.clone(),
-                ),
-            );
+            runtime_manager.put_cached_parents_post_state(cache_key, merged.clone());
             tracing::debug!(
                 target: "f1r3fly.casper.compute_parents_post_state.timing",
                 "compute_parents_post_state timing: path=merged, parents={}, cache_lookup_ms={}, collect_ancestors_ms={}, flatten_visible_ms={}, floor_derive_ms={}, merge_ms={}, visible_blocks={}, rejected_deploys={}, rejected_slashes={}, total_ms={}",
@@ -1594,8 +1711,8 @@ pub async fn compute_parents_post_state(
                 floor_derive_ms,
                 merge_ms,
                 visible_blocks_len,
-                rejected.len(),
-                rejected_slashes.len(),
+                merged.rejected_user.len(),
+                merged.rejected_slashes.len(),
                 total_started.elapsed().as_millis()
             );
             tracing::debug!(
@@ -1603,11 +1720,11 @@ pub async fn compute_parents_post_state(
                 step = "compute_parents_post_state.EXIT",
                 path = "merged",
                 post_state = %hex::encode(&computed_state[..8.min(computed_state.len())]),
-                n_rejected = rejected.len(),
-                n_rejected_slash = rejected_slashes.len(),
+                n_rejected = merged.rejected_user.len(),
+                n_rejected_slash = merged.rejected_slashes.len(),
                 "merge.step: exit compute_parents_post_state"
             );
-            Ok((computed_state, rejected, rejected_slashes))
+            Ok(merged)
         }
     }
 }

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -100,11 +100,31 @@ pub struct ParentsPostStateCacheKey {
     pub disable_late_block_filtering: bool,
 }
 
-pub type ParentsPostStateCacheVal = (
-    StateHash,
-    Vec<prost::bytes::Bytes>,
-    Vec<crate::rust::merging::rejected_slash::RejectedSlash>,
-);
+/// The merged pre-state a block builds on, with every fact the merge
+/// derived alongside it. One struct through the derivation, the
+/// parents-post-state cache, and the checkpoint path — the facts travel
+/// together or not at all: a consumer holding the state without the
+/// applied set cannot tell which deploys' effects that state already
+/// contains, and executing one of them again double-applies it.
+#[derive(Clone, Debug)]
+pub struct MergedPreState {
+    pub state: StateHash,
+    /// Rejected user deploys as (sig, carrier) — the carrier is the source
+    /// block whose copy the merge adjudicated.
+    pub rejected_user: Vec<(prost::bytes::Bytes, BlockHash)>,
+    pub rejected_slashes: Vec<crate::rust::merging::rejected_slash::RejectedSlash>,
+    /// User sigs whose chains the merge APPLIED from scope: their effects
+    /// are in `state`, so executing any of them on top would double-apply.
+    /// Empty on the non-merging shapes (genesis, single parent, covering
+    /// parent), where effects arrive via a parent's post-state instead.
+    pub applied_from_scope: std::collections::HashSet<prost::bytes::Bytes>,
+    /// The block whose committed state `state` derives from: the floor for
+    /// the merged path; `None` where the header already determines it
+    /// (genesis, single parent, covering parent).
+    pub merge_base: Option<BlockHash>,
+}
+
+pub type ParentsPostStateCacheVal = MergedPreState;
 
 impl RuntimeManager {
     const MAX_BLOCK_INDEX_CACHE_ENTRIES: usize = 128;

--- a/casper/tests/batch2/dedup_orphan_recovery_spec.rs
+++ b/casper/tests/batch2/dedup_orphan_recovery_spec.rs
@@ -321,7 +321,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (_merged_state, rejected_sigs, rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         vec![block_a.clone(), block_b.clone()],
         &snapshot,
@@ -334,13 +334,17 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
     .expect("compute_parents_post_state over [block_a, block_b]");
 
     assert!(
-        rejected_slashes.is_empty(),
+        merged.rejected_slashes.is_empty(),
         "no system slashes are involved in this fixture; rejected_slashes \
          must be empty (got {} entries)",
-        rejected_slashes.len()
+        merged.rejected_slashes.len()
     );
 
-    let rejected_set: HashSet<prost::bytes::Bytes> = rejected_sigs.iter().cloned().collect();
+    let rejected_set: HashSet<prost::bytes::Bytes> = merged
+        .rejected_user
+        .iter()
+        .map(|(sig, _)| sig.clone())
+        .collect();
     let v_orphaned = rejected_set.contains(&sig_v);
     let w_orphaned = rejected_set.contains(&sig_w);
     assert!(
@@ -353,7 +357,11 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
          lines ~563-573) is not reaching the merge output",
         v_orphaned,
         w_orphaned,
-        rejected_sigs
+        merged
+            .rejected_user
+            .iter()
+            .map(|(sig, _)| sig.clone())
+            .collect::<Vec<_>>()
             .iter()
             .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
             .collect::<Vec<_>>()

--- a/casper/tests/batch2/exactly_once_spec.rs
+++ b/casper/tests/batch2/exactly_once_spec.rs
@@ -1,0 +1,529 @@
+// Exactly-once at the merge: one signature, one effect, in every committed
+// state.
+//
+// Two reds, one per delivery mechanism of the duplicate:
+//
+// 1. SIBLING COPIES ACROSS THE BASE/SCOPE BOUNDARY — the majority-stake
+//    validator's copy becomes the merge base (instant self-witness floor),
+//    the other copy arrives in scope, and freshest-copy dedup never sees a
+//    pair because it only compares scope chains. Both effects land.
+//
+// 2. REINSTATED EFFECT PLUS FRESH RE-EXECUTION — a merge re-applies a
+//    rejected chain from scope (reinstatement, invisible to the
+//    deploys-in-scope walk because the effect travels as diffs, not as a
+//    body deploy), and the retry path re-selects the same deploy from the
+//    proposer's stores (the rejected-in-scope exemption bypasses the scope
+//    filter). The block executes a deploy whose effect is already in its
+//    own pre-state.
+//
+// Both were verified in production runs (two-datum single-value cells,
+// `[0, 0]` twin initializations, the refund-failure quarantine destroying
+// the deploy). The fix under test: the settled-in-base dedup sentinel in
+// the merger and the never-execute-what-the-pre-state-has guard in the
+// block creator.
+
+use casper::rust::blocks::proposer::block_creator;
+use casper::rust::blocks::proposer::propose_result::BlockCreatorResult;
+use casper::rust::casper::{Casper, MultiParentCasper};
+use casper::rust::finality::floor::floor_of_block;
+use casper::rust::safety::clique_oracle::FtThreshold;
+use casper::rust::util::construct_deploy;
+use models::rhoapi::expr::ExprInstance;
+use models::rhoapi::{Expr, Par};
+use models::rust::casper::protocol::casper_message::BlockMessage;
+use prost::bytes::Bytes;
+use serial_test::serial;
+
+use crate::helper::test_node::TestNode;
+use crate::util::genesis_builder::GenesisBuilder;
+
+fn rejected_sigs(block: &BlockMessage) -> Vec<Bytes> {
+    block
+        .body
+        .rejected_deploys
+        .iter()
+        .map(|rd| rd.sig.clone())
+        .collect()
+}
+
+fn short(sig: &Bytes) -> String { hex::encode(&sig[..8.min(sig.len())]) }
+
+async fn three_node_network() -> (Vec<TestNode>, String) {
+    let n_validators = 3usize;
+    let genesis_parameters =
+        GenesisBuilder::build_genesis_parameters_with_defaults(None, Some(n_validators));
+    let genesis = GenesisBuilder::new()
+        .build_genesis_with_parameters(Some(genesis_parameters))
+        .await
+        .unwrap();
+    let shard_id = genesis.genesis_block.shard_id.clone();
+    let mut nodes = TestNode::create_network(genesis, n_validators, None, None, None, None)
+        .await
+        .expect("create_network");
+    for node in nodes.iter_mut() {
+        node.allow_empty_blocks = true;
+    }
+    (nodes, shard_id)
+}
+
+/// Every datum currently on `@"<name>"` at `state_hash`, decoded to string
+/// payloads. The exactly-once assert is a datum COUNT on these cells.
+async fn string_datums(node: &TestNode, state_hash: &Bytes, name: &str) -> Vec<String> {
+    let channel = Par {
+        exprs: vec![Expr {
+            expr_instance: Some(ExprInstance::GString(name.to_string())),
+        }],
+        ..Default::default()
+    };
+    node.runtime_manager
+        .get_data(state_hash.clone(), &channel)
+        .await
+        .unwrap_or_else(|e| panic!("get_data @\"{}\": {:?}", name, e))
+        .iter()
+        .map(
+            |par| match par.exprs.first().and_then(|e| e.expr_instance.clone()) {
+                Some(ExprInstance::GString(s)) => s,
+                other => format!("<non-string datum: {:?}>", other),
+            },
+        )
+        .collect()
+}
+
+/// True iff `hash` is the floor of `tip` or one of that floor's DAG
+/// ancestors, per this node's DAG.
+async fn floor_covers(node: &TestNode, tip: &Bytes, hash: &Bytes, height: i64) -> bool {
+    let dag = node.casper.block_dag().await.expect("dag representation");
+    let floor = floor_of_block(&dag, tip, FtThreshold::from_f32_lossy(0.0))
+        .await
+        .expect("floor_of_block");
+    if floor.hash == *hash {
+        return true;
+    }
+    floor.block_number >= height
+        && dag
+            .is_dag_ancestor(hash, &floor.hash)
+            .expect("is_dag_ancestor")
+}
+
+/// RED 1: two SIBLING inclusions of one signature, no rejection record
+/// anywhere. The majority-stake validator's copy becomes the floor of the
+/// reconciling merge (instant self-witness), so its copy arrives via the
+/// BASE while only the other copy is in scope — freshest-copy dedup never
+/// sees a pair (it only compares scope chains against each other). The
+/// settled-in-base sentinel must drop the scope copy. One signature, one
+/// effect.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn duplicate_sibling_inclusions_must_reconcile_to_one_effect() {
+    let (mut nodes, shard_id) = three_node_network().await;
+
+    let dup_deploy = construct_deploy::source_deploy_now_full(
+        r#"@"X3"!("once")"#.to_string(),
+        None,
+        None,
+        Some(construct_deploy::DEFAULT_SEC.clone()),
+        Some(0),
+        Some(shard_id.clone()),
+    )
+    .expect("build duplicate deploy");
+
+    // Copy in C (nodes[2], height 1) and copy in A (nodes[0], height 2 —
+    // above a spacer so the copies sit at distinct heights and dedup's
+    // freshest-wins ordering is deterministic).
+    let c_block = nodes[2]
+        .add_block_from_deploys(std::slice::from_ref(&dup_deploy))
+        .await
+        .expect("sibling C");
+    let s0 = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        let spacer = construct_deploy::basic_deploy_data(
+            0,
+            Some(construct_deploy::DEFAULT_SEC2.clone()),
+            Some(shard_id.clone()),
+        )
+        .expect("spacer");
+        nodes[0]
+            .add_block_from_deploys(std::slice::from_ref(&spacer))
+            .await
+            .expect("spacer S0")
+    };
+    let a_block = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&dup_deploy))
+        .await
+        .expect("sibling A");
+
+    // The reconciling merge (nodes[1]).
+    for block in [&c_block, &s0, &a_block] {
+        nodes[1]
+            .process_block((*block).clone())
+            .await
+            .expect("nodes[1] processes the siblings");
+    }
+    let marker = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(
+            1,
+            Some(construct_deploy::DEFAULT_SEC2.clone()),
+            Some(shard_id.clone()),
+        )
+        .expect("merge marker")
+    };
+    let m_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&marker))
+        .await
+        .expect("reconciling merge M");
+    assert!(
+        m_block
+            .header
+            .parents_hash_list
+            .contains(&a_block.block_hash)
+            && m_block
+                .header
+                .parents_hash_list
+                .contains(&c_block.block_hash),
+        "M must merge both sibling carriers; parents={:?}",
+        m_block
+            .header
+            .parents_hash_list
+            .iter()
+            .map(|h| hex::encode(&h[..4.min(h.len())]))
+            .collect::<Vec<_>>()
+    );
+
+    // THE RED: one signature, one effect — however the merge reconciles
+    // (settled-in-base drop or rejection-with-record), the merged state
+    // must hold exactly one datum.
+    let x3_at_m = string_datums(&nodes[1], &m_block.body.state.post_state_hash, "X3").await;
+    assert_eq!(
+        x3_at_m.len(),
+        1,
+        "DUPLICATE CO-MERGE: @\"X3\" holds {} datums after the merge that \
+         should reconcile two sibling copies of one signature (datums: \
+         {:?}; rejected: {:?})",
+        x3_at_m.len(),
+        x3_at_m,
+        rejected_sigs(&m_block)
+            .iter()
+            .map(short)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// RED 2: a reinstated effect must not be executed again by the block that
+/// inherits it.
+///
+/// Staging walks the two verified return paths into one block:
+/// - contest on nodes[0]/nodes[1]; the adjudicating merge M rejects one
+///   contender with a record;
+/// - nodes[2] (majority stake, no record in view) merges the loser's
+///   carrier: the loser's chain is APPLIED FROM SCOPE (reinstatement). The
+///   effect now travels as merge diffs — invisible to the
+///   deploys-in-scope body walk;
+/// - nodes[2]'s floor advances over the carrier (self-witness spacers,
+///   verified per round — staging precondition, not assumed);
+/// - the record side (winner + M) is delivered, and the loser is placed in
+///   nodes[2]'s stores the way the recovery plane does (deploy storage +
+///   rejected buffer); the rejected-in-scope exemption then re-admits it
+///   through selection.
+///
+/// The proposal is driven through `block_creator::create` on the FULL
+/// frontier (own tip + the record branch). Going through the node's own
+/// snapshot instead cannot stage the geometry: parent narrowing collapses
+/// the frontier to a single parent whenever a record is in candidate
+/// scope, so the record branch never enters scope and selection filters
+/// the retry. Narrowing only serializes one node's own proposals — any
+/// validator without the narrowing trigger active legally mints the
+/// widened block from the same view, which is the block this call
+/// constructs. The scope sets are hand-extended to their true
+/// widened-frontier values (the record is visible from these parents),
+/// which is what re-admits the retry through the rejected-in-scope
+/// exemption.
+///
+/// Without the pre-state guard the created block executes the deploy
+/// twice: the witness cell holds two datums in its committed post-state.
+/// With the guard the fresh copy is dropped and the effect appears exactly
+/// once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn reinstated_effect_must_not_be_executed_again() {
+    let (mut nodes, shard_id) = three_node_network().await;
+
+    // Seed the contended cell (nodes[1]); nodes[0] and nodes[2] process it.
+    let seed = construct_deploy::source_deploy_now_full(
+        r#"@"race"!("s")"#.to_string(),
+        None,
+        None,
+        Some(construct_deploy::DEFAULT_SEC2.clone()),
+        Some(0),
+        Some(shard_id.clone()),
+    )
+    .expect("build seed");
+    let s_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&seed))
+        .await
+        .expect("seed block S");
+    for i in [0usize, 2usize] {
+        nodes[i]
+            .process_block(s_block.clone())
+            .await
+            .expect("process S");
+    }
+
+    // nodes[2]'s neutral branch off S FIRST, so its later merge takes the
+    // loser's chain via SCOPE (not spine inheritance).
+    let _n1 = nodes[2]
+        .add_block_from_deploys(std::slice::from_ref(
+            &construct_deploy::basic_deploy_data(
+                100,
+                Some(construct_deploy::DEFAULT_SEC2.clone()),
+                Some(shard_id.clone()),
+            )
+            .expect("neutral spacer"),
+        ))
+        .await
+        .expect("neutral branch N1 on nodes[2]");
+
+    // Contenders: both consume the seed (genuine conflict), both write a
+    // witness cell, and both CREATE a number cell (`new c in { c!(0) }`) so
+    // the deploy's effect is visible to the created-cell state probe.
+    let contender_d = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"for (@v <- @"race") { @"race"!("d") | @"XD"!(v) | new c in { c!(0) } }"#.to_string(),
+            None,
+            None,
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            Some(0),
+            Some(shard_id.clone()),
+        )
+        .expect("build contender d")
+    };
+    let contender_f = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"for (@v <- @"race") { @"race"!("f") | @"XF"!(v) | new c in { c!(0) } }"#.to_string(),
+            None,
+            None,
+            Some(
+                crate::util::genesis_builder::EXTRA_GENESIS_VAULT_KEY_PAIRS[0]
+                    .0
+                    .clone(),
+            ),
+            None,
+            Some(shard_id.clone()),
+        )
+        .expect("build contender f")
+    };
+    let d_sig: Bytes = contender_d.sig.clone();
+    let f_sig: Bytes = contender_f.sig.clone();
+    let c_block = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&contender_d))
+        .await
+        .expect("block C with d");
+    let a_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&contender_f))
+        .await
+        .expect("block A with f");
+
+    // Adjudicating merge M on nodes[1].
+    nodes[1]
+        .process_block(c_block.clone())
+        .await
+        .expect("nodes[1] processes C");
+    let m_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(
+            &construct_deploy::basic_deploy_data(
+                101,
+                Some(construct_deploy::DEFAULT_SEC2.clone()),
+                Some(shard_id.clone()),
+            )
+            .expect("m marker"),
+        ))
+        .await
+        .expect("adjudicating merge M");
+    let m_rejected = rejected_sigs(&m_block);
+    let d_lost = m_rejected.contains(&d_sig);
+    let f_lost = m_rejected.contains(&f_sig);
+    assert!(
+        d_lost ^ f_lost,
+        "exactly one contender must be rejected at M (rejected: {:?})",
+        m_rejected.iter().map(short).collect::<Vec<_>>(),
+    );
+    let (loser_sig, loser_cell, carrier, loser_deploy, winner_block) = if d_lost {
+        (
+            d_sig.clone(),
+            "XD",
+            c_block.clone(),
+            contender_d,
+            a_block.clone(),
+        )
+    } else {
+        (
+            f_sig.clone(),
+            "XF",
+            a_block.clone(),
+            contender_f,
+            c_block.clone(),
+        )
+    };
+
+    // THE REINSTATEMENT: nodes[2] sees only S, N1, and the loser's carrier
+    // — no record. Its merge applies the loser's chain from scope.
+    nodes[2]
+        .process_block(carrier.clone())
+        .await
+        .expect("nodes[2] processes the loser's carrier only");
+    let x_block = nodes[2]
+        .add_block_from_deploys(std::slice::from_ref(
+            &construct_deploy::basic_deploy_data(
+                102,
+                Some(construct_deploy::DEFAULT_SEC2.clone()),
+                Some(shard_id.clone()),
+            )
+            .expect("x marker"),
+        ))
+        .await
+        .expect("reinstating merge X on nodes[2]");
+    assert!(
+        !rejected_sigs(&x_block).contains(&loser_sig),
+        "X must not reject the loser (no record in view)"
+    );
+    let x_live = !string_datums(&nodes[2], &x_block.body.state.post_state_hash, loser_cell)
+        .await
+        .is_empty();
+    assert!(
+        x_live,
+        "the reinstating merge X must carry the loser's effect in its \
+         post-state (applied from scope)"
+    );
+
+    // Advance nodes[2]'s floor over the carrier so the reinstated content
+    // sits below the base of its next merge. Verified per round.
+    let carrier_height = carrier.body.state.block_number;
+    let mut covered = false;
+    let mut last_spacer: Option<BlockMessage> = None;
+    for round in 0..30i32 {
+        let b = nodes[2]
+            .add_block_from_deploys(std::slice::from_ref(
+                &construct_deploy::basic_deploy_data(
+                    110 + round,
+                    Some(construct_deploy::DEFAULT_SEC2.clone()),
+                    Some(shard_id.clone()),
+                )
+                .expect("floor spacer"),
+            ))
+            .await
+            .expect("floor spacer block");
+        last_spacer = Some(b.clone());
+        if floor_covers(
+            &nodes[2],
+            &b.block_hash,
+            &carrier.block_hash,
+            carrier_height,
+        )
+        .await
+        {
+            covered = true;
+            break;
+        }
+    }
+    assert!(
+        covered,
+        "staging precondition: nodes[2]'s floor must come to cover the \
+         loser's carrier within the spacer rounds"
+    );
+    let _ = last_spacer;
+
+    // The record side arrives: winner branch and M. nodes[2]'s next
+    // proposal will merge its own lineage with the record branch.
+    for b in [&winner_block, &m_block] {
+        nodes[2]
+            .process_block((*b).clone())
+            .await
+            .expect("nodes[2] ingests the record side");
+    }
+
+    // The recovery plane returns the loser to nodes[2]'s stores (the
+    // verified return routes are several — validate-side populate, owner
+    // retry, client resubmission; the seam models their common endpoint).
+    nodes[2]
+        .deploy_storage
+        .lock()
+        .add(vec![loser_deploy.clone()])
+        .expect("inject loser into deploy storage");
+    nodes[2]
+        .rejected_deploy_buffer
+        .lock()
+        .expect("buffer lock")
+        .add(vec![loser_deploy])
+        .expect("inject loser into rejected buffer");
+
+    // Drive the proposal through `create` on the FULL frontier: nodes[2]'s
+    // own tip plus the record branch — the block any non-narrowed proposer
+    // would mint from this view. The scope sets get their true
+    // widened-frontier values: the record is visible from these parents,
+    // which re-admits the buffered retry through the rejected-in-scope
+    // exemption.
+    let mut snapshot = nodes[2]
+        .casper
+        .get_snapshot()
+        .await
+        .expect("nodes[2] snapshot");
+    if !snapshot
+        .parents
+        .iter()
+        .any(|p| p.block_hash == m_block.block_hash)
+    {
+        snapshot.parents.push(m_block.clone());
+    }
+    snapshot.rejected_in_scope.insert(loser_sig.clone());
+    snapshot.deploys_in_scope.insert(loser_sig.clone());
+
+    let validator_identity = nodes[2]
+        .validator_id_opt
+        .clone()
+        .expect("nodes[2] validator identity");
+    let deploy_storage = nodes[2].deploy_storage.clone();
+    let rejected_buffer = nodes[2].rejected_deploy_buffer.clone();
+    let runtime_manager = nodes[2].runtime_manager.clone();
+    let created = block_creator::create(
+        &snapshot,
+        &validator_identity,
+        None,
+        deploy_storage,
+        rejected_buffer,
+        &runtime_manager,
+        &mut nodes[2].block_store,
+        true,
+    )
+    .await
+    .expect("create proposal B on the full frontier");
+    let BlockCreatorResult::Created(b_block, _pre, b_post) = created else {
+        panic!("create must mint a block on the full frontier; got a non-Created result");
+    };
+
+    // THE RED: the loser's witness cell must hold EXACTLY ONE datum in B's
+    // committed post-state. Two datums = the same signature executed twice
+    // into one state (the verified [0,0] twin-initialization class).
+    let witness = string_datums(&nodes[2], &b_post, loser_cell).await;
+    assert_eq!(
+        witness.len(),
+        1,
+        "DOUBLE EXECUTION: @\"{}\" holds {} datums in B's post-state — the \
+         reinstated effect was in B's pre-state and the block executed the \
+         deploy again (datums: {:?}; B carries loser fresh: {}; B rejected: \
+         {:?})",
+        loser_cell,
+        witness.len(),
+        witness,
+        b_block
+            .body
+            .deploys
+            .iter()
+            .any(|pd| pd.deploy.sig == loser_sig),
+        rejected_sigs(&b_block)
+            .iter()
+            .map(short)
+            .collect::<Vec<_>>(),
+    );
+}

--- a/casper/tests/batch2/mod.rs
+++ b/casper/tests/batch2/mod.rs
@@ -1,6 +1,7 @@
 pub mod clique_oracle_test;
 pub mod dedup_orphan_recovery_spec;
 pub mod estimator_test;
+pub mod exactly_once_spec;
 pub mod finalized_win_pending_rejection_spec;
 pub mod finalizer_test;
 pub mod limited_parent_depth_spec;

--- a/casper/tests/batch2/multi_validator_recovery_spec.rs
+++ b/casper/tests/batch2/multi_validator_recovery_spec.rs
@@ -316,7 +316,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (_merged_state, rejected_sigs, rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         vec![r0.clone(), r1.clone()],
         &snapshot,
@@ -329,13 +329,17 @@ for(@_v <- @"multi-validator-shared") { Nil }
     .expect("compute_parents_post_state over [R0, R1]");
 
     assert!(
-        rejected_slashes.is_empty(),
+        merged.rejected_slashes.is_empty(),
         "no system slashes are involved in this fixture; rejected_slashes \
          must be empty (got {} entries)",
-        rejected_slashes.len()
+        merged.rejected_slashes.len()
     );
 
-    let rejected_set: HashSet<prost::bytes::Bytes> = rejected_sigs.iter().cloned().collect();
+    let rejected_set: HashSet<prost::bytes::Bytes> = merged
+        .rejected_user
+        .iter()
+        .map(|(sig, _)| sig.clone())
+        .collect();
 
     // Dedup must keep the shared recovered sig out of the rejected
     // list. If it appears here, dedup did not run and conflict
@@ -345,7 +349,11 @@ for(@_v <- @"multi-validator-shared") { Nil }
     assert!(
         !rejected_set.contains(&sig_x),
         "sig_x must NOT appear in `rejected_user_deploys`. Got: {:?}",
-        rejected_sigs
+        merged
+            .rejected_user
+            .iter()
+            .map(|(sig, _)| sig.clone())
+            .collect::<Vec<_>>()
             .iter()
             .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
             .collect::<Vec<_>>()
@@ -369,7 +377,11 @@ for(@_v <- @"multi-validator-shared") { Nil }
          fire, dedup did not retain a winning chain.",
         v0_orphaned,
         v1_orphaned,
-        rejected_sigs
+        merged
+            .rejected_user
+            .iter()
+            .map(|(sig, _)| sig.clone())
+            .collect::<Vec<_>>()
             .iter()
             .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
             .collect::<Vec<_>>()

--- a/casper/tests/batch2/slash_recovery_spec.rs
+++ b/casper/tests/batch2/slash_recovery_spec.rs
@@ -535,18 +535,17 @@ async fn e1c_re_issues_merge_rejected_slash() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (merged_state, merged_rejected, _) =
-        casper::rust::util::rholang::interpreter_util::compute_parents_post_state(
-            &nodes[1].block_store,
-            snapshot.parents.clone(),
-            &snapshot,
-            &nodes[1].runtime_manager,
-            &latest_messages,
-            None,
-            Some(&nodes[1].rejected_deploy_buffer),
-        )
-        .await
-        .expect("real merge to seed cache value");
+    let mut merged = casper::rust::util::rholang::interpreter_util::compute_parents_post_state(
+        &nodes[1].block_store,
+        snapshot.parents.clone(),
+        &snapshot,
+        &nodes[1].runtime_manager,
+        &latest_messages,
+        None,
+        Some(&nodes[1].rejected_deploy_buffer),
+    )
+    .await
+    .expect("real merge to seed cache value");
 
     let synthetic = RejectedSlash {
         invalid_block_hash: invalid_block.block_hash.clone(),
@@ -555,7 +554,10 @@ async fn e1c_re_issues_merge_rejected_slash() {
     };
     nodes[1]
         .runtime_manager
-        .put_cached_parents_post_state(cache_key, (merged_state, merged_rejected, vec![synthetic]));
+        .put_cached_parents_post_state(cache_key, {
+            merged.rejected_slashes = vec![synthetic];
+            merged
+        });
     drop(snapshot);
 
     // Propose. A user deploy keeps `create_block` from short-circuiting
@@ -717,18 +719,17 @@ async fn rejected_slash_recovery_keeps_empty_proposer_alive() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (merged_state, merged_rejected, _) =
-        casper::rust::util::rholang::interpreter_util::compute_parents_post_state(
-            &nodes[1].block_store,
-            snapshot.parents.clone(),
-            &snapshot,
-            &nodes[1].runtime_manager,
-            &latest_messages,
-            None,
-            Some(&nodes[1].rejected_deploy_buffer),
-        )
-        .await
-        .expect("real merge to seed cache value");
+    let mut merged = casper::rust::util::rholang::interpreter_util::compute_parents_post_state(
+        &nodes[1].block_store,
+        snapshot.parents.clone(),
+        &snapshot,
+        &nodes[1].runtime_manager,
+        &latest_messages,
+        None,
+        Some(&nodes[1].rejected_deploy_buffer),
+    )
+    .await
+    .expect("real merge to seed cache value");
 
     let synthetic = RejectedSlash {
         invalid_block_hash: invalid_block.block_hash.clone(),
@@ -737,7 +738,10 @@ async fn rejected_slash_recovery_keeps_empty_proposer_alive() {
     };
     nodes[1]
         .runtime_manager
-        .put_cached_parents_post_state(cache_key, (merged_state, merged_rejected, vec![synthetic]));
+        .put_cached_parents_post_state(cache_key, {
+            merged.rejected_slashes = vec![synthetic];
+            merged
+        });
     drop(snapshot);
 
     // No user deploy. With allow_empty_blocks=false (TestNode default) and

--- a/casper/tests/block_creator_memory_profile_spec.rs
+++ b/casper/tests/block_creator_memory_profile_spec.rs
@@ -564,18 +564,10 @@ async fn run_block_creator_phase_split_memory_profile() {
 
         let rss_before = vm_rss_kb();
 
-        let (pre_state_hash, _rejected, _rejected_slashes) = if skip_parents_compute {
+        let pre_state_hash = if skip_parents_compute {
             match snapshot.parents.first() {
-                Some(parent) => (
-                    parent.body.state.post_state_hash.clone(),
-                    Vec::new(),
-                    Vec::new(),
-                ),
-                None => (
-                    RuntimeManager::empty_state_hash_fixed(),
-                    Vec::new(),
-                    Vec::new(),
-                ),
+                Some(parent) => parent.body.state.post_state_hash.clone(),
+                None => RuntimeManager::empty_state_hash_fixed(),
             }
         } else {
             let latest_messages: std::collections::BTreeMap<_, _> = snapshot
@@ -594,7 +586,7 @@ async fn run_block_creator_phase_split_memory_profile() {
             )
             .await
             {
-                Ok(result) => result,
+                Ok(result) => result.state,
                 Err(err) => {
                     error_count += 1;
                     if error_samples.len() < 5 {

--- a/casper/tests/compute_parents_post_state_regression_spec.rs
+++ b/casper/tests/compute_parents_post_state_regression_spec.rs
@@ -326,18 +326,17 @@ async fn run_compute_parents_post_state_finalized_skew_regression() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (state_without_skew, rejected_without_skew, _rejected_slashes) =
-        compute_parents_post_state(
-            &block_store,
-            parents.clone(),
-            &snapshot_without_skew,
-            &runtime_manager,
-            &latest_messages_without_skew,
-            None,
-            None,
-        )
-        .await
-        .expect("Failed to compute parents post-state without finalized skew");
+    let merged_without_skew = compute_parents_post_state(
+        &block_store,
+        parents.clone(),
+        &snapshot_without_skew,
+        &runtime_manager,
+        &latest_messages_without_skew,
+        None,
+        None,
+    )
+    .await
+    .expect("Failed to compute parents post-state without finalized skew");
 
     runtime_manager.parents_post_state_cache.clear();
     runtime_manager.block_index_cache.clear();
@@ -361,7 +360,7 @@ async fn run_compute_parents_post_state_finalized_skew_regression() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (state_with_skew, rejected_with_skew, _rejected_slashes) = compute_parents_post_state(
+    let merged_with_skew = compute_parents_post_state(
         &block_store,
         parents,
         &snapshot_with_skew,
@@ -374,11 +373,11 @@ async fn run_compute_parents_post_state_finalized_skew_regression() {
     .expect("Failed to compute parents post-state with finalized skew");
 
     assert_eq!(
-        state_without_skew, state_with_skew,
+        merged_without_skew.state, merged_with_skew.state,
         "Parents post-state should be invariant to finalized-set skew for the same parent set."
     );
     assert_eq!(
-        rejected_without_skew, rejected_with_skew,
+        merged_without_skew.rejected_user, merged_with_skew.rejected_user,
         "Rejected deploy set should be invariant to finalized-set skew for the same parent set."
     );
 }
@@ -610,7 +609,7 @@ async fn run_compute_parents_dag_cover_fast_path_regression() {
     runtime_manager.parents_post_state_cache.clear();
     runtime_manager.block_index_cache.clear();
 
-    let (merged_state, rejected, _rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         vec![cover.clone(), side.clone()],
         &snapshot,
@@ -623,11 +622,11 @@ async fn run_compute_parents_dag_cover_fast_path_regression() {
     .expect("Failed to compute parents post-state");
 
     assert!(
-        rejected.is_empty(),
+        merged.rejected_user.is_empty(),
         "non-conflicting side deploy should merge cleanly"
     );
     assert_eq!(
-        merged_state,
+        merged.state,
         proto_util::post_state_hash(&cover),
         "a valid DAG-covering parent should already contain the secondary parent's effects"
     );

--- a/casper/tests/genesis/contracts/pos_spec.rs
+++ b/casper/tests/genesis/contracts/pos_spec.rs
@@ -86,16 +86,16 @@ fn pos_spec() {
                     vec![],
                     // pos_spec runs the full 16-test PoSTest.rho through the interpreter over a
                     // custom-param genesis with test vaults (an unavoidable GENESIS_CACHE miss) —
-                    // the heaviest genesis-contract spec, ~11-50s in isolation now that the harness
-                    // enforces. `.config/nextest.toml` gives it `threads-required = "num-cpus"`,
-                    // which isolates it within a single-crate run (`cargo nextest run -p casper`
-                    // => ~11s). But under a full-workspace run (`--workspace`, ~2700 tests) other
-                    // crates' interpreter/LMDB-heavy tests still contend at the OS level, starving
-                    // it well past a short bound (observed ~400-900s). This timeout only exists to
-                    // catch a genuine HANG (the work is deterministic and finite); a very generous
-                    // value keeps scheduling latency from producing a false failure while still
-                    // bounding a true hang. See .config/nextest.toml.
-                    Duration::from_secs(1800),
+                    // the heaviest genesis-contract spec, ~10-50s in isolation. The bound is a
+                    // WEDGE-CATCHER: pos_spec intermittently wedges under parallel suite
+                    // execution (all tokio workers parked, zero runnable tasks; the timed run
+                    // localized it to the 'eval-test-source' phase — the interpreter evaluating
+                    // PoSTest.rho), and the previous 1800s value burned half an hour per
+                    // occurrence. The RhoSpec harness times the WHOLE pipeline and names the
+                    // wedged phase in the failure message, so an expiry here is diagnostic
+                    // signal, not lost work; a healthy run that trips it under load should be
+                    // retried, not accommodated with a wider bound.
+                    Duration::from_secs(60),
                     genesis_parameters,
                 );
 

--- a/casper/tests/helper/rho_spec.rs
+++ b/casper/tests/helper/rho_spec.rs
@@ -313,73 +313,91 @@ pub async fn get_results(
     genesis_parameters: GenesisParameters,
     test_result_collector: Arc<TestResultCollector>,
 ) -> Result<TestResult, InterpreterError> {
-    let mut genesis_builder = GenesisBuilder::new();
-    let genesis = genesis_builder
-        .build_genesis_with_parameters(Some(genesis_parameters))
-        .await
-        .map_err(|e| {
-            InterpreterError::BugFoundError(format!("Failed to build genesis: {:?}", e))
-        })?;
+    // The WHOLE pipeline runs under the execution bound, with a live phase
+    // label folded into the timeout error. The bound must cover genesis
+    // build and runtime setup, not just the test-source eval: a wedge in an
+    // untimed phase is an unbounded hang, and the observed intermittent
+    // wedge (all workers parked, zero runnable tasks — see the flake-hunt
+    // wedge samples) must always surface as a bounded, phase-named failure.
+    let phase = Arc::new(std::sync::Mutex::new("genesis-build"));
+    let phase_in_body = phase.clone();
+    let set_phase = move |name: &'static str| {
+        *phase_in_body
+            .lock()
+            .expect("phase label mutex is never poisoned") = name;
+    };
 
-    // Run the suite against the GENESIS post-state (registry, ListOps, PoS, vaults, …), not a
-    // fresh empty scope. Otherwise the RhoSpec framework — whose `testSuite` contracts are gated
-    // on `rho:lang:listOps` (RhoSpecContract.rho) — never installs, no assertions are collected,
-    // and every genesis spec passes VACUOUSLY. Open the same shared RSpace scope genesis was
-    // written into and reset the runtime to the genesis root below.
-    let mut kvs_manager = mk_test_rnode_store_manager_shared(genesis.rspace_scope_id.clone());
-    let r_store = kvs_manager.r_space_stores().await.map_err(|e| {
-        InterpreterError::BugFoundError(format!("Failed to create RSpaceStore: {}", e))
-    })?;
+    let body =
+        async {
+            let mut genesis_builder = GenesisBuilder::new();
+            let genesis = genesis_builder
+                .build_genesis_with_parameters(Some(genesis_parameters))
+                .await
+                .map_err(|e| {
+                    InterpreterError::BugFoundError(format!("Failed to build genesis: {:?}", e))
+                })?;
 
-    // NOTE: In Scala, RSpacePlusPlus_RhoTypes.create() calls Rust via JNA, where Matcher
-    // is created automatically (see rspace++/libs/rspace_rhotypes/src/lib.rs).
-    // In pure Rust code (without JNA), we must create the Matcher explicitly here,
-    // as RSpace::create(stores, matcher) requires it as a parameter.
-    let matcher =
-        Arc::new(Box::new(Matcher)
-            as Box<
-                dyn Match<BindPattern, ListParWithRandom, TaggedContinuation>,
-            >);
+            // Run the suite against the GENESIS post-state (registry, ListOps, PoS, vaults, …), not a
+            // fresh empty scope. Otherwise the RhoSpec framework — whose `testSuite` contracts are gated
+            // on `rho:lang:listOps` (RhoSpecContract.rho) — never installs, no assertions are collected,
+            // and every genesis spec passes VACUOUSLY. Open the same shared RSpace scope genesis was
+            // written into and reset the runtime to the genesis root below.
+            set_phase("store-open");
+            let mut kvs_manager =
+                mk_test_rnode_store_manager_shared(genesis.rspace_scope_id.clone());
+            let r_store = kvs_manager.r_space_stores().await.map_err(|e| {
+                InterpreterError::BugFoundError(format!("Failed to create RSpaceStore: {}", e))
+            })?;
 
-    let mut additional_system_processes = test_framework_contracts(test_result_collector.clone());
+            // NOTE: In Scala, RSpacePlusPlus_RhoTypes.create() calls Rust via JNA, where Matcher
+            // is created automatically (see rspace++/libs/rspace_rhotypes/src/lib.rs).
+            // In pure Rust code (without JNA), we must create the Matcher explicitly here,
+            // as RSpace::create(stores, matcher) requires it as a parameter.
+            let matcher = Arc::new(Box::new(Matcher)
+                as Box<dyn Match<BindPattern, ListParWithRandom, TaggedContinuation>>);
 
-    let mut runtime = create_runtime_from_kv_store(
-        r_store,
-        std::sync::Arc::new(Genesis::default_mergeable_tags()),
-        true,
-        &mut additional_system_processes,
-        matcher,
-        rholang::rust::interpreter::external_services::ExternalServices::noop(),
-    )
-    .await;
+            let mut additional_system_processes =
+                test_framework_contracts(test_result_collector.clone());
 
-    // Position the runtime at the genesis post-state so the standard library / registry
-    // (rho:lang:listOps, rho:system:pos, rho:vault:*, …) resolve for the test suite.
-    runtime
-        .reset(&Blake2b256Hash::from_bytes_prost(
-            &genesis.genesis_block.body.state.post_state_hash,
-        ))
-        .await?;
+            set_phase("runtime-create");
+            let mut runtime = create_runtime_from_kv_store(
+                r_store,
+                std::sync::Arc::new(Genesis::default_mergeable_tags()),
+                true,
+                &mut additional_system_processes,
+                matcher,
+                rholang::rust::interpreter::external_services::ExternalServices::noop(),
+            )
+            .await;
 
-    println!("Starting tests from {}", test_object.path);
+            // Position the runtime at the genesis post-state so the standard library / registry
+            // (rho:lang:listOps, rho:system:pos, rho:vault:*, …) resolve for the test suite.
+            set_phase("genesis-reset");
+            runtime
+                .reset(&Blake2b256Hash::from_bytes_prost(
+                    &genesis.genesis_block.body.state.post_state_hash,
+                ))
+                .await?;
 
-    let runtime = setup_runtime(runtime, other_libs).await?;
+            println!("Starting tests from {}", test_object.path);
 
-    let rand = Blake2b512Random::create_from_length(128).split_short(1);
+            set_phase("rhospec-install");
+            let runtime = setup_runtime(runtime, other_libs).await?;
 
-    // Note: tokio::time::timeout similar to Scala's `monix.eval.Task.timeout()`.
-    // If test execution takes longer than `execution_timeout`, it returns a timeout error.
-    match tokio::time::timeout(
-        execution_timeout,
-        TestUtil::eval_source(test_object, &runtime, rand),
-    )
-    .await
-    {
+            let rand = Blake2b512Random::create_from_length(128).split_short(1);
+
+            set_phase("eval-test-source");
+            TestUtil::eval_source(test_object, &runtime, rand).await
+        };
+
+    match tokio::time::timeout(execution_timeout, body).await {
         Ok(result) => result?,
         Err(_) => {
             return Err(InterpreterError::BugFoundError(format!(
-                "Timeout of {:?} expired while executing test from {}",
-                execution_timeout, test_object.path
+                "Timeout of {:?} expired in phase '{}' while executing test from {}",
+                execution_timeout,
+                phase.lock().expect("phase label mutex is never poisoned"),
+                test_object.path
             )))
         }
     }

--- a/casper/tests/util/rholang/runtime_manager_test.rs
+++ b/casper/tests/util/rholang/runtime_manager_test.rs
@@ -2043,7 +2043,7 @@ async fn bridge_query_survives_multi_parent_merge() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (merged_state, rejected, rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         parents,
         &snapshot_merge,
@@ -2056,16 +2056,20 @@ async fn bridge_query_survives_multi_parent_merge() {
     .expect("merge parents");
 
     assert!(
-        rejected.is_empty(),
+        merged.rejected_user.is_empty(),
         "Merge rejected deploys: {:?}",
-        rejected
+        merged
+            .rejected_user
+            .iter()
+            .map(|(s, _)| hex::encode(&s[..8.min(s.len())]))
+            .collect::<Vec<_>>()
     );
     // Non-slash merge scenario must surface an empty rejected_slashes list so
     // the block creator's dedup step runs as a no-op.
     assert!(
-        rejected_slashes.is_empty(),
+        merged.rejected_slashes.is_empty(),
         "Merge rejected slashes unexpectedly populated: count={}",
-        rejected_slashes.len()
+        merged.rejected_slashes.len()
     );
 
     // --- Query getNonce from merged state ---
@@ -2092,7 +2096,7 @@ in {{
     let query_block_raw = block_implicits::get_random_block(
         Some(2),
         Some(3),
-        Some(merged_state.clone()),
+        Some(merged.state.clone()),
         Some(StateHash::default()),
         Some(validator.clone()),
         Some(1),
@@ -2555,7 +2559,7 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (merged_state, rejected, _rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         parents,
         &snapshot_merge,
@@ -2569,18 +2573,22 @@ async fn concurrent_registry_inserts_should_not_conflict() {
 
     tracing::info!(
         "Merge result: rejected={}, merged_state={}",
-        rejected.len(),
-        hex::encode(&merged_state[..8]),
+        merged.rejected_user.len(),
+        hex::encode(&merged.state[..8]),
     );
 
-    if !rejected.is_empty() {
-        let rejected_sigs: Vec<String> = rejected
+    if !merged.rejected_user.is_empty() {
+        let rejected_sigs: Vec<String> = merged
+            .rejected_user
+            .iter()
+            .map(|(s, _)| s.clone())
+            .collect::<Vec<_>>()
             .iter()
             .map(|d| hex::encode(&d[..std::cmp::min(8, d.len())]))
             .collect();
         tracing::warn!(
             "CONFLICT DETECTED: {} deploys rejected: {:?}",
-            rejected.len(),
+            merged.rejected_user.len(),
             rejected_sigs,
         );
 
@@ -2608,11 +2616,11 @@ async fn concurrent_registry_inserts_should_not_conflict() {
     // single-value-cell conflict. A rejection here would be a real regression: a
     // genuinely-mergeable race mis-rejected.
     assert!(
-        rejected.is_empty(),
+        merged.rejected_user.is_empty(),
         "concurrent insertArbitrary to DISTINCT registry leaves must merge with 0 \
          rejected (they share TreeHashMap internal nodes, but the produces there are \
          mergeable); got {} rejected — keep-one wrongly rejected a mergeable race.",
-        rejected.len(),
+        merged.rejected_user.len(),
     );
 
     // Verify both URIs accessible from merged state
@@ -2629,14 +2637,14 @@ async fn concurrent_registry_inserts_should_not_conflict() {
 
     let data_a = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_a[0].deploy.sig),
         )
         .await
         .unwrap();
     let data_b = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_b[0].deploy.sig),
         )
         .await
@@ -3264,7 +3272,7 @@ new deployId(`rho:system:deployId`) in {
         .iter()
         .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
         .collect();
-    let (merged_state, rejected, _rejected_slashes) = compute_parents_post_state(
+    let merged = compute_parents_post_state(
         &block_store,
         vec![block_c.clone(), block_d.clone()],
         &snapshot_cd,
@@ -3276,7 +3284,11 @@ new deployId(`rho:system:deployId`) in {
     .await
     .expect("merge [C, D]");
 
-    let rejected_set: HashSet<prost::bytes::Bytes> = rejected.iter().cloned().collect();
+    let rejected_set: HashSet<prost::bytes::Bytes> = merged
+        .rejected_user
+        .iter()
+        .map(|(s, _)| s.clone())
+        .collect();
     let ba_rejected = rejected_set.contains(&pd_a[0].deploy.sig);
     let bb_rejected = rejected_set.contains(&pd_b[0].deploy.sig);
     let bc_rejected = rejected_set.contains(&pd_c[0].deploy.sig);
@@ -3299,32 +3311,32 @@ new deployId(`rho:system:deployId`) in {
         "BD (trivial, key_B, child of BB)   rejected: {}",
         bd_rejected
     );
-    tracing::info!("Total rejected: {} deploys", rejected.len());
+    tracing::info!("Total rejected: {} deploys", merged.rejected_user.len());
 
     let ba_data = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_a[0].deploy.sig),
         )
         .await
         .unwrap();
     let bb_data = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_b[0].deploy.sig),
         )
         .await
         .unwrap();
     let bc_data = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_c[0].deploy.sig),
         )
         .await
         .unwrap();
     let bd_data = rm
         .get_data(
-            merged_state.clone(),
+            merged.state.clone(),
             &make_deploy_id_par(&pd_d[0].deploy.sig),
         )
         .await


### PR DESCRIPTION
Layer 1 of the ground-up consensus stack: exactly-once at the merge.

- Settled-in-base dedup sentinel: a sig whose effect is already in the merge base drops every scope copy — the base/scope-boundary blindness that double-applied sibling inclusions is closed.
- Create-side pre-state guard: a block never executes a deploy whose effect its own pre-state already carries (the reinstated-effect re-execution class).
- Also bounds the whole RhoSpec pipeline so a wedged pos_spec fails fast and labeled instead of hanging the suite.

Co-Authored-By: Claude <noreply@anthropic.com>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
