### PR TITLE
feat(casper): rejection records name the carrier they adjudicated

### DIFF
--- a/block-storage/src/rust/key_value_block_store.rs
+++ b/block-storage/src/rust/key_value_block_store.rs
@@ -131,9 +131,12 @@ impl KeyValueBlockStore {
         Ok(has_any)
     }
 
-    /// Fetch rejected deploy signatures for a block without decoding a full BlockMessage.
-    /// Returns the `body.rejected_deploys[*].sig` values. Most blocks have none; only
-    /// multi-parent merge blocks that dropped a conflicting deploy populate this list.
+    /// Fetch KEPT rejected deploy signatures for a block without decoding a
+    /// full BlockMessage. Returns the `body.rejected_deploys[*].sig` values
+    /// of non-duplicate records only: a duplicate-flagged record discarded a
+    /// redundant copy and does not dispute the sig's standing win, so
+    /// disposition readers skip it. Most blocks have none; only multi-parent
+    /// merge blocks that dropped a conflicting deploy populate this list.
     pub fn rejected_deploy_sigs(
         &self,
         block_hash: &BlockHash,
@@ -144,7 +147,12 @@ impl KeyValueBlockStore {
             None => return Ok(None),
         };
         let body = Self::decode_block_deploy_sigs(&bytes)?;
-        let sigs = body.rejected_deploys.into_iter().map(|r| r.sig).collect();
+        let sigs = body
+            .rejected_deploys
+            .into_iter()
+            .filter(|r| !r.duplicate)
+            .map(|r| r.sig)
+            .collect();
         Ok(Some(sigs))
     }
 
@@ -429,6 +437,8 @@ struct BlockDeploySigsDeploy {
 struct BlockDeploySigsRejectedDeploy {
     #[prost(bytes = "vec", tag = "1")]
     sig: Vec<u8>,
+    #[prost(bool, tag = "2")]
+    duplicate: bool,
 }
 
 // See block-storage/src/test/scala/coop/rchain/blockstorage/KeyValueBlockStoreSpec.scala

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -1645,16 +1645,6 @@ fn drain_selected_recovered_deploys_from_deploy_storage(
     Ok(removed_from_storage)
 }
 
-fn filter_unprocessed_rejected_deploys(
-    rejected_deploys: Vec<Bytes>,
-    processed_deploy_sigs: &HashSet<Bytes>,
-) -> Vec<Bytes> {
-    rejected_deploys
-        .into_iter()
-        .filter(|sig| !processed_deploy_sigs.contains(sig))
-        .collect()
-}
-
 /// Removes the ordinary deploy-storage copies of recovered deploys whose sig
 /// already shows a canonical win in the parent scope. The rejected-buffer
 /// entry is NOT touched here: a canonical-but-unfinalized win can still be
@@ -3124,20 +3114,14 @@ pub async fn create(
     )
     .record(checkpoint_started.elapsed().as_secs_f64());
 
-    let (
+    let interpreter_util::DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
-        new_bonds,
-    ) = checkpoint_data;
-    let processed_deploy_sigs: HashSet<Bytes> = processed_deploys
-        .iter()
-        .map(|pd| pd.deploy.sig.clone())
-        .collect();
-    let rejected_deploys =
-        filter_unprocessed_rejected_deploys(rejected_deploys, &processed_deploy_sigs);
+        system_deploys: processed_system_deploys,
+        bonds: new_bonds,
+    } = checkpoint_data;
 
     let block_bonds = {
         let parent_hashes: Vec<BlockHash> = parents.iter().map(|p| p.block_hash.clone()).collect();
@@ -3276,7 +3260,7 @@ fn package_block(
     pre_state_hash: Bytes,
     post_state_hash: Bytes,
     deploys: Vec<ProcessedDeploy>,
-    rejected_deploys: Vec<Bytes>,
+    rejected_deploys: Vec<RejectedDeploy>,
     system_deploys: Vec<ProcessedSystemDeploy>,
     bonds_map: Vec<Bond>,
     shard_id: String,
@@ -3289,15 +3273,10 @@ fn package_block(
         block_number: block_data.block_number,
     };
 
-    let rejected_deploys_wrapped: Vec<RejectedDeploy> = rejected_deploys
-        .into_iter()
-        .map(|r| RejectedDeploy { sig: r })
-        .collect();
-
     let body = Body {
         state,
         deploys,
-        rejected_deploys: rejected_deploys_wrapped,
+        rejected_deploys,
         system_deploys,
         extra_bytes: Bytes::new(),
     };
@@ -4536,21 +4515,6 @@ mod tests {
 
         snapshot.last_finalized_block = parent_hash;
         assert!(!parent_frontier_extends_lfb(&snapshot, &block_store).expect("lfb parent"));
-    }
-
-    #[test]
-    fn processed_deploys_are_not_packaged_as_rejected_deploys() {
-        let processed_sig = Bytes::from_static(b"processed");
-        let other_sig = Bytes::from_static(b"other");
-        let fresh_sig = Bytes::from_static(b"fresh");
-        let processed_deploy_sigs: HashSet<Bytes> = [processed_sig.clone()].into_iter().collect();
-
-        let filtered = filter_unprocessed_rejected_deploys(
-            vec![processed_sig, other_sig.clone(), fresh_sig.clone()],
-            &processed_deploy_sigs,
-        );
-
-        assert_eq!(filtered, vec![other_sig, fresh_sig]);
     }
 
     /// A bonded validator that PoS still considers active is slashable

--- a/casper/src/rust/engine/multi_parent_casper/snapshot.rs
+++ b/casper/src/rust/engine/multi_parent_casper/snapshot.rs
@@ -1211,6 +1211,8 @@ mod tests {
         );
         rejected.body.rejected_deploys = vec![RejectedDeploy {
             sig: prost::bytes::Bytes::from_static(b"sig"),
+            duplicate: false,
+            carrier: prost::bytes::Bytes::new(),
         }];
 
         block_store

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
 use models::rhoapi::ListParWithRandom;
 use models::rust::block_hash::BlockHash;
+use models::rust::casper::protocol::casper_message::RejectedDeploy;
 use prost::bytes::Bytes;
 use rholang::rust::interpreter::merging::rholang_merging_logic::RholangMergingLogic;
 use rholang::rust::interpreter::rho_runtime::RhoHistoryRepository;
@@ -572,7 +573,11 @@ pub fn merge(
 ) -> Result<
     (
         Blake2b256Hash,
-        Vec<(Bytes, BlockHash)>,
+        // Rejected user deploys as full records: each names the CARRIER it
+        // adjudicated (the rejected chain's source block) and carries the
+        // formation-time duplicate flag. The record is consensus content —
+        // it travels to the block body as-is.
+        Vec<RejectedDeploy>,
         Vec<(Bytes, BlockHash)>,
         // User sigs whose chains this merge APPLIED from scope: their
         // effects are in the returned state, so none of them may also be
@@ -1572,11 +1577,33 @@ pub fn merge(
         })
         .collect();
 
-    let mut rejected_user_deploys: Vec<(Bytes, BlockHash)> = all_pairs
-        .iter()
-        .filter(|(id, _)| !is_system_deploy_id(id))
-        .cloned()
-        .collect();
+    // Duplicate flag: the record does not dispute the sig's standing win
+    // when the effect is present in THIS merge's own post-state — either a
+    // kept chain in the same merge carries a copy, or the effect is
+    // settled in the base. Both are frozen, validator-recomputable facts
+    // of this merge; readers discard duplicate-flagged records from the
+    // disposition ordering.
+    let mut duplicate_of = |sig: &Bytes| -> Result<bool, CasperError> {
+        if applied_user_sigs.contains(sig) || settled_sigs.contains(sig) {
+            return Ok(true);
+        }
+        if settled_checked.insert(sig.clone()) && sig_settled_in_base(sig)? {
+            settled_sigs.insert(sig.clone());
+            return Ok(true);
+        }
+        Ok(false)
+    };
+
+    let mut rejected_user_deploys: Vec<RejectedDeploy> = Vec::new();
+    for (id, src) in &all_pairs {
+        if !is_system_deploy_id(id) {
+            rejected_user_deploys.push(RejectedDeploy {
+                sig: id.clone(),
+                duplicate: duplicate_of(id)?,
+                carrier: src.clone(),
+            });
+        }
+    }
     let mut rejected_slashes: Vec<(Bytes, BlockHash)> = all_pairs
         .into_iter()
         .filter(|(id, _)| is_slash_deploy_id(id))
@@ -1589,11 +1616,16 @@ pub fn merge(
     if !collateral_lost_pairs.is_empty() {
         let existing_ids: HashSet<Bytes> = rejected_user_deploys
             .iter()
-            .map(|(id, _)| id.clone())
+            .map(|record| record.sig.clone())
             .collect();
-        for pair in collateral_lost_pairs {
-            if !existing_ids.contains(&pair.0) {
-                rejected_user_deploys.push(pair);
+        for (id, src) in collateral_lost_pairs {
+            if !existing_ids.contains(&id) {
+                let duplicate = duplicate_of(&id)?;
+                rejected_user_deploys.push(RejectedDeploy {
+                    sig: id,
+                    duplicate,
+                    carrier: src,
+                });
             }
         }
     }
@@ -1617,7 +1649,13 @@ pub fn merge(
     if !rejected_user_deploys.is_empty() {
         let rejected_str: Vec<_> = rejected_user_deploys
             .iter()
-            .map(|(sig, _)| hex::encode(&sig[..std::cmp::min(8, sig.len())]))
+            .map(|record| {
+                format!(
+                    "{}{}",
+                    hex::encode(&record.sig[..std::cmp::min(8, record.sig.len())]),
+                    if record.duplicate { "(dup)" } else { "" }
+                )
+            })
             .collect();
         tracing::info!(
             "DagMerger rejected {} user deploys: {}",

--- a/casper/src/rust/test_utils/helper/block_generator.rs
+++ b/casper/src/rust/test_utils/helper/block_generator.rs
@@ -64,7 +64,7 @@ async fn compute_block_checkpoint(
         .map(|d| d.deploy)
         .collect();
 
-    let (_, post_state_hash, processed_deploys, _, _, _) = compute_deploys_checkpoint(
+    let checkpoint = compute_deploys_checkpoint(
         block_store,
         parents,
         deploys,
@@ -77,7 +77,7 @@ async fn compute_block_checkpoint(
     )
     .await?;
 
-    Ok((post_state_hash, processed_deploys))
+    Ok((checkpoint.post_state_hash, checkpoint.deploys))
 }
 
 fn inject_post_state_hash(

--- a/casper/src/rust/util/proto_util.rs
+++ b/casper/src/rust/util/proto_util.rs
@@ -14,7 +14,7 @@ use models::rust::block_metadata::BlockMetadata;
 use models::rust::casper::pretty_printer::PrettyPrinter;
 use models::rust::casper::protocol::casper_message::{
     BlockMessage, Body, Bond, DeployData, Header, Justification, ProcessedDeploy,
-    ProcessedSystemDeploy,
+    ProcessedSystemDeploy, RejectedDeploy,
 };
 use models::rust::validator::Validator;
 use rholang::rust::interpreter::deploy_parameters::DeployParameters;
@@ -264,6 +264,19 @@ pub fn get_parent_metadatas_above_block_number(
 }
 
 pub fn deploys(block: &BlockMessage) -> Vec<ProcessedDeploy> { block.body.deploys.clone() }
+
+/// The block's KEPT rejection records. A duplicate-flagged record states
+/// that the copy it discarded was redundant — its effect already stood in
+/// the forming merge's own post-state — so it does not dispute the sig's
+/// standing win. Every disposition reader consumes records through this
+/// one filter so the discard policy cannot drift between readers.
+pub fn kept_rejected_records(block: &BlockMessage) -> impl Iterator<Item = &RejectedDeploy> {
+    block
+        .body
+        .rejected_deploys
+        .iter()
+        .filter(|record| !record.duplicate)
+}
 
 pub fn system_deploys(block: &BlockMessage) -> Vec<ProcessedSystemDeploy> {
     block.body.system_deploys.clone()

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -10,7 +10,8 @@ use models::rust::block::state_hash::StateHash;
 use models::rust::block_hash::BlockHash;
 use models::rust::casper::pretty_printer::PrettyPrinter;
 use models::rust::casper::protocol::casper_message::{
-    BlockMessage, Bond, DeployData, ProcessedDeploy, ProcessedSystemDeploy, SystemDeployData,
+    BlockMessage, Bond, DeployData, ProcessedDeploy, ProcessedSystemDeploy, RejectedDeploy,
+    SystemDeployData,
 };
 use models::rust::validator::Validator;
 use prost::bytes::Bytes;
@@ -198,7 +199,7 @@ fn canonical_dispositions(
         for pd in &block.body.deploys {
             record_disposition(&mut disposition, pd.deploy.sig.clone(), bn, true);
         }
-        for rd in &block.body.rejected_deploys {
+        for rd in proto_util::kept_rejected_records(&block) {
             record_disposition(&mut disposition, rd.sig.clone(), bn, false);
         }
         for p in &block.header.parents_hash_list {
@@ -246,7 +247,7 @@ fn max_visible_rejection_heights(
         if bn < earliest_block_number {
             continue;
         }
-        for rd in &block.body.rejected_deploys {
+        for rd in proto_util::kept_rejected_records(&block) {
             latest
                 .entry(rd.sig.clone())
                 .and_modify(|height| *height = (*height).max(bn))
@@ -315,7 +316,7 @@ fn rejected_sig_has_visible_non_source_win(
                 record_disposition(&mut disposition, pd.deploy.sig.clone(), bn, true);
             }
         }
-        for rd in &block.body.rejected_deploys {
+        for rd in proto_util::kept_rejected_records(&block) {
             if rd.sig == *sig {
                 record_disposition(&mut disposition, rd.sig.clone(), bn, false);
             }
@@ -324,68 +325,39 @@ fn rejected_sig_has_visible_non_source_win(
     Ok(disposition.get(sig).map(|(_, won)| *won).unwrap_or(false))
 }
 
-#[cfg(test)]
-fn visible_rejected_deploy_sigs(
+/// Record-emission dedup, carrier-exact: a computed record is redundant —
+/// and only then suppressible — when a visible block already carries the
+/// IDENTICAL record (same sig, same carrier, same duplicate flag). A
+/// record adjudicates exactly the copy its carrier names; a visible record
+/// naming a sibling carrier of the same sig covers nothing about this one,
+/// and suppressing on it leaves an adjudicated copy permanently
+/// unrecorded — the copy then reads as a standing win and recovery stands
+/// down on lost work. Flag-differing records are distinct testimony (the
+/// same copy can be adjudicated redundant by one merge and effect-dropping
+/// by another base) and never suppress each other.
+fn suppress_already_recorded_rejections(
     block_store: &KeyValueBlockStore,
     visible_blocks: &HashSet<BlockHash>,
-) -> Result<HashSet<Bytes>, CasperError> {
-    Ok(
-        visible_rejected_deploy_latest_heights(block_store, visible_blocks)?
-            .into_keys()
-            .collect(),
-    )
-}
+    rejected_records: &mut Vec<RejectedDeploy>,
+) -> Result<usize, CasperError> {
+    if rejected_records.is_empty() {
+        return Ok(0);
+    }
 
-fn visible_rejected_deploy_latest_heights(
-    block_store: &KeyValueBlockStore,
-    visible_blocks: &HashSet<BlockHash>,
-) -> Result<HashMap<Bytes, i64>, CasperError> {
-    let mut latest: HashMap<Bytes, i64> = HashMap::new();
+    let mut visible_records: HashSet<RejectedDeploy> = HashSet::new();
     for hash in visible_blocks {
         let Some(block) = block_store.get(hash)? else {
             continue;
         };
-        for rd in &block.body.rejected_deploys {
-            latest
-                .entry(rd.sig.clone())
-                .and_modify(|height| *height = (*height).max(block.body.state.block_number))
-                .or_insert(block.body.state.block_number);
-        }
+        visible_records.extend(block.body.rejected_deploys.iter().cloned());
     }
-    Ok(latest)
-}
-
-fn suppress_rejected_pairs_with_later_visible_rejection(
-    block_store: &KeyValueBlockStore,
-    visible_blocks: &HashSet<BlockHash>,
-    rejected_user_pairs: &mut Vec<(Bytes, BlockHash)>,
-) -> Result<usize, CasperError> {
-    if rejected_user_pairs.is_empty() {
+    if visible_records.is_empty() {
         return Ok(0);
     }
 
-    let visible_rejected_heights =
-        visible_rejected_deploy_latest_heights(block_store, visible_blocks)?;
-    if visible_rejected_heights.is_empty() {
-        return Ok(0);
-    }
-
-    let before = rejected_user_pairs.len();
-    let mut retained = Vec::with_capacity(rejected_user_pairs.len());
-    for (sig, source_block) in std::mem::take(rejected_user_pairs) {
-        let suppress = match visible_rejected_heights.get(&sig) {
-            Some(rejected_height) => match block_store.get(&source_block)? {
-                Some(source) => *rejected_height > source.body.state.block_number,
-                None => false,
-            },
-            None => false,
-        };
-        if !suppress {
-            retained.push((sig, source_block));
-        }
-    }
-    *rejected_user_pairs = retained;
-    Ok(before.saturating_sub(rejected_user_pairs.len()))
+    let before = rejected_records.len();
+    rejected_records.retain(|record| !visible_records.contains(record));
+    Ok(before.saturating_sub(rejected_records.len()))
 }
 
 fn retain_pending_rejected_deploys_for_buffer(
@@ -526,25 +498,18 @@ pub async fn validate_block_checkpoint(
     match computed_parents_info {
         Ok(merged) => {
             let computed_pre_state_hash = merged.state.clone();
-            let block_deploy_sigs: HashSet<_> = block
-                .body
-                .deploys
-                .iter()
-                .map(|pd| pd.deploy.sig.clone())
-                .collect();
-            let rejected_deploy_ids: HashSet<_> = merged
-                .rejected_user
-                .iter()
-                .map(|(sig, _)| sig)
-                .filter(|sig| !block_deploy_sigs.contains(*sig))
-                .cloned()
-                .collect();
-            let block_rejected_deploy_sigs: HashSet<_> = block
-                .body
-                .rejected_deploys
-                .iter()
-                .map(|d| d.sig.clone())
-                .collect();
+            // The rejected-record equality is exact and total: every record
+            // the recomputed merge formed must appear in the block — sig,
+            // carrier, and duplicate flag — and nothing else may. There is
+            // deliberately NO carve-out for sigs the block also carries in
+            // `body.deploys`: a record is consensus content regardless of
+            // whether its subject rides fresh in the same block, and
+            // excusing that overlap let a block drop the adjudication its
+            // own merge computed while executing the adjudicated deploy.
+            let computed_rejected: HashSet<RejectedDeploy> =
+                merged.rejected_user.iter().cloned().collect();
+            let block_rejected: HashSet<RejectedDeploy> =
+                block.body.rejected_deploys.iter().cloned().collect();
 
             if incoming_pre_state_hash != computed_pre_state_hash {
                 tracing::debug!(target: "f1r3fly.casper.block_validation", block = %hex::encode(&block.block_hash[..8.min(block.block_hash.len())]), computed = %hex::encode(&computed_pre_state_hash[..8.min(computed_pre_state_hash.len())]), incoming = %hex::encode(&incoming_pre_state_hash[..8.min(incoming_pre_state_hash.len())]), "validate.block_checkpoint: PRE-STATE MISMATCH (recomputed merge != block's recorded pre-state) -> reject, NO replay");
@@ -556,15 +521,25 @@ pub async fn validate_block_checkpoint(
                 );
 
                 Ok(Either::Right(None))
-            } else if rejected_deploy_ids != block_rejected_deploy_sigs {
-                // Detailed logging for InvalidRejectedDeploy mismatch
-                let extra_in_computed: Vec<_> = rejected_deploy_ids
-                    .difference(&block_rejected_deploy_sigs)
-                    .cloned()
+            } else if computed_rejected != block_rejected {
+                // Detailed logging for InvalidRejectedDeploy mismatch: a
+                // record differing in ANY field — sig, carrier, or
+                // duplicate flag — is a disagreement.
+                let describe = |record: &RejectedDeploy| {
+                    format!(
+                        "{}@{}{}",
+                        hex::encode(&record.sig[..8.min(record.sig.len())]),
+                        hex::encode(&record.carrier[..8.min(record.carrier.len())]),
+                        if record.duplicate { "(dup)" } else { "" }
+                    )
+                };
+                let extra_in_computed: Vec<String> = computed_rejected
+                    .difference(&block_rejected)
+                    .map(describe)
                     .collect();
-                let missing_in_computed: Vec<_> = block_rejected_deploy_sigs
-                    .difference(&rejected_deploy_ids)
-                    .cloned()
+                let missing_in_computed: Vec<String> = block_rejected
+                    .difference(&computed_rejected)
+                    .map(describe)
                     .collect();
 
                 // Find duplicates across all deploy sigs in the block
@@ -581,12 +556,14 @@ pub async fn validate_block_checkpoint(
                     block_num = block.body.state.block_number,
                     block_hash = %PrettyPrinter::build_string_bytes(&block.block_hash),
                     sender = %PrettyPrinter::build_string_bytes(&block.sender),
-                    validator_rejected = rejected_deploy_ids.len(),
-                    block_rejected = block_rejected_deploy_sigs.len(),
+                    validator_rejected = computed_rejected.len(),
+                    block_rejected = block_rejected.len(),
                     extra_count = extra_in_computed.len(),
                     missing_count = missing_in_computed.len(),
+                    extra_in_computed = ?extra_in_computed,
+                    missing_in_computed = ?missing_in_computed,
                     duplicate_count,
-                    "rejected deploy mismatch: validator and block creator disagree on rejected deploys"
+                    "rejected deploy mismatch: validator and block creator disagree on rejected records"
                 );
 
                 Ok(Either::Left(BlockStatus::invalid_rejected_deploy()))
@@ -854,6 +831,19 @@ pub fn print_deploy_errors(deploy_sig: &Bytes, errors: &[InterpreterError]) {
     tracing::warn!("Deploy ({}) errors: {}", deploy_info, error_messages);
 }
 
+/// The result of executing a block's deploys against its merged pre-state
+/// — everything block packaging needs, named. The rejected records travel
+/// exactly as the merge formed them: sig, carrier, and duplicate flag are
+/// all consensus content, re-derived and compared by every validator.
+pub struct DeploysCheckpoint {
+    pub pre_state_hash: StateHash,
+    pub post_state_hash: StateHash,
+    pub deploys: Vec<ProcessedDeploy>,
+    pub rejected_deploys: Vec<RejectedDeploy>,
+    pub system_deploys: Vec<ProcessedSystemDeploy>,
+    pub bonds: Vec<Bond>,
+}
+
 pub async fn compute_deploys_checkpoint(
     block_store: &mut KeyValueBlockStore,
     parents: Vec<BlockMessage>,
@@ -864,17 +854,7 @@ pub async fn compute_deploys_checkpoint(
     block_data: BlockData,
     invalid_blocks: HashMap<BlockHash, Validator>,
     rejected_deploy_buffer: Option<&std::sync::Arc<std::sync::Mutex<block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer>>>,
-) -> Result<
-    (
-        StateHash,
-        StateHash,
-        Vec<ProcessedDeploy>,
-        Vec<prost::bytes::Bytes>,
-        Vec<ProcessedSystemDeploy>,
-        Vec<Bond>,
-    ),
-    CasperError,
-> {
+) -> Result<DeploysCheckpoint, CasperError> {
     let checkpoint_started = std::time::Instant::now();
     // Using tracing events for async - Span[F] equivalent from Scala
     tracing::debug!(target: "f1r3fly.casper.compute_deploys_checkpoint", "compute-deploys-checkpoint-started");
@@ -908,11 +888,7 @@ pub async fn compute_deploys_checkpoint(
     .await?;
     let parents_ms = parents_started.elapsed().as_millis();
     let pre_state_hash = computed_parents_info.state.clone();
-    let rejected_deploys: Vec<prost::bytes::Bytes> = computed_parents_info
-        .rejected_user
-        .iter()
-        .map(|(sig, _)| sig.clone())
-        .collect();
+    let rejected_deploys: Vec<RejectedDeploy> = computed_parents_info.rejected_user.clone();
 
     // Compute state and bonds using one spawned runtime
     let compute_state_started = std::time::Instant::now();
@@ -939,14 +915,14 @@ pub async fn compute_deploys_checkpoint(
         rejected_deploys.len()
     );
 
-    Ok((
+    Ok(DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
+        system_deploys: processed_system_deploys,
         bonds,
-    ))
+    })
 }
 
 /// Ensure every block in the merge `scope` has its mergeable-channels entry
@@ -1495,17 +1471,17 @@ pub async fn compute_parents_post_state(
             )?;
             let merge_ms = merge_started.elapsed().as_millis();
 
-            let (state, mut rejected_user_pairs, rejected_slash_pairs, applied_user_sigs) =
+            let (state, mut rejected_user_records, rejected_slash_pairs, applied_user_sigs) =
                 merger_result;
-            let suppressed = suppress_rejected_pairs_with_later_visible_rejection(
+            let suppressed = suppress_already_recorded_rejections(
                 block_store,
                 &visible_blocks,
-                &mut rejected_user_pairs,
+                &mut rejected_user_records,
             )?;
             if suppressed > 0 {
                 tracing::debug!(
                     target: "f1r3fly.casper.recovery",
-                    "compute_parents_post_state: suppressed {} already-visible rejected deploy(s)",
+                    "compute_parents_post_state: suppressed {} already-recorded rejection(s)",
                     suppressed
                 );
             }
@@ -1513,28 +1489,40 @@ pub async fn compute_parents_post_state(
                 target: "f1r3fly.merge.step",
                 step = "compute_parents_post_state.MERGE_POST",
                 new_state = %hex::encode(&state.bytes()[..8.min(state.bytes().len())]),
-                n_rejected_user = rejected_user_pairs.len(),
+                n_rejected_user = rejected_user_records.len(),
                 n_rejected_slash = rejected_slash_pairs.len(),
                 merge_ms,
                 "merge.step: dag_merger::merge returned"
             );
-            tracing::debug!(target: "f1r3fly.casper.compute_parents_post_state", merged_state = %hex::encode(&state.bytes()[..8.min(state.bytes().len())]), n_rejected_user = rejected_user_pairs.len(), n_rejected_slash = rejected_slash_pairs.len(), merge_ms, "merge.compute_parents_post_state: DagMerger produced merged state");
+            tracing::debug!(target: "f1r3fly.casper.compute_parents_post_state", merged_state = %hex::encode(&state.bytes()[..8.min(state.bytes().len())]), n_rejected_user = rejected_user_records.len(), n_rejected_slash = rejected_slash_pairs.len(), merge_ms, "merge.compute_parents_post_state: DagMerger produced merged state");
 
-            // Populate the rejected-deploy buffer from (sig, source_block_hash) pairs.
-            // Looking up the `Signed<DeployData>` from the block store lets the block
-            // creator re-propose these deploys in a subsequent block. Fetching each
-            // source block at most once keeps the cost proportional to the number of
-            // distinct rejected-from blocks.
-            //
+            // Populate the rejected-deploy buffer from the records' (sig,
+            // carrier) naming. Looking up the `Signed<DeployData>` from the
+            // carrier block lets the block creator re-propose these deploys
+            // in a subsequent block. Fetching each carrier at most once
+            // keeps the cost proportional to the number of distinct
+            // carriers. Duplicate-flagged records buffer nothing: their
+            // copy's effect already stands, so a re-proposal could only be
+            // executed onto a state that carries it.
             if let Some(buffer) = rejected_deploy_buffer {
-                if !rejected_user_pairs.is_empty() {
+                if !rejected_user_records.is_empty() {
                     let floor_won = canonical_won_sigs(
                         block_store,
                         std::slice::from_ref(&floor_hash),
                         i64::MIN,
                     )?;
                     let mut by_block: HashMap<BlockHash, Vec<Bytes>> = HashMap::new();
-                    for (sig, src_block) in &rejected_user_pairs {
+                    for record in &rejected_user_records {
+                        let (sig, src_block) = (&record.sig, &record.carrier);
+                        if record.duplicate {
+                            tracing::debug!(
+                                target: "f1r3fly.casper.recovery",
+                                "RejectedDeployBuffer populate: skipped duplicate-flagged sig {} from {}",
+                                PrettyPrinter::build_string_bytes(sig),
+                                PrettyPrinter::build_string_bytes(src_block)
+                            );
+                            continue;
+                        }
                         if floor_won.contains(sig)
                             || rejected_sig_has_visible_non_source_win(
                                 block_store,
@@ -1683,7 +1671,7 @@ pub async fn compute_parents_post_state(
             let computed_state = prost::bytes::Bytes::copy_from_slice(&state.bytes());
             let merged = MergedPreState {
                 state: computed_state.clone(),
-                rejected_user: rejected_user_pairs,
+                rejected_user: rejected_user_records,
                 rejected_slashes,
                 applied_from_scope: applied_user_sigs,
                 merge_base: Some(floor_hash.clone()),
@@ -1750,8 +1738,7 @@ mod backstop_tests {
     use super::{
         block_in_floor_merge_scope, canonical_won_sigs, merge_scope_backstop_exceeded,
         rejected_sig_has_visible_non_source_win, retain_pending_rejected_deploys_for_buffer,
-        suppress_rejected_pairs_with_later_visible_rejection, visible_rejected_deploy_sigs,
-        MAX_FLOOR_DISTANCE_BLOCKS,
+        suppress_already_recorded_rejections, MAX_FLOOR_DISTANCE_BLOCKS,
     };
     use crate::rust::util::construct_deploy;
 
@@ -2019,7 +2006,11 @@ mod backstop_tests {
             Some("root".to_string()),
             None,
         );
-        later_rejection.body.rejected_deploys = vec![RejectedDeploy { sig: sig.clone() }];
+        later_rejection.body.rejected_deploys = vec![RejectedDeploy {
+            sig: sig.clone(),
+            duplicate: false,
+            carrier: Bytes::new(),
+        }];
         block_store
             .put_block_message(&lower_clean)
             .expect("store lower clean");
@@ -2081,6 +2072,8 @@ mod backstop_tests {
         );
         rejected_floor.body.rejected_deploys = vec![RejectedDeploy {
             sig: rejected_sig.clone(),
+            duplicate: false,
+            carrier: Bytes::new(),
         }];
         let clean_floor = block_implicits::get_random_block(
             Some(11),
@@ -2122,91 +2115,18 @@ mod backstop_tests {
         assert!(clean_floor_wins.contains(&deploy.sig));
     }
 
+    /// Emission dedup is exact: only a visible record IDENTICAL in sig,
+    /// carrier, and flag makes re-emission redundant. A visible record of
+    /// the same sig naming a different carrier is testimony about a
+    /// different copy and suppresses nothing.
     #[tokio::test]
-    async fn visible_rejected_deploys_are_detected_from_visible_blocks() {
-        let mut kvm = InMemoryStoreManager::new();
-        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
-            .await
-            .expect("block store");
-        let rejected_sig = Bytes::from_static(b"rejected");
-        let unseen_sig = Bytes::from_static(b"unseen");
-        let mut rejected_block = block_implicits::get_random_block(
-            Some(1),
-            Some(1),
-            None,
-            None,
-            None,
-            None,
-            Some(1),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some("root".to_string()),
-            None,
-        );
-        rejected_block.body.rejected_deploys = vec![RejectedDeploy {
-            sig: rejected_sig.clone(),
-        }];
-        let unseen_block = block_implicits::get_random_block(
-            Some(1),
-            Some(1),
-            None,
-            None,
-            None,
-            None,
-            Some(1),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some("root".to_string()),
-            None,
-        );
-        block_store
-            .put_block_message(&rejected_block)
-            .expect("store rejected block");
-        block_store
-            .put_block_message(&unseen_block)
-            .expect("store unseen block");
-
-        let visible_blocks = [rejected_block.block_hash.clone()].into_iter().collect();
-        let detected =
-            visible_rejected_deploy_sigs(&block_store, &visible_blocks).expect("detect rejected");
-
-        assert!(detected.contains(&rejected_sig));
-        assert!(!detected.contains(&unseen_sig));
-    }
-
-    #[tokio::test]
-    async fn older_visible_rejection_does_not_suppress_recovery_source_rejection() {
+    async fn only_the_identical_visible_record_suppresses_re_emission() {
         let mut kvm = InMemoryStoreManager::new();
         let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
             .await
             .expect("block store");
         let recovered_sig = Bytes::from_static(b"recovered");
         let duplicate_sig = Bytes::from_static(b"duplicate");
-        let mut old_rejection = block_implicits::get_random_block(
-            Some(10),
-            Some(1),
-            None,
-            None,
-            None,
-            None,
-            Some(10),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some(Vec::new()),
-            Some("root".to_string()),
-            None,
-        );
-        old_rejection.body.rejected_deploys = vec![RejectedDeploy {
-            sig: recovered_sig.clone(),
-        }];
         let source = block_implicits::get_random_block(
             Some(20),
             Some(1),
@@ -2223,7 +2143,32 @@ mod backstop_tests {
             Some("root".to_string()),
             None,
         );
-        let mut later_rejection = block_implicits::get_random_block(
+        // A visible record of `recovered_sig` naming a DIFFERENT carrier:
+        // it adjudicated a sibling copy, not the one at `source`.
+        let mut sibling_record_block = block_implicits::get_random_block(
+            Some(10),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Some(10),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some("root".to_string()),
+            None,
+        );
+        sibling_record_block.body.rejected_deploys = vec![RejectedDeploy {
+            sig: recovered_sig.clone(),
+            duplicate: false,
+            carrier: Bytes::from(vec![0xD7; 32]),
+        }];
+        // A visible record IDENTICAL to the computed one for
+        // `duplicate_sig`: same sig, same carrier, same flag.
+        let mut identical_record_block = block_implicits::get_random_block(
             Some(21),
             Some(1),
             None,
@@ -2239,40 +2184,149 @@ mod backstop_tests {
             Some("root".to_string()),
             None,
         );
-        later_rejection.body.rejected_deploys = vec![RejectedDeploy {
+        identical_record_block.body.rejected_deploys = vec![RejectedDeploy {
             sig: duplicate_sig.clone(),
+            duplicate: false,
+            carrier: source.block_hash.clone(),
         }];
         block_store
-            .put_block_message(&old_rejection)
-            .expect("store old rejection");
+            .put_block_message(&sibling_record_block)
+            .expect("store sibling record");
         block_store
             .put_block_message(&source)
             .expect("store source");
         block_store
-            .put_block_message(&later_rejection)
-            .expect("store later rejection");
+            .put_block_message(&identical_record_block)
+            .expect("store identical record");
 
         let visible_blocks: HashSet<_> = [
-            old_rejection.block_hash.clone(),
+            sibling_record_block.block_hash.clone(),
             source.block_hash.clone(),
-            later_rejection.block_hash.clone(),
+            identical_record_block.block_hash.clone(),
         ]
         .into_iter()
         .collect();
-        let mut rejected_pairs = vec![
-            (recovered_sig.clone(), source.block_hash.clone()),
-            (duplicate_sig.clone(), source.block_hash.clone()),
-        ];
+        let retained_record = RejectedDeploy {
+            sig: recovered_sig.clone(),
+            duplicate: false,
+            carrier: source.block_hash.clone(),
+        };
+        let mut rejected_records = vec![retained_record.clone(), RejectedDeploy {
+            sig: duplicate_sig.clone(),
+            duplicate: false,
+            carrier: source.block_hash.clone(),
+        }];
 
-        let suppressed = suppress_rejected_pairs_with_later_visible_rejection(
+        let suppressed = suppress_already_recorded_rejections(
             &block_store,
             &visible_blocks,
-            &mut rejected_pairs,
+            &mut rejected_records,
         )
-        .expect("suppress rejected pairs");
+        .expect("suppress rejected records");
 
         assert_eq!(suppressed, 1);
-        assert_eq!(rejected_pairs, vec![(recovered_sig, source.block_hash)]);
+        assert_eq!(rejected_records, vec![retained_record]);
+    }
+
+    /// A record adjudicates the copy its carrier names, and ONLY that copy.
+    /// A visible record naming a SIBLING carrier of the same sig covers
+    /// nothing about this carrier's copy — suppressing this pair on it
+    /// leaves the sibling's adjudication permanently unrecorded: the copy
+    /// reads as a standing win, recovery stands down, and the work is lost
+    /// while the record plane looks complete.
+    #[tokio::test]
+    async fn record_naming_a_sibling_carrier_does_not_suppress_this_carriers_pair() {
+        let mut kvm = InMemoryStoreManager::new();
+        let block_store = KeyValueBlockStore::create_from_kvm(&mut kvm)
+            .await
+            .expect("block store");
+        let deploy = construct_deploy::source_deploy_now_full(
+            "@11!(11)".to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("deploy");
+        let sig = deploy.sig.clone();
+
+        // This carrier: holds the copy the computed pair adjudicates.
+        let this_carrier = block_implicits::get_random_block(
+            Some(20),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Some(20),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(vec![ProcessedDeploy::empty(deploy)]),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some("root".to_string()),
+            None,
+        );
+        // A later visible record of the SAME sig naming a DIFFERENT carrier
+        // (a sibling copy adjudicated elsewhere).
+        let mut sibling_record_block = block_implicits::get_random_block(
+            Some(21),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            Some(21),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some(Vec::new()),
+            Some("root".to_string()),
+            None,
+        );
+        sibling_record_block.body.rejected_deploys = vec![RejectedDeploy {
+            sig: sig.clone(),
+            duplicate: false,
+            carrier: Bytes::from(vec![0xC4; 32]),
+        }];
+        block_store
+            .put_block_message(&this_carrier)
+            .expect("store this carrier");
+        block_store
+            .put_block_message(&sibling_record_block)
+            .expect("store sibling record");
+
+        let visible_blocks: HashSet<BlockHash> = [
+            this_carrier.block_hash.clone(),
+            sibling_record_block.block_hash.clone(),
+        ]
+        .into_iter()
+        .collect();
+        let this_record = RejectedDeploy {
+            sig: sig.clone(),
+            duplicate: false,
+            carrier: this_carrier.block_hash.clone(),
+        };
+        let mut rejected_records = vec![this_record.clone()];
+
+        let suppressed = suppress_already_recorded_rejections(
+            &block_store,
+            &visible_blocks,
+            &mut rejected_records,
+        )
+        .expect("suppress rejected records");
+
+        assert_eq!(
+            suppressed, 0,
+            "a record naming a sibling carrier covers nothing about this copy"
+        );
+        assert_eq!(
+            rejected_records,
+            vec![this_record],
+            "the record for this carrier must be emitted"
+        );
     }
 
     #[tokio::test]

--- a/casper/src/rust/util/rholang/runtime_manager.rs
+++ b/casper/src/rust/util/rholang/runtime_manager.rs
@@ -109,9 +109,10 @@ pub struct ParentsPostStateCacheKey {
 #[derive(Clone, Debug)]
 pub struct MergedPreState {
     pub state: StateHash,
-    /// Rejected user deploys as (sig, carrier) — the carrier is the source
-    /// block whose copy the merge adjudicated.
-    pub rejected_user: Vec<(prost::bytes::Bytes, BlockHash)>,
+    /// Rejected user deploys as full records — each names the carrier it
+    /// adjudicated and carries the formation-time duplicate flag. These
+    /// travel to the block body as-is; the record IS the consensus content.
+    pub rejected_user: Vec<models::rust::casper::protocol::casper_message::RejectedDeploy>,
     pub rejected_slashes: Vec<crate::rust::merging::rejected_slash::RejectedSlash>,
     /// User sigs whose chains the merge APPLIED from scope: their effects
     /// are in `state`, so executing any of them on top would double-apply.

--- a/casper/tests/api/deploy_finalization_status_test.rs
+++ b/casper/tests/api/deploy_finalization_status_test.rs
@@ -479,6 +479,8 @@ async fn resolve_and_resolve_batch_agree_across_states() {
     );
     block_b.body.rejected_deploys = vec![RejectedDeploy {
         sig: sig_clean_canonical_reject_canonical.clone(),
+        duplicate: false,
+        carrier: prost::bytes::Bytes::new(),
     }];
 
     // Block S: non-canonical sibling of B at h=2. Has main parent A
@@ -515,6 +517,8 @@ async fn resolve_and_resolve_batch_agree_across_states() {
     );
     block_s.body.rejected_deploys = vec![RejectedDeploy {
         sig: sig_clean_canonical_reject_sibling.clone(),
+        duplicate: false,
+        carrier: prost::bytes::Bytes::new(),
     }];
 
     // Block C: LFB. Multi-parent merge of [B, S]. Main parent = B,
@@ -1114,6 +1118,8 @@ async fn resolve_returns_finalized_when_canonical_clean_supersedes_canonical_fai
     );
     block_b.body.rejected_deploys = vec![RejectedDeploy {
         sig: sig_under_test.clone(),
+        duplicate: false,
+        carrier: prost::bytes::Bytes::new(),
     }];
 
     // Block C: h=3 LFB, canonical descendant of B. sig clean (recovery
@@ -1523,6 +1529,8 @@ async fn resolve_returns_pending_for_non_canonical_clean_with_canonical_reject()
     );
     block_c.body.rejected_deploys = vec![RejectedDeploy {
         sig: sig_under_test.clone(),
+        duplicate: false,
+        carrier: prost::bytes::Bytes::new(),
     }];
 
     block_store.put_block_message(&block_a).expect("store A");

--- a/casper/tests/batch2/carrier_record_spec.rs
+++ b/casper/tests/batch2/carrier_record_spec.rs
@@ -1,0 +1,418 @@
+// A rejection record names the copy it adjudicated, and the record list is
+// consensus down to that naming.
+//
+// Two reds, one per half of the contract:
+//
+// 1. THE SAME-BLOCK EXEMPTION: the checkpoint's rejected-list equality
+//    excuses any computed rejection whose sig the block itself carries in
+//    `body.deploys`. A block can therefore execute a deploy fresh, drop the
+//    record its own merge computed for that sig's scope copy, and validate
+//    clean — the adjudication vanishes from the chain while its subject
+//    rides in the same block. The equality must hold with no carve-out: a
+//    computed record is part of the block's consensus content whether or
+//    not the sig also appears in the body.
+//
+// 2. THE CARRIER IS CONSENSUS: the record's carrier field states which
+//    copy was adjudicated. A reader trusting that statement needs it
+//    validator-checked exactly like the sig — a block naming a carrier its
+//    own recomputed merge did not reject must be invalid, else the field
+//    is advisory metadata a proposer can forge.
+
+use std::collections::{BTreeMap, HashMap};
+
+use casper::rust::block_status::{BlockError, InvalidBlock};
+use casper::rust::casper::Casper;
+use casper::rust::util::rholang::interpreter_util;
+use casper::rust::util::{construct_deploy, proto_util};
+use models::rust::block_hash::BlockHash;
+use models::rust::casper::protocol::casper_message::{
+    BlockMessage, Body, F1r3flyState, Header, Justification,
+};
+use models::rust::validator::Validator;
+use prost::bytes::Bytes;
+use rholang::rust::interpreter::system_processes::BlockData;
+use rspace_plus_plus::rspace::history::Either;
+use serial_test::serial;
+
+use crate::helper::test_node::TestNode;
+use crate::util::genesis_builder::GenesisBuilder;
+
+fn short(sig: &Bytes) -> String { hex::encode(&sig[..8.min(sig.len())]) }
+
+async fn three_node_network() -> (Vec<TestNode>, String) {
+    let n_validators = 3usize;
+    let genesis_parameters =
+        GenesisBuilder::build_genesis_parameters_with_defaults(None, Some(n_validators));
+    let genesis = GenesisBuilder::new()
+        .build_genesis_with_parameters(Some(genesis_parameters))
+        .await
+        .unwrap();
+    let shard_id = genesis.genesis_block.shard_id.clone();
+    let mut nodes = TestNode::create_network(genesis, n_validators, None, None, None, None)
+        .await
+        .expect("create_network");
+    for node in nodes.iter_mut() {
+        node.allow_empty_blocks = true;
+    }
+    (nodes, shard_id)
+}
+
+/// Stage the contest: a seed cell, two contenders that both consume it
+/// (a genuine conflict), carried on divergent branches. Returns the two
+/// carrier blocks and the contender deploys keyed by sig.
+async fn stage_contest(
+    nodes: &mut [TestNode],
+    shard_id: &str,
+) -> (
+    BlockMessage,
+    BlockMessage,
+    Vec<(
+        Bytes,
+        crypto::rust::signatures::signed::Signed<
+            models::rust::casper::protocol::casper_message::DeployData,
+        >,
+    )>,
+) {
+    let seed = construct_deploy::source_deploy_now_full(
+        r#"@"race"!("s")"#.to_string(),
+        None,
+        None,
+        Some(construct_deploy::DEFAULT_SEC2.clone()),
+        Some(0),
+        Some(shard_id.to_string()),
+    )
+    .expect("build seed");
+    let s_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&seed))
+        .await
+        .expect("seed block S");
+    for i in [0usize, 2usize] {
+        nodes[i]
+            .process_block(s_block.clone())
+            .await
+            .expect("process S");
+    }
+
+    let contender_d = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"for (@v <- @"race") { @"race"!("d") | @"XD"!(v) }"#.to_string(),
+            None,
+            None,
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            Some(0),
+            Some(shard_id.to_string()),
+        )
+        .expect("build contender d")
+    };
+    let contender_f = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"for (@v <- @"race") { @"race"!("f") | @"XF"!(v) }"#.to_string(),
+            None,
+            None,
+            Some(
+                crate::util::genesis_builder::EXTRA_GENESIS_VAULT_KEY_PAIRS[0]
+                    .0
+                    .clone(),
+            ),
+            None,
+            Some(shard_id.to_string()),
+        )
+        .expect("build contender f")
+    };
+    let contenders = vec![
+        (contender_d.sig.clone(), contender_d.clone()),
+        (contender_f.sig.clone(), contender_f.clone()),
+    ];
+    let c_block = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&contender_d))
+        .await
+        .expect("block C with d");
+    let a_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&contender_f))
+        .await
+        .expect("block A with f");
+    (c_block, a_block, contenders)
+}
+
+/// RED 1: a block that executes a deploy fresh while OMITTING the record
+/// its own merge computed for that sig must be `InvalidRejectedDeploy`.
+///
+/// The block is assembled through the production checkpoint on the full
+/// frontier — the merge adjudicates the contest and rejects one contender;
+/// that loser is then executed FRESH in the same block (its effect is not
+/// in the merged pre-state, so execution is clean and replay reproduces
+/// it), and the record list is packaged EMPTY. Every state check passes:
+/// the pre-state hash matches the recomputed merge, and replay matches the
+/// recorded post-state. Only the rejected-list equality can catch the
+/// dropped adjudication — and its same-sig carve-out excuses exactly this
+/// shape, so the block validates clean end to end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn fresh_carry_must_not_excuse_a_dropped_record() {
+    let (mut nodes, shard_id) = three_node_network().await;
+    let (c_block, a_block, contenders) = stage_contest(&mut nodes, &shard_id).await;
+
+    // nodes[2] sees both carriers and no adjudication: its merge computes
+    // the contest's rejection fresh, with no visible record covering it.
+    for b in [&c_block, &a_block] {
+        nodes[2]
+            .process_block((*b).clone())
+            .await
+            .expect("nodes[2] processes a carrier");
+    }
+
+    let snapshot = nodes[2]
+        .casper
+        .get_snapshot()
+        .await
+        .expect("nodes[2] snapshot");
+    assert!(
+        snapshot
+            .parents
+            .iter()
+            .any(|p| p.block_hash == c_block.block_hash)
+            && snapshot
+                .parents
+                .iter()
+                .any(|p| p.block_hash == a_block.block_hash),
+        "staging precondition: both carriers must be in nodes[2]'s frontier"
+    );
+
+    let latest_messages: BTreeMap<Validator, BlockHash> = snapshot
+        .justifications
+        .iter()
+        .map(|j| (j.validator.clone(), j.latest_block_hash.clone()))
+        .collect();
+    let runtime_manager = nodes[2].runtime_manager.clone();
+    let merged = interpreter_util::compute_parents_post_state(
+        &nodes[2].block_store,
+        snapshot.parents.clone(),
+        &snapshot,
+        &runtime_manager,
+        &latest_messages,
+        None,
+        None,
+    )
+    .await
+    .expect("merge over the full frontier");
+    assert_eq!(
+        merged.rejected_user.len(),
+        1,
+        "staging precondition: the contest must reject exactly one contender \
+         (rejected: {:?})",
+        merged
+            .rejected_user
+            .iter()
+            .map(|record| short(&record.sig))
+            .collect::<Vec<_>>(),
+    );
+    let loser_sig = merged.rejected_user[0].sig.clone();
+    let loser_deploy = contenders
+        .iter()
+        .find(|(sig, _)| *sig == loser_sig)
+        .map(|(_, d)| d.clone())
+        .expect("loser is one of the contenders");
+
+    // Build the block through the production checkpoint: the merge rejects
+    // the loser's scope copy, then the same deploy executes fresh on the
+    // merged pre-state.
+    let validator_identity = nodes[2]
+        .validator_id_opt
+        .clone()
+        .expect("nodes[2] validator identity");
+    let next_block_num = snapshot.max_block_num + 1;
+    let next_seq_num = snapshot
+        .max_seq_nums
+        .get(&validator_identity.public_key.bytes)
+        .map(|seq| *seq as i32 + 1)
+        .unwrap_or(1);
+    let now_millis = snapshot
+        .parents
+        .iter()
+        .map(|p| p.header.timestamp)
+        .max()
+        .expect("parents have timestamps")
+        + 1;
+    let block_data = BlockData {
+        time_stamp: now_millis,
+        block_number: next_block_num,
+        sender: validator_identity.public_key.clone(),
+        seq_num: next_seq_num,
+    };
+    let checkpoint = interpreter_util::compute_deploys_checkpoint(
+        &mut nodes[2].block_store,
+        snapshot.parents.clone(),
+        vec![loser_deploy],
+        Vec::new(),
+        &snapshot,
+        &runtime_manager,
+        block_data.clone(),
+        HashMap::new(),
+        None,
+    )
+    .await
+    .expect("checkpoint on the full frontier");
+    assert!(
+        checkpoint
+            .rejected_deploys
+            .iter()
+            .any(|record| record.sig == loser_sig),
+        "staging precondition: the checkpoint's merge must reject the loser's \
+         scope copy (rejected: {:?})",
+        checkpoint
+            .rejected_deploys
+            .iter()
+            .map(|record| short(&record.sig))
+            .collect::<Vec<_>>(),
+    );
+    let fresh_execution = checkpoint
+        .deploys
+        .iter()
+        .find(|pd| pd.deploy.sig == loser_sig)
+        .expect("the loser must execute fresh in this block");
+    assert!(
+        !fresh_execution.is_failed,
+        "staging precondition: the fresh execution must succeed"
+    );
+
+    // Package with the record list EMPTY: the adjudication is dropped while
+    // its subject rides in the body.
+    let body = Body {
+        state: F1r3flyState {
+            pre_state_hash: checkpoint.pre_state_hash,
+            post_state_hash: checkpoint.post_state_hash,
+            bonds: checkpoint.bonds,
+            block_number: next_block_num,
+        },
+        deploys: checkpoint.deploys,
+        rejected_deploys: Vec::new(),
+        system_deploys: checkpoint.system_deploys,
+        extra_bytes: Bytes::new(),
+    };
+    let header = Header {
+        parents_hash_list: snapshot
+            .parents
+            .iter()
+            .map(|p| p.block_hash.clone())
+            .collect(),
+        timestamp: now_millis,
+        version: 1,
+        extra_bytes: Bytes::new(),
+    };
+    let justifications: Vec<Justification> = snapshot.justifications.iter().cloned().collect();
+    let unsigned = proto_util::unsigned_block_proto(
+        body,
+        header,
+        justifications,
+        shard_id.clone(),
+        Some(next_seq_num),
+    );
+    let block = validator_identity.sign_block(&unsigned);
+
+    // THE RED: the rejected-list equality must catch the dropped record.
+    let mut validation_snapshot = nodes[2]
+        .casper
+        .get_snapshot()
+        .await
+        .expect("validation snapshot");
+    let result = interpreter_util::validate_block_checkpoint(
+        &block,
+        &nodes[2].block_store,
+        &mut validation_snapshot,
+        &runtime_manager,
+        None,
+    )
+    .await
+    .expect("validation completes");
+    assert!(
+        matches!(
+            result,
+            Either::Left(BlockError::Invalid(InvalidBlock::InvalidRejectedDeploy))
+        ),
+        "DROPPED ADJUDICATION: a block carrying deploy {} fresh while omitting \
+         the record its own merge computed for that sig must be \
+         InvalidRejectedDeploy; validation returned {:?}",
+        short(&loser_sig),
+        match &result {
+            Either::Left(err) => format!("Left({:?})", err),
+            Either::Right(hash) =>
+                format!("Right({:?} — the block validated clean)", hash.is_some()),
+        },
+    );
+}
+
+/// RED 2: the carrier a record names is consensus content. A block whose
+/// record carries a carrier the validator's own recomputed merge did not
+/// reject must be `InvalidRejectedDeploy` — otherwise the field is
+/// forgeable metadata and no reader may trust it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn record_carrier_is_consensus_checked() {
+    let (mut nodes, shard_id) = three_node_network().await;
+    let (c_block, _a_block, _contenders) = stage_contest(&mut nodes, &shard_id).await;
+
+    // The adjudicating merge M on nodes[1] rejects one contender with a
+    // record.
+    nodes[1]
+        .process_block(c_block.clone())
+        .await
+        .expect("nodes[1] processes C");
+    let marker = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(
+            7,
+            Some(construct_deploy::DEFAULT_SEC2.clone()),
+            Some(shard_id.clone()),
+        )
+        .expect("merge marker")
+    };
+    let m_block = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&marker))
+        .await
+        .expect("adjudicating merge M");
+    assert!(
+        !m_block.body.rejected_deploys.is_empty(),
+        "staging precondition: M must adjudicate the contest with a record"
+    );
+
+    // Tamper the record's carrier: the sig is untouched, so any sig-level
+    // equality still holds.
+    let mut tampered = m_block.clone();
+    let forged_carrier = Bytes::from(vec![0xAB; 32]);
+    assert_ne!(
+        tampered.body.rejected_deploys[0].carrier, forged_carrier,
+        "the forgery must differ from the recorded carrier"
+    );
+    tampered.body.rejected_deploys[0].carrier = forged_carrier;
+
+    let runtime_manager = nodes[1].runtime_manager.clone();
+    let mut validation_snapshot = nodes[1]
+        .casper
+        .get_snapshot()
+        .await
+        .expect("validation snapshot");
+    let result = interpreter_util::validate_block_checkpoint(
+        &tampered,
+        &nodes[1].block_store,
+        &mut validation_snapshot,
+        &runtime_manager,
+        None,
+    )
+    .await
+    .expect("validation completes");
+    assert!(
+        matches!(
+            result,
+            Either::Left(BlockError::Invalid(InvalidBlock::InvalidRejectedDeploy))
+        ),
+        "FORGED CARRIER: a record naming a carrier the recomputed merge did \
+         not reject must be InvalidRejectedDeploy; validation returned {:?}",
+        match &result {
+            Either::Left(err) => format!("Left({:?})", err),
+            Either::Right(hash) =>
+                format!("Right({:?} — the block validated clean)", hash.is_some()),
+        },
+    );
+}

--- a/casper/tests/batch2/dedup_orphan_recovery_spec.rs
+++ b/casper/tests/batch2/dedup_orphan_recovery_spec.rs
@@ -214,7 +214,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_a, pd_a, _, sys_pd_a, bonds_a) = compute_deploys_checkpoint(
+    let checkpoint_a = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&block_a_raw)
@@ -230,7 +230,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
     )
     .await
     .expect("compute block_a checkpoint");
-    for pd in &pd_a {
+    for pd in &checkpoint_a.deploys {
         assert!(
             !pd.is_failed,
             "deploy in block_a must execute cleanly (sig {}): {:?}",
@@ -239,10 +239,10 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         );
     }
     let mut block_a = block_a_raw;
-    block_a.body.state.post_state_hash = post_state_a.clone();
-    block_a.body.deploys = pd_a;
-    block_a.body.system_deploys = sys_pd_a;
-    block_a.body.state.bonds = bonds_a;
+    block_a.body.state.post_state_hash = checkpoint_a.post_state_hash.clone();
+    block_a.body.deploys = checkpoint_a.deploys;
+    block_a.body.system_deploys = checkpoint_a.system_deploys;
+    block_a.body.state.bonds = checkpoint_a.bonds;
     block_store.put_block_message(&block_a).expect("store A");
     dag_storage
         .insert(&block_a, InsertMode::Normal)
@@ -268,7 +268,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_b, pd_b, _, sys_pd_b, bonds_b) = compute_deploys_checkpoint(
+    let checkpoint_b = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&block_b_raw)
@@ -284,7 +284,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
     )
     .await
     .expect("compute block_b checkpoint");
-    for pd in &pd_b {
+    for pd in &checkpoint_b.deploys {
         assert!(
             !pd.is_failed,
             "deploy in block_b must execute cleanly (sig {}): {:?}",
@@ -293,10 +293,10 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         );
     }
     let mut block_b = block_b_raw;
-    block_b.body.state.post_state_hash = post_state_b.clone();
-    block_b.body.deploys = pd_b;
-    block_b.body.system_deploys = sys_pd_b;
-    block_b.body.state.bonds = bonds_b;
+    block_b.body.state.post_state_hash = checkpoint_b.post_state_hash.clone();
+    block_b.body.deploys = checkpoint_b.deploys;
+    block_b.body.system_deploys = checkpoint_b.system_deploys;
+    block_b.body.state.bonds = checkpoint_b.bonds;
     block_store.put_block_message(&block_b).expect("store B");
     dag_storage
         .insert(&block_b, InsertMode::Normal)
@@ -343,7 +343,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
     let rejected_set: HashSet<prost::bytes::Bytes> = merged
         .rejected_user
         .iter()
-        .map(|(sig, _)| sig.clone())
+        .map(|record| record.sig.clone())
         .collect();
     let v_orphaned = rejected_set.contains(&sig_v);
     let w_orphaned = rejected_set.contains(&sig_w);
@@ -360,10 +360,7 @@ for(@_v <- @"dedup-orphan-shared") { Nil }
         merged
             .rejected_user
             .iter()
-            .map(|(sig, _)| sig.clone())
-            .collect::<Vec<_>>()
-            .iter()
-            .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
+            .map(|record| hex::encode(&record.sig[..std::cmp::min(8, record.sig.len())]))
             .collect::<Vec<_>>()
     );
     assert!(

--- a/casper/tests/batch2/mod.rs
+++ b/casper/tests/batch2/mod.rs
@@ -1,3 +1,4 @@
+pub mod carrier_record_spec;
 pub mod clique_oracle_test;
 pub mod dedup_orphan_recovery_spec;
 pub mod estimator_test;

--- a/casper/tests/batch2/multi_validator_recovery_spec.rs
+++ b/casper/tests/batch2/multi_validator_recovery_spec.rs
@@ -210,7 +210,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_r0, pd_r0, _, sys_pd_r0, bonds_r0) = compute_deploys_checkpoint(
+    let checkpoint_r0 = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&r0_raw)
@@ -226,7 +226,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
     )
     .await
     .expect("compute R0 checkpoint");
-    for pd in &pd_r0 {
+    for pd in &checkpoint_r0.deploys {
         assert!(
             !pd.is_failed,
             "deploy in R0 must execute cleanly (sig {}): {:?}",
@@ -235,10 +235,10 @@ for(@_v <- @"multi-validator-shared") { Nil }
         );
     }
     let mut r0 = r0_raw;
-    r0.body.state.post_state_hash = post_state_r0.clone();
-    r0.body.deploys = pd_r0;
-    r0.body.system_deploys = sys_pd_r0;
-    r0.body.state.bonds = bonds_r0;
+    r0.body.state.post_state_hash = checkpoint_r0.post_state_hash.clone();
+    r0.body.deploys = checkpoint_r0.deploys;
+    r0.body.system_deploys = checkpoint_r0.system_deploys;
+    r0.body.state.bonds = checkpoint_r0.bonds;
     block_store.put_block_message(&r0).expect("store R0");
     dag_storage.insert(&r0, InsertMode::Normal).expect("dag R0");
 
@@ -262,7 +262,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_r1, pd_r1, _, sys_pd_r1, bonds_r1) = compute_deploys_checkpoint(
+    let checkpoint_r1 = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&r1_raw)
@@ -278,7 +278,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
     )
     .await
     .expect("compute R1 checkpoint");
-    for pd in &pd_r1 {
+    for pd in &checkpoint_r1.deploys {
         assert!(
             !pd.is_failed,
             "deploy in R1 must execute cleanly (sig {}): {:?}",
@@ -287,10 +287,10 @@ for(@_v <- @"multi-validator-shared") { Nil }
         );
     }
     let mut r1 = r1_raw;
-    r1.body.state.post_state_hash = post_state_r1.clone();
-    r1.body.deploys = pd_r1;
-    r1.body.system_deploys = sys_pd_r1;
-    r1.body.state.bonds = bonds_r1;
+    r1.body.state.post_state_hash = checkpoint_r1.post_state_hash.clone();
+    r1.body.deploys = checkpoint_r1.deploys;
+    r1.body.system_deploys = checkpoint_r1.system_deploys;
+    r1.body.state.bonds = checkpoint_r1.bonds;
     block_store.put_block_message(&r1).expect("store R1");
     dag_storage.insert(&r1, InsertMode::Normal).expect("dag R1");
 
@@ -338,7 +338,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
     let rejected_set: HashSet<prost::bytes::Bytes> = merged
         .rejected_user
         .iter()
-        .map(|(sig, _)| sig.clone())
+        .map(|record| record.sig.clone())
         .collect();
 
     // Dedup must keep the shared recovered sig out of the rejected
@@ -352,10 +352,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
         merged
             .rejected_user
             .iter()
-            .map(|(sig, _)| sig.clone())
-            .collect::<Vec<_>>()
-            .iter()
-            .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
+            .map(|record| hex::encode(&record.sig[..std::cmp::min(8, record.sig.len())]))
             .collect::<Vec<_>>()
     );
 
@@ -380,10 +377,7 @@ for(@_v <- @"multi-validator-shared") { Nil }
         merged
             .rejected_user
             .iter()
-            .map(|(sig, _)| sig.clone())
-            .collect::<Vec<_>>()
-            .iter()
-            .map(|s| hex::encode(&s[..std::cmp::min(8, s.len())]))
+            .map(|record| hex::encode(&record.sig[..std::cmp::min(8, record.sig.len())]))
             .collect::<Vec<_>>()
     );
 }

--- a/casper/tests/batch2/recovery_repeat_deploy_misfire_spec.rs
+++ b/casper/tests/batch2/recovery_repeat_deploy_misfire_spec.rs
@@ -130,6 +130,8 @@ async fn repeat_deploy_grants_exemption_on_parent_rejection_record() {
         );
         block_n.body.rejected_deploys = vec![RejectedDeploy {
             sig: deploy_sig.clone(),
+            duplicate: false,
+            carrier: prost::bytes::Bytes::new(),
         }];
         block_store
             .put(block_n.block_hash.clone(), &block_n)
@@ -353,6 +355,8 @@ async fn repeat_deploy_verdict_is_identical_across_divergent_local_views() {
         );
         block_m.body.rejected_deploys = vec![RejectedDeploy {
             sig: deploy_sig.clone(),
+            duplicate: false,
+            carrier: prost::bytes::Bytes::new(),
         }];
         block_store
             .put(block_m.block_hash.clone(), &block_m)

--- a/casper/tests/batch2/validate_test.rs
+++ b/casper/tests/batch2/validate_test.rs
@@ -1197,6 +1197,8 @@ async fn repeat_deploy_validation_allows_recovered_deploy_from_rejected_in_scope
         block_m.body.rejected_deploys = vec![
             models::rust::casper::protocol::casper_message::RejectedDeploy {
                 sig: deploy_sig.clone(),
+                duplicate: false,
+                carrier: prost::bytes::Bytes::new(),
             },
         ];
         block_store
@@ -3279,6 +3281,8 @@ async fn validate_block_checkpoint_recompute_rejects_pre_state_and_rejected_depl
         let mut tampered_rej = genesis.clone();
         tampered_rej.body.rejected_deploys.push(RejectedDeploy {
             sig: Bytes::from(vec![0xABu8; 64]),
+            duplicate: false,
+            carrier: Bytes::new(),
         });
 
         let mut snap_rej = mk_casper_snapshot(

--- a/casper/tests/compute_parents_post_state_regression_spec.rs
+++ b/casper/tests/compute_parents_post_state_regression_spec.rs
@@ -118,25 +118,24 @@ async fn step_block(
         .map(|d| d.deploy)
         .collect::<Vec<_>>();
 
-    let (_, post_state_hash, processed_deploys, _, processed_system_deploys, bonds) =
-        compute_deploys_checkpoint(
-            block_store,
-            parents,
-            deploys,
-            Vec::<SystemDeployEnum>::new(),
-            &snapshot,
-            runtime_manager,
-            BlockData::from_block(block),
-            HashMap::new(),
-            None,
-        )
-        .await?;
+    let checkpoint = compute_deploys_checkpoint(
+        block_store,
+        parents,
+        deploys,
+        Vec::<SystemDeployEnum>::new(),
+        &snapshot,
+        runtime_manager,
+        BlockData::from_block(block),
+        HashMap::new(),
+        None,
+    )
+    .await?;
 
     let mut updated = block.clone();
-    updated.body.state.post_state_hash = post_state_hash;
-    updated.body.deploys = processed_deploys;
-    updated.body.system_deploys = processed_system_deploys;
-    updated.body.state.bonds = bonds;
+    updated.body.state.post_state_hash = checkpoint.post_state_hash;
+    updated.body.deploys = checkpoint.deploys;
+    updated.body.system_deploys = checkpoint.system_deploys;
+    updated.body.state.bonds = checkpoint.bonds;
 
     block_store
         .put_block_message(&updated)

--- a/casper/tests/helper/block_generator.rs
+++ b/casper/tests/helper/block_generator.rs
@@ -63,7 +63,7 @@ async fn compute_block_checkpoint(
         .map(|d| d.deploy)
         .collect();
 
-    let (_, post_state_hash, processed_deploys, _, _, _) = compute_deploys_checkpoint(
+    let checkpoint = compute_deploys_checkpoint(
         block_store,
         parents,
         deploys,
@@ -76,7 +76,7 @@ async fn compute_block_checkpoint(
     )
     .await?;
 
-    Ok((post_state_hash, processed_deploys))
+    Ok((checkpoint.post_state_hash, checkpoint.deploys))
 }
 
 fn inject_post_state_hash(

--- a/casper/tests/slashing/integration_helpers.rs
+++ b/casper/tests/slashing/integration_helpers.rs
@@ -196,14 +196,14 @@ pub async fn equivocate_block(
     )
     .await?;
 
-    let (
+    let interpreter_util::DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
-        new_bonds,
-    ) = checkpoint;
+        system_deploys: processed_system_deploys,
+        bonds: new_bonds,
+    } = checkpoint;
 
     let casper_version = snapshot.on_chain_state.shard_conf.casper_version;
 
@@ -211,9 +211,7 @@ pub async fn equivocate_block(
     // that function is private to block_creator.rs (`fn`, not
     // `pub fn`), so we replicate its 25-line body here. The
     // proto_util helpers are public.
-    use models::rust::casper::protocol::casper_message::{
-        Body, F1r3flyState, Header, RejectedDeploy,
-    };
+    use models::rust::casper::protocol::casper_message::{Body, F1r3flyState, Header};
 
     let state = F1r3flyState {
         pre_state_hash,
@@ -221,14 +219,10 @@ pub async fn equivocate_block(
         bonds: new_bonds,
         block_number: block_data.block_number,
     };
-    let rejected_deploys_wrapped: Vec<RejectedDeploy> = rejected_deploys
-        .into_iter()
-        .map(|sig| RejectedDeploy { sig })
-        .collect();
     let body = Body {
         state,
         deploys: processed_deploys,
-        rejected_deploys: rejected_deploys_wrapped,
+        rejected_deploys,
         system_deploys: processed_system_deploys,
         extra_bytes: Bytes::new(),
     };
@@ -335,20 +329,18 @@ pub async fn propose_with_explicit_justifications(
     )
     .await?;
 
-    let (
+    let interpreter_util::DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
-        new_bonds,
-    ) = checkpoint;
+        system_deploys: processed_system_deploys,
+        bonds: new_bonds,
+    } = checkpoint;
 
     let casper_version = snapshot.on_chain_state.shard_conf.casper_version;
 
-    use models::rust::casper::protocol::casper_message::{
-        Body, F1r3flyState, Header, RejectedDeploy,
-    };
+    use models::rust::casper::protocol::casper_message::{Body, F1r3flyState, Header};
 
     let state = F1r3flyState {
         pre_state_hash,
@@ -356,14 +348,10 @@ pub async fn propose_with_explicit_justifications(
         bonds: new_bonds,
         block_number: block_data.block_number,
     };
-    let rejected_deploys_wrapped: Vec<RejectedDeploy> = rejected_deploys
-        .into_iter()
-        .map(|sig| RejectedDeploy { sig })
-        .collect();
     let body = Body {
         state,
         deploys: processed_deploys,
-        rejected_deploys: rejected_deploys_wrapped,
+        rejected_deploys,
         system_deploys: processed_system_deploys,
         extra_bytes: Bytes::new(),
     };
@@ -508,20 +496,18 @@ pub async fn propose_with_block_mutation(
     )
     .await?;
 
-    let (
+    let interpreter_util::DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
-        new_bonds,
-    ) = checkpoint;
+        system_deploys: processed_system_deploys,
+        bonds: new_bonds,
+    } = checkpoint;
 
     let casper_version = snapshot.on_chain_state.shard_conf.casper_version;
 
-    use models::rust::casper::protocol::casper_message::{
-        Body, F1r3flyState, Header, RejectedDeploy,
-    };
+    use models::rust::casper::protocol::casper_message::{Body, F1r3flyState, Header};
 
     let state = F1r3flyState {
         pre_state_hash,
@@ -529,14 +515,10 @@ pub async fn propose_with_block_mutation(
         bonds: new_bonds,
         block_number: block_data.block_number,
     };
-    let rejected_deploys_wrapped: Vec<RejectedDeploy> = rejected_deploys
-        .into_iter()
-        .map(|sig| RejectedDeploy { sig })
-        .collect();
     let body = Body {
         state,
         deploys: processed_deploys,
-        rejected_deploys: rejected_deploys_wrapped,
+        rejected_deploys,
         system_deploys: processed_system_deploys,
         extra_bytes: Bytes::new(),
     };
@@ -656,20 +638,18 @@ pub async fn propose_neglecting_block(
     )
     .await?;
 
-    let (
+    let interpreter_util::DeploysCheckpoint {
         pre_state_hash,
         post_state_hash,
-        processed_deploys,
+        deploys: processed_deploys,
         rejected_deploys,
-        processed_system_deploys,
-        new_bonds,
-    ) = checkpoint;
+        system_deploys: processed_system_deploys,
+        bonds: new_bonds,
+    } = checkpoint;
 
     let casper_version = snapshot.on_chain_state.shard_conf.casper_version;
 
-    use models::rust::casper::protocol::casper_message::{
-        Body, F1r3flyState, Header, RejectedDeploy,
-    };
+    use models::rust::casper::protocol::casper_message::{Body, F1r3flyState, Header};
 
     let state = F1r3flyState {
         pre_state_hash,
@@ -677,14 +657,10 @@ pub async fn propose_neglecting_block(
         bonds: new_bonds,
         block_number: block_data.block_number,
     };
-    let rejected_deploys_wrapped: Vec<RejectedDeploy> = rejected_deploys
-        .into_iter()
-        .map(|sig| RejectedDeploy { sig })
-        .collect();
     let body = Body {
         state,
         deploys: processed_deploys,
-        rejected_deploys: rejected_deploys_wrapped,
+        rejected_deploys,
         system_deploys: processed_system_deploys,
         extra_bytes: Bytes::new(),
     };

--- a/casper/tests/util/rholang/interpreter_util_test.rs
+++ b/casper/tests/util/rholang/interpreter_util_test.rs
@@ -17,10 +17,7 @@ use dashmap::DashSet;
 use models::rhoapi::PCost;
 use models::rust::block::state_hash::StateHash;
 use models::rust::block_hash::BlockHash;
-use models::rust::casper::protocol::casper_message::{
-    BlockMessage, Bond, DeployData, ProcessedDeploy, ProcessedSystemDeploy,
-};
-use prost::bytes::Bytes;
+use models::rust::casper::protocol::casper_message::{BlockMessage, DeployData, ProcessedDeploy};
 use rholang::rust::interpreter::system_processes::BlockData;
 use rspace_plus_plus::rspace::history::Either;
 
@@ -206,7 +203,7 @@ impl TestContext {
             .await?;
 
         // Scala: yield processedDeploys.map(_.cost)
-        let costs = result.2.iter().map(|pd| pd.cost).collect();
+        let costs = result.deploys.iter().map(|pd| pd.cost).collect();
 
         Ok(costs)
     }
@@ -221,17 +218,7 @@ impl TestContext {
         runtime_manager: &mut RuntimeManager,
         block_number: i64,
         seq_num: i32,
-    ) -> Result<
-        (
-            StateHash,
-            StateHash,
-            Vec<ProcessedDeploy>,
-            Vec<Bytes>,
-            Vec<ProcessedSystemDeploy>,
-            Vec<Bond>,
-        ),
-        CasperError,
-    > {
+    ) -> Result<interpreter_util::DeploysCheckpoint, CasperError> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -1043,7 +1030,12 @@ async fn validate_block_checkpoint_should_return_a_checkpoint_with_the_right_has
             .await
             .expect("Failed to compute deploys checkpoint");
 
-            let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) = deploys_checkpoint;
+            let interpreter_util::DeploysCheckpoint {
+                pre_state_hash,
+                post_state_hash: computed_ts_hash,
+                deploys: processed_deploys,
+                ..
+            } = deploys_checkpoint;
 
             let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
             let block = block_generator::create_block(
@@ -1160,7 +1152,12 @@ contract @"recursionTest"(@list) = {
             .await
             .expect("Failed to compute deploys checkpoint");
 
-            let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) = deploys_checkpoint;
+            let interpreter_util::DeploysCheckpoint {
+                pre_state_hash,
+                post_state_hash: computed_ts_hash,
+                deploys: processed_deploys,
+                ..
+            } = deploys_checkpoint;
 
             let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
             let block = block_generator::create_block(
@@ -1281,7 +1278,12 @@ async fn validate_block_checkpoint_should_pass_persistent_produce_test_with_caus
             .await
             .expect("Failed to compute deploys checkpoint");
 
-            let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) = deploys_checkpoint;
+            let interpreter_util::DeploysCheckpoint {
+                pre_state_hash,
+                post_state_hash: computed_ts_hash,
+                deploys: processed_deploys,
+                ..
+            } = deploys_checkpoint;
 
             let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
             let block = block_generator::create_block(
@@ -1398,7 +1400,12 @@ new loop, primeCheck, stdoutAck(`rho:io:stdoutAck`) in {
             .await
             .expect("Failed to compute deploys checkpoint");
 
-            let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) = deploys_checkpoint;
+            let interpreter_util::DeploysCheckpoint {
+                pre_state_hash,
+                post_state_hash: computed_ts_hash,
+                deploys: processed_deploys,
+                ..
+            } = deploys_checkpoint;
 
             let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
             let block = block_generator::create_block(
@@ -1507,8 +1514,12 @@ async fn validate_block_checkpoint_should_pass_tests_involving_races() {
                 .await
                 .expect("Failed to compute deploys checkpoint");
 
-                let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) =
-                    deploys_checkpoint;
+                let interpreter_util::DeploysCheckpoint {
+                    pre_state_hash,
+                    post_state_hash: computed_ts_hash,
+                    deploys: processed_deploys,
+                    ..
+                } = deploys_checkpoint;
 
                 let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
                 let block = block_generator::create_block(
@@ -1607,7 +1618,12 @@ async fn validate_block_checkpoint_should_return_none_for_logs_containing_extra_
             .await
             .expect("Failed to compute deploys checkpoint");
 
-            let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) = deploys_checkpoint;
+            let interpreter_util::DeploysCheckpoint {
+                pre_state_hash,
+                post_state_hash: computed_ts_hash,
+                deploys: processed_deploys,
+                ..
+            } = deploys_checkpoint;
 
             // create single deploy with log that includes excess comm events
             let mut bad_processed_deploy = processed_deploys[0].clone();
@@ -1738,8 +1754,12 @@ async fn validate_block_checkpoint_should_pass_map_update_test() {
                 .await
                 .expect("Failed to compute deploys checkpoint");
 
-                let (pre_state_hash, computed_ts_hash, processed_deploys, _, _, _) =
-                    deploys_checkpoint;
+                let interpreter_util::DeploysCheckpoint {
+                    pre_state_hash,
+                    post_state_hash: computed_ts_hash,
+                    deploys: processed_deploys,
+                    ..
+                } = deploys_checkpoint;
 
                 let creator = ctx.genesis_context.validator_pks()[0].bytes.clone();
                 let block = block_generator::create_block(

--- a/casper/tests/util/rholang/runtime_manager_test.rs
+++ b/casper/tests/util/rholang/runtime_manager_test.rs
@@ -1923,7 +1923,7 @@ async fn bridge_query_survives_multi_parent_merge() {
         .map(|d| d.deploy)
         .collect();
     let snapshot_a = mk_snapshot(&genesis_hash);
-    let (_, post_state_a, pd_a, _, sys_pd_a, bonds_a) = compute_deploys_checkpoint(
+    let checkpoint_a = compute_deploys_checkpoint(
         &mut block_store,
         parents_a,
         deploys_a,
@@ -1938,16 +1938,16 @@ async fn bridge_query_survives_multi_parent_merge() {
     .expect("compute block A");
 
     assert!(
-        !pd_a[0].is_failed,
+        !checkpoint_a.deploys[0].is_failed,
         "Bridge deploy failed: {:?}",
-        pd_a[0].system_deploy_error
+        checkpoint_a.deploys[0].system_deploy_error
     );
 
     let mut block_a = block_a_raw;
-    block_a.body.state.post_state_hash = post_state_a.clone();
-    block_a.body.deploys = pd_a.clone();
-    block_a.body.system_deploys = sys_pd_a;
-    block_a.body.state.bonds = bonds_a;
+    block_a.body.state.post_state_hash = checkpoint_a.post_state_hash.clone();
+    block_a.body.deploys = checkpoint_a.deploys.clone();
+    block_a.body.system_deploys = checkpoint_a.system_deploys;
+    block_a.body.state.bonds = checkpoint_a.bonds;
     block_store.put_block_message(&block_a).expect("store A");
     dag_storage
         .insert(
@@ -1959,8 +1959,8 @@ async fn bridge_query_survives_multi_parent_merge() {
     // Verify bridge wrote data and extract queryUri
     let bridge_data = rm
         .get_data(
-            post_state_a.clone(),
-            &make_deploy_id_par(&pd_a[0].deploy.sig),
+            checkpoint_a.post_state_hash.clone(),
+            &make_deploy_id_par(&checkpoint_a.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
@@ -2008,7 +2008,7 @@ async fn bridge_query_survives_multi_parent_merge() {
 
     let parents_b = vec![genesis_block.clone()];
     let snapshot_b = mk_snapshot(&genesis_hash);
-    let (_, post_state_b, pd_b, _, sys_pd_b, bonds_b) = compute_deploys_checkpoint(
+    let checkpoint_b = compute_deploys_checkpoint(
         &mut block_store,
         parents_b,
         Vec::new(),
@@ -2023,10 +2023,10 @@ async fn bridge_query_survives_multi_parent_merge() {
     .expect("compute block B");
 
     let mut block_b = block_b_raw;
-    block_b.body.state.post_state_hash = post_state_b.clone();
-    block_b.body.deploys = pd_b;
-    block_b.body.system_deploys = sys_pd_b;
-    block_b.body.state.bonds = bonds_b;
+    block_b.body.state.post_state_hash = checkpoint_b.post_state_hash.clone();
+    block_b.body.deploys = checkpoint_b.deploys;
+    block_b.body.system_deploys = checkpoint_b.system_deploys;
+    block_b.body.state.bonds = checkpoint_b.bonds;
     block_store.put_block_message(&block_b).expect("store B");
     dag_storage
         .insert(
@@ -2061,7 +2061,7 @@ async fn bridge_query_survives_multi_parent_merge() {
         merged
             .rejected_user
             .iter()
-            .map(|(s, _)| hex::encode(&s[..8.min(s.len())]))
+            .map(|record| hex::encode(&record.sig[..8.min(record.sig.len())]))
             .collect::<Vec<_>>()
     );
     // Non-slash merge scenario must surface an empty rejected_slashes list so
@@ -2116,7 +2116,7 @@ in {{
         .map(|d| d.deploy)
         .collect();
     let snapshot_q = mk_snapshot(&genesis_hash);
-    let (_, post_state_q, pd_q, _, _, _) = compute_deploys_checkpoint(
+    let checkpoint_q = compute_deploys_checkpoint(
         &mut block_store,
         parents_q,
         deploys_q,
@@ -2131,13 +2131,16 @@ in {{
     .expect("compute query block");
 
     assert!(
-        !pd_q[0].is_failed,
+        !checkpoint_q.deploys[0].is_failed,
         "Query deploy failed: {:?}",
-        pd_q[0].system_deploy_error
+        checkpoint_q.deploys[0].system_deploy_error
     );
 
     let query_data = rm
-        .get_data(post_state_q, &make_deploy_id_par(&pd_q[0].deploy.sig))
+        .get_data(
+            checkpoint_q.post_state_hash,
+            &make_deploy_id_par(&checkpoint_q.deploys[0].deploy.sig),
+        )
         .await
         .unwrap();
 
@@ -2297,7 +2300,7 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         .map(|d| d.deploy)
         .collect();
     let snapshot_a = mk_snapshot(&genesis_hash);
-    let (_, post_state_a, pd_a, _, sys_pd_a, bonds_a) = compute_deploys_checkpoint(
+    let checkpoint_a = compute_deploys_checkpoint(
         &mut block_store,
         parents_a,
         deploys_a,
@@ -2312,21 +2315,21 @@ async fn concurrent_registry_inserts_should_not_conflict() {
     .expect("compute block A");
 
     assert!(
-        !pd_a[0].is_failed,
+        !checkpoint_a.deploys[0].is_failed,
         "Contract A deploy failed: {:?}",
-        pd_a[0].system_deploy_error
+        checkpoint_a.deploys[0].system_deploy_error
     );
     tracing::info!(
         "Block A: cost={}, events={}",
-        pd_a[0].cost.cost,
-        pd_a[0].deploy_log.len()
+        checkpoint_a.deploys[0].cost.cost,
+        checkpoint_a.deploys[0].deploy_log.len()
     );
 
     let mut block_a = block_a_raw;
-    block_a.body.state.post_state_hash = post_state_a.clone();
-    block_a.body.deploys = pd_a.clone();
-    block_a.body.system_deploys = sys_pd_a;
-    block_a.body.state.bonds = bonds_a;
+    block_a.body.state.post_state_hash = checkpoint_a.post_state_hash.clone();
+    block_a.body.deploys = checkpoint_a.deploys.clone();
+    block_a.body.system_deploys = checkpoint_a.system_deploys;
+    block_a.body.state.bonds = checkpoint_a.bonds;
     block_store.put_block_message(&block_a).expect("store A");
     dag_storage
         .insert(&block_a, InsertMode::Normal)
@@ -2360,7 +2363,7 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         .map(|d| d.deploy)
         .collect();
     let snapshot_b = mk_snapshot(&genesis_hash);
-    let (_, post_state_b, pd_b, _, sys_pd_b, bonds_b) = compute_deploys_checkpoint(
+    let checkpoint_b = compute_deploys_checkpoint(
         &mut block_store,
         parents_b,
         deploys_b,
@@ -2375,21 +2378,21 @@ async fn concurrent_registry_inserts_should_not_conflict() {
     .expect("compute block B");
 
     assert!(
-        !pd_b[0].is_failed,
+        !checkpoint_b.deploys[0].is_failed,
         "Contract B deploy failed: {:?}",
-        pd_b[0].system_deploy_error
+        checkpoint_b.deploys[0].system_deploy_error
     );
     tracing::info!(
         "Block B: cost={}, events={}",
-        pd_b[0].cost.cost,
-        pd_b[0].deploy_log.len()
+        checkpoint_b.deploys[0].cost.cost,
+        checkpoint_b.deploys[0].deploy_log.len()
     );
 
     let mut block_b = block_b_raw;
-    block_b.body.state.post_state_hash = post_state_b.clone();
-    block_b.body.deploys = pd_b.clone();
-    block_b.body.system_deploys = sys_pd_b;
-    block_b.body.state.bonds = bonds_b;
+    block_b.body.state.post_state_hash = checkpoint_b.post_state_hash.clone();
+    block_b.body.deploys = checkpoint_b.deploys.clone();
+    block_b.body.system_deploys = checkpoint_b.system_deploys;
+    block_b.body.state.bonds = checkpoint_b.bonds;
     block_store.put_block_message(&block_b).expect("store B");
     dag_storage
         .insert(&block_b, InsertMode::Normal)
@@ -2407,13 +2410,13 @@ async fn concurrent_registry_inserts_should_not_conflict() {
             );
 
         let eli_a = create_event_log_index(
-            &pd_a[0].deploy_log,
+            &checkpoint_a.deploys[0].deploy_log,
             history_repo.clone(),
             &genesis_hash_b256,
             std::collections::BTreeMap::new(),
         );
         let eli_b = create_event_log_index(
-            &pd_b[0].deploy_log,
+            &checkpoint_b.deploys[0].deploy_log,
             history_repo.clone(),
             &genesis_hash_b256,
             std::collections::BTreeMap::new(),
@@ -2465,9 +2468,9 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         // Search deploy A's event log for COMMs involving racing channels
         tracing::info!(
             "Searching deploy A events ({} total) for racing channels...",
-            pd_a[0].deploy_log.len()
+            checkpoint_a.deploys[0].deploy_log.len()
         );
-        for (idx, event) in pd_a[0].deploy_log.iter().enumerate() {
+        for (idx, event) in checkpoint_a.deploys[0].deploy_log.iter().enumerate() {
             use models::rust::casper::protocol::casper_message::Event as CasperEvent;
             match event {
                 CasperEvent::Comm(comm) => {
@@ -2581,10 +2584,7 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         let rejected_sigs: Vec<String> = merged
             .rejected_user
             .iter()
-            .map(|(s, _)| s.clone())
-            .collect::<Vec<_>>()
-            .iter()
-            .map(|d| hex::encode(&d[..std::cmp::min(8, d.len())]))
+            .map(|record| hex::encode(&record.sig[..std::cmp::min(8, record.sig.len())]))
             .collect();
         tracing::warn!(
             "CONFLICT DETECTED: {} deploys rejected: {:?}",
@@ -2593,8 +2593,8 @@ async fn concurrent_registry_inserts_should_not_conflict() {
         );
 
         // Identify which deploy was rejected
-        let a_sig = hex::encode(&pd_a[0].deploy.sig[..8]);
-        let b_sig = hex::encode(&pd_b[0].deploy.sig[..8]);
+        let a_sig = hex::encode(&checkpoint_a.deploys[0].deploy.sig[..8]);
+        let b_sig = hex::encode(&checkpoint_b.deploys[0].deploy.sig[..8]);
         let a_rejected = rejected_sigs.contains(&a_sig);
         let b_rejected = rejected_sigs.contains(&b_sig);
         tracing::warn!(
@@ -2638,14 +2638,14 @@ async fn concurrent_registry_inserts_should_not_conflict() {
     let data_a = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_a[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_a.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
     let data_b = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_b[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_b.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
@@ -3068,7 +3068,7 @@ new deployId(`rho:system:deployId`) in {
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_a, pd_a, _, sys_pd_a, bonds_a) = compute_deploys_checkpoint(
+    let checkpoint_a = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&block_a_raw)
@@ -3085,15 +3085,15 @@ new deployId(`rho:system:deployId`) in {
     .await
     .expect("compute block A");
     assert!(
-        !pd_a[0].is_failed,
+        !checkpoint_a.deploys[0].is_failed,
         "Bridge A failed: {:?}",
-        pd_a[0].system_deploy_error
+        checkpoint_a.deploys[0].system_deploy_error
     );
     let mut block_a = block_a_raw;
-    block_a.body.state.post_state_hash = post_state_a.clone();
-    block_a.body.deploys = pd_a.clone();
-    block_a.body.system_deploys = sys_pd_a;
-    block_a.body.state.bonds = bonds_a;
+    block_a.body.state.post_state_hash = checkpoint_a.post_state_hash.clone();
+    block_a.body.deploys = checkpoint_a.deploys.clone();
+    block_a.body.system_deploys = checkpoint_a.system_deploys;
+    block_a.body.state.bonds = checkpoint_a.bonds;
     block_store.put_block_message(&block_a).expect("store A");
     dag_storage
         .insert(&block_a, InsertMode::Normal)
@@ -3125,7 +3125,7 @@ new deployId(`rho:system:deployId`) in {
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_b, pd_b, _, sys_pd_b, bonds_b) = compute_deploys_checkpoint(
+    let checkpoint_b = compute_deploys_checkpoint(
         &mut block_store,
         vec![genesis_block.clone()],
         proto_util::deploys(&block_b_raw)
@@ -3142,15 +3142,15 @@ new deployId(`rho:system:deployId`) in {
     .await
     .expect("compute block B");
     assert!(
-        !pd_b[0].is_failed,
+        !checkpoint_b.deploys[0].is_failed,
         "Bridge B failed: {:?}",
-        pd_b[0].system_deploy_error
+        checkpoint_b.deploys[0].system_deploy_error
     );
     let mut block_b = block_b_raw;
-    block_b.body.state.post_state_hash = post_state_b.clone();
-    block_b.body.deploys = pd_b.clone();
-    block_b.body.system_deploys = sys_pd_b;
-    block_b.body.state.bonds = bonds_b;
+    block_b.body.state.post_state_hash = checkpoint_b.post_state_hash.clone();
+    block_b.body.deploys = checkpoint_b.deploys.clone();
+    block_b.body.system_deploys = checkpoint_b.system_deploys;
+    block_b.body.state.bonds = checkpoint_b.bonds;
     block_store.put_block_message(&block_b).expect("store B");
     dag_storage
         .insert(&block_b, InsertMode::Normal)
@@ -3169,7 +3169,7 @@ new deployId(`rho:system:deployId`) in {
     let block_c_raw = block_implicits::get_random_block(
         Some(2),
         Some(3),
-        Some(post_state_a.clone()),
+        Some(checkpoint_a.post_state_hash.clone()),
         Some(StateHash::default()),
         Some(validator.clone()),
         Some(1),
@@ -3182,7 +3182,7 @@ new deployId(`rho:system:deployId`) in {
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_c, pd_c, _, sys_pd_c, bonds_c) = compute_deploys_checkpoint(
+    let checkpoint_c = compute_deploys_checkpoint(
         &mut block_store,
         vec![block_a.clone()],
         proto_util::deploys(&block_c_raw)
@@ -3199,15 +3199,15 @@ new deployId(`rho:system:deployId`) in {
     .await
     .expect("compute block C");
     assert!(
-        !pd_c[0].is_failed,
+        !checkpoint_c.deploys[0].is_failed,
         "Trivial C failed: {:?}",
-        pd_c[0].system_deploy_error
+        checkpoint_c.deploys[0].system_deploy_error
     );
     let mut block_c = block_c_raw;
-    block_c.body.state.post_state_hash = post_state_c.clone();
-    block_c.body.deploys = pd_c.clone();
-    block_c.body.system_deploys = sys_pd_c;
-    block_c.body.state.bonds = bonds_c;
+    block_c.body.state.post_state_hash = checkpoint_c.post_state_hash.clone();
+    block_c.body.deploys = checkpoint_c.deploys.clone();
+    block_c.body.system_deploys = checkpoint_c.system_deploys;
+    block_c.body.state.bonds = checkpoint_c.bonds;
     block_store.put_block_message(&block_c).expect("store C");
     dag_storage
         .insert(&block_c, InsertMode::Normal)
@@ -3220,7 +3220,7 @@ new deployId(`rho:system:deployId`) in {
     let block_d_raw = block_implicits::get_random_block(
         Some(2),
         Some(4),
-        Some(post_state_b.clone()),
+        Some(checkpoint_b.post_state_hash.clone()),
         Some(StateHash::default()),
         Some(validator.clone()),
         Some(1),
@@ -3233,7 +3233,7 @@ new deployId(`rho:system:deployId`) in {
         Some(shard_name.clone()),
         None,
     );
-    let (_, post_state_d, pd_d, _, sys_pd_d, bonds_d) = compute_deploys_checkpoint(
+    let checkpoint_d = compute_deploys_checkpoint(
         &mut block_store,
         vec![block_b.clone()],
         proto_util::deploys(&block_d_raw)
@@ -3250,15 +3250,15 @@ new deployId(`rho:system:deployId`) in {
     .await
     .expect("compute block D");
     assert!(
-        !pd_d[0].is_failed,
+        !checkpoint_d.deploys[0].is_failed,
         "Trivial D failed: {:?}",
-        pd_d[0].system_deploy_error
+        checkpoint_d.deploys[0].system_deploy_error
     );
     let mut block_d = block_d_raw;
-    block_d.body.state.post_state_hash = post_state_d.clone();
-    block_d.body.deploys = pd_d.clone();
-    block_d.body.system_deploys = sys_pd_d;
-    block_d.body.state.bonds = bonds_d;
+    block_d.body.state.post_state_hash = checkpoint_d.post_state_hash.clone();
+    block_d.body.deploys = checkpoint_d.deploys.clone();
+    block_d.body.system_deploys = checkpoint_d.system_deploys;
+    block_d.body.state.bonds = checkpoint_d.bonds;
     block_store.put_block_message(&block_d).expect("store D");
     dag_storage
         .insert(&block_d, InsertMode::Normal)
@@ -3287,12 +3287,12 @@ new deployId(`rho:system:deployId`) in {
     let rejected_set: HashSet<prost::bytes::Bytes> = merged
         .rejected_user
         .iter()
-        .map(|(s, _)| s.clone())
+        .map(|record| record.sig.clone())
         .collect();
-    let ba_rejected = rejected_set.contains(&pd_a[0].deploy.sig);
-    let bb_rejected = rejected_set.contains(&pd_b[0].deploy.sig);
-    let bc_rejected = rejected_set.contains(&pd_c[0].deploy.sig);
-    let bd_rejected = rejected_set.contains(&pd_d[0].deploy.sig);
+    let ba_rejected = rejected_set.contains(&checkpoint_a.deploys[0].deploy.sig);
+    let bb_rejected = rejected_set.contains(&checkpoint_b.deploys[0].deploy.sig);
+    let bc_rejected = rejected_set.contains(&checkpoint_c.deploys[0].deploy.sig);
+    let bd_rejected = rejected_set.contains(&checkpoint_d.deploys[0].deploy.sig);
 
     tracing::info!("──────── Rejection outcome ────────");
     tracing::info!(
@@ -3316,28 +3316,28 @@ new deployId(`rho:system:deployId`) in {
     let ba_data = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_a[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_a.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
     let bb_data = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_b[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_b.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
     let bc_data = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_c[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_c.deploys[0].deploy.sig),
         )
         .await
         .unwrap();
     let bd_data = rm
         .get_data(
             merged.state.clone(),
-            &make_deploy_id_par(&pd_d[0].deploy.sig),
+            &make_deploy_id_par(&checkpoint_d.deploys[0].deploy.sig),
         )
         .await
         .unwrap();

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -190,7 +190,18 @@ message BodyProto {
 }
 
 message RejectedDeployProto{
-  bytes sig = 1;
+  bytes sig       = 1;
+  // Set by the merge that formed this record when the sig's effect is
+  // present in that merge's own post-state (a kept copy in the same merge,
+  // or already settled in its base): the record discarded a redundant copy
+  // and does not dispute the sig's standing win. Validators recompute the
+  // flag during checkpoint validation; a mismatch invalidates the block.
+  bool duplicate  = 2;
+  // The block that held the copy this record adjudicated. The merge knows
+  // it exactly (the rejected chain's source block); recording it makes
+  // coverage an equality instead of an inference. Validators recompute the
+  // carrier during checkpoint validation; a mismatch invalidates the block.
+  bytes carrier   = 3;
 }
 
 message JustificationProto {

--- a/models/src/rust/casper/protocol/casper_message.rs
+++ b/models/src/rust/casper/protocol/casper_message.rs
@@ -422,15 +422,35 @@ impl Header {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RejectedDeploy {
     pub sig: ByteString,
+    /// Set by the merge that formed this record when the sig's effect is
+    /// present in that merge's own post-state (a kept copy in the same
+    /// merge, or already settled in its base): the record discarded a
+    /// redundant copy and does not dispute the sig's standing win.
+    pub duplicate: bool,
+    /// The block that held the copy this record adjudicated — the rejected
+    /// chain's source block, recorded by the forming merge.
+    pub carrier: ByteString,
 }
 
 impl RejectedDeploy {
-    pub fn from_proto(proto: RejectedDeployProto) -> Self { Self { sig: proto.sig } }
+    pub fn from_proto(proto: RejectedDeployProto) -> Self {
+        Self {
+            sig: proto.sig,
+            duplicate: proto.duplicate,
+            carrier: proto.carrier,
+        }
+    }
 
-    pub fn to_proto(self) -> RejectedDeployProto { RejectedDeployProto { sig: self.sig } }
+    pub fn to_proto(self) -> RejectedDeployProto {
+        RejectedDeployProto {
+            sig: self.sig,
+            duplicate: self.duplicate,
+            carrier: self.carrier,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
Layer 2: rejection records are full consensus content — each names the carrier block it adjudicated and carries a formation-time duplicate flag.

- Records travel merge → checkpoint → block body structurally (the strip sites are gone, not patched); validation compares full records and the same-block sig-set exemption is closed.
- The height-blind rejection suppressor is replaced by exact (sig, carrier, flag) record matching.
- Format break: `RejectedDeployProto` gains fields 2–3. proto3 default-omission keeps the genesis encoding byte-stable, so no fixture regeneration.

Co-Authored-By: Claude <noreply@anthropic.com>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
