### PR TITLE
fix(rspace): merge-apply hardening — absent-removal error, netted no-op

### DIFF
--- a/casper/tests/batch2/mod.rs
+++ b/casper/tests/batch2/mod.rs
@@ -9,6 +9,7 @@ pub mod limited_parent_depth_spec;
 pub mod lmdb_key_value_store_spec;
 pub mod map_cell_convergence_spec;
 pub mod multi_validator_recovery_spec;
+pub mod netted_noop_merge_spec;
 pub mod recovery_cycle_spec;
 pub mod recovery_repeat_deploy_misfire_spec;
 pub mod rholang_build_test;

--- a/casper/tests/batch2/netted_noop_merge_spec.rs
+++ b/casper/tests/batch2/netted_noop_merge_spec.rs
@@ -1,0 +1,238 @@
+// A continuation installed on one chain and COMM-fired by a dependent
+// chain, both inside ONE merge scope, net to an empty channel change
+// (`ChannelChange::cancel_common`). The netted no-op is a legitimate
+// merge outcome — the consume pointer ends exactly at base — and the
+// merge must form. The pre-fix merger raised `Merging logic error:
+// empty consume change when computing trie action` instead, failing the
+// whole propose: every validator whose parent view spanned the pair was
+// silenced simultaneously (the error is a pure function of the view).
+// The shape needs no conflict and no rejection — clean dependent
+// execution — so no recovery narrowing exists to route around it.
+//
+// Choreography (three validators, stakes {1,3,5}; the 5/9-stake v2 stays
+// SILENT so v0+v1's 4/9 can never witness anything and the floor stays
+// pinned at genesis — the install chain must remain ABOVE the merge base
+// for the pair to net; a floor that reaches W settles the install into
+// the base and defuses the shape, which is exactly why the defect fires
+// under floor lag):
+//
+//   genesis <- W (v0: `for (@x <- @"nn_cell") { @"nn_out"!(x) }` —
+//                installs the waiting continuation, no datum yet)
+//   W <- P       (v1: `@"nn_cell"!(42)` — the produce COMM-fires the
+//                waiting continuation; @"nn_out" receives 42)
+//   W <- F       (v0: unrelated marker, sibling of P)
+//   [P, F] <- M  (v0 merges over the genesis cut: scope = {W, P, F}; W's
+//                install chain and P's fire chain are dependency-grouped
+//                into one branch; their cont changes net to empty.
+//                THE PIN: M must form and validate.)
+
+use casper::rust::casper::MultiParentCasper;
+use casper::rust::util::construct_deploy;
+use models::rhoapi::expr::ExprInstance;
+use models::rhoapi::{Expr, Par};
+use rspace_plus_plus::rspace::history::Either;
+use serial_test::serial;
+
+use crate::helper::test_node::TestNode;
+use crate::util::genesis_builder::GenesisBuilder;
+
+fn gstring_channel(name: &str) -> Par {
+    Par {
+        exprs: vec![Expr {
+            expr_instance: Some(ExprInstance::GString(name.to_string())),
+        }],
+        ..Default::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn netted_install_fire_pair_merges_as_a_noop() {
+    let n_validators = 3usize;
+    let genesis_parameters =
+        GenesisBuilder::build_genesis_parameters_with_defaults(None, Some(n_validators));
+    let genesis = GenesisBuilder::new()
+        .build_genesis_with_parameters(Some(genesis_parameters))
+        .await
+        .unwrap();
+    let shard_id = genesis.genesis_block.shard_id.clone();
+
+    let mut nodes = TestNode::create_network(genesis, n_validators, None, None, None, None)
+        .await
+        .expect("create_network");
+    for node in nodes.iter_mut() {
+        node.allow_empty_blocks = true;
+    }
+
+    // W: v0 installs the waiting continuation (no datum on the cell yet).
+    let install = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"for (@x <- @"nn_cell") { @"nn_out"!(x) }"#.to_string(),
+            None,
+            None,
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            Some(0),
+            Some(shard_id.clone()),
+        )
+        .expect("build install deploy")
+    };
+    let block_w = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&install))
+        .await
+        .expect("v0 proposes W (install)");
+    nodes[1]
+        .process_block(block_w.clone())
+        .await
+        .expect("v1 processes W");
+
+    // P: v1 produces into the cell — the COMM fires W's continuation.
+    let fire = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::source_deploy_now_full(
+            r#"@"nn_cell"!(42)"#.to_string(),
+            None,
+            None,
+            Some(construct_deploy::DEFAULT_SEC2.clone()),
+            Some(0),
+            Some(shard_id.clone()),
+        )
+        .expect("build fire deploy")
+    };
+    let block_p = nodes[1]
+        .add_block_from_deploys(std::slice::from_ref(&fire))
+        .await
+        .expect("v1 proposes P (fire)");
+
+    // F: v0's unrelated sibling of P, so the next proposal is a real merge.
+    let marker = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(
+            7,
+            Some(construct_deploy::DEFAULT_SEC.clone()),
+            Some(shard_id.clone()),
+        )
+        .expect("build marker")
+    };
+    let block_f = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&marker))
+        .await
+        .expect("v0 proposes F (marker sibling)");
+    nodes[1]
+        .process_block(block_f.clone())
+        .await
+        .expect("v1 processes F");
+
+    nodes[0]
+        .process_block(block_p.clone())
+        .await
+        .expect("v0 processes P");
+
+    // THE PIN: the merge over [P, F] spans W's install chain and P's fire
+    // chain; their netted cont change must merge as a no-op. Pre-fix this
+    // propose died with `empty consume change when computing trie action`.
+    let block_m = nodes[0]
+        .create_block_unsafe(&[])
+        .await
+        .expect("the netted install+fire pair must merge, not error the propose");
+    // Genesis may ride along as an extra parent: the silent v2's latest
+    // message is genesis, and covered-ancestor parents are legal.
+    assert!(
+        block_m
+            .header
+            .parents_hash_list
+            .contains(&block_p.block_hash)
+            && block_m
+                .header
+                .parents_hash_list
+                .contains(&block_f.block_hash),
+        "fixture precondition: M must merge P and F; parents={:?}",
+        block_m
+            .header
+            .parents_hash_list
+            .iter()
+            .map(|h| hex::encode(&h[..4.min(h.len())]))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        block_m.body.rejected_deploys.is_empty(),
+        "clean dependent execution: nothing may be rejected (got {:?})",
+        block_m
+            .body
+            .rejected_deploys
+            .iter()
+            .map(|rd| hex::encode(&rd.sig[..8.min(rd.sig.len())]))
+            .collect::<Vec<_>>()
+    );
+
+    let own_outcome = nodes[0]
+        .process_block(block_m.clone())
+        .await
+        .expect("v0 processes its own merge");
+    assert!(
+        matches!(own_outcome, Either::Right(_)),
+        "v0 must admit its own netted-noop merge; got {:?}",
+        own_outcome
+    );
+    let outcome = nodes[1]
+        .process_block(block_m.clone())
+        .await
+        .expect("v1 processes M");
+    assert!(
+        matches!(outcome, Either::Right(_)),
+        "v1 must validate the netted-noop merge identically; got {:?}",
+        outcome
+    );
+
+    // Fixture precondition: the merge ran over the GENESIS cut — the
+    // install chain was still above the base, so the netting genuinely
+    // occurred (a floor that reaches W settles the install into the base
+    // and this spec stops testing anything).
+    {
+        let dag = nodes[0].casper.block_dag().await.expect("dag");
+        let ftt = casper::rust::safety::clique_oracle::FtThreshold::from_ppm(
+            nodes[0]
+                .casper
+                .casper_shard_conf()
+                .fault_tolerance_threshold_ppm,
+        );
+        let floor = casper::rust::finality::floor::floor_of_block(&dag, &block_m.block_hash, ftt)
+            .await
+            .expect("floor_of_block(M)");
+        assert_eq!(
+            floor.block_number, 0,
+            "fixture precondition: M's floor must still be genesis so the \
+             install chain is in merge scope; got floor #{}",
+            floor.block_number
+        );
+    }
+
+    // The COMM's outcome lands exactly once and the cell ends empty: the
+    // fired continuation must be neither re-inserted nor double-applied.
+    let out_data = nodes[0]
+        .runtime_manager
+        .get_data(
+            block_m.body.state.post_state_hash.clone(),
+            &gstring_channel("nn_out"),
+        )
+        .await
+        .expect("read @\"nn_out\"");
+    assert_eq!(
+        out_data.len(),
+        1,
+        "the fired continuation's output must land exactly once"
+    );
+    let cell_data = nodes[0]
+        .runtime_manager
+        .get_data(
+            block_m.body.state.post_state_hash.clone(),
+            &gstring_channel("nn_cell"),
+        )
+        .await
+        .expect("read @\"nn_cell\"");
+    assert!(
+        cell_data.is_empty(),
+        "the consumed cell must end empty in the merged state; datums: {}",
+        cell_data.len()
+    );
+}

--- a/rspace++/src/rspace/merger/state_change_merger.rs
+++ b/rspace++/src/rspace/merger/state_change_merger.rs
@@ -66,6 +66,22 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
     let consume_with_join_actions: Vec<ConsumeAndJoinActions<C, P, A, K>> = cont_changes_sorted
         .iter()
         .map(|(consume_channels, channel_change)| {
+            // A fully-netted change — a continuation installed by one chain
+            // and COMM-fired by a dependent chain in the same merge, both
+            // sides cancelled by `ChannelChange::cancel_common` — is a
+            // legitimate no-op: the consume pointer ends exactly at base.
+            // No trie action, no join action. Only an entry that still
+            // CLAIMS content and produces no delta is incoherence (the
+            // `init == new_val` error below).
+            if channel_change.added.is_empty() && channel_change.removed.is_empty() {
+                tracing::debug!(
+                    target: "f1r3fly.merge.step",
+                    step = "compute_trie_actions.CONT_NETTED_NOOP",
+                    n_channels = consume_channels.len(),
+                    "fully-netted cont change (install+fire cancelled) -> no-op",
+                );
+                return Ok(None);
+            }
             // Use hash_from_hashes to match EXEC path's hash_from_vec behavior:
             // The EXEC path uses hash_from_vec(&channels) which serializes each channel,
             // hashes each, sorts, concatenates, and hashes again.
@@ -120,7 +136,7 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                     new_konts = new_val.len(),
                     "base empty -> TrieInsertConsume + AddJoin",
                 );
-                Ok(ConsumeAndJoinActions {
+                Ok(Some(ConsumeAndJoinActions {
                     consume_action: HotStoreTrieAction::TrieInsertAction(
                         TrieInsertAction::TrieInsertBinaryConsume(TrieInsertBinaryConsume {
                             hash: history_pointer,
@@ -128,7 +144,7 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                         }),
                     ),
                     join_action: Some(JoinActionKind::AddJoin(consume_channels.clone())),
-                })
+                }))
             } else if new_val.is_empty() {
                 // All konts present in base are removed - remove consume, remove join.
                 tracing::debug!(
@@ -138,14 +154,14 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                     base_konts = init.len(),
                     "all base konts removed -> TrieDeleteConsume + RemoveJoin",
                 );
-                Ok(ConsumeAndJoinActions {
+                Ok(Some(ConsumeAndJoinActions {
                     consume_action: HotStoreTrieAction::TrieDeleteAction(
                         TrieDeleteAction::TrieDeleteConsume(TrieDeleteConsume {
                             hash: history_pointer,
                         }),
                     ),
                     join_action: Some(JoinActionKind::RemoveJoin(consume_channels.clone())),
-                })
+                }))
             } else {
                 // Konts were updated but consume is present in base state - update konts, no
                 // joins.
@@ -157,7 +173,7 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                     new_konts = new_val.len(),
                     "konts updated, consume present in base -> TrieInsertConsume, no join change",
                 );
-                Ok(ConsumeAndJoinActions {
+                Ok(Some(ConsumeAndJoinActions {
                     consume_action: HotStoreTrieAction::TrieInsertAction(
                         TrieInsertAction::TrieInsertBinaryConsume(TrieInsertBinaryConsume {
                             hash: history_pointer,
@@ -165,10 +181,13 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                         }),
                     ),
                     join_action: None,
-                })
+                }))
             }
         })
-        .collect::<Result<Vec<ConsumeAndJoinActions<C, P, A, K>>, HistoryError>>()?;
+        .collect::<Result<Vec<Option<ConsumeAndJoinActions<C, P, A, K>>>, HistoryError>>()?
+        .into_iter()
+        .flatten()
+        .collect();
 
     let consume_trie_actions = consume_with_join_actions
         .iter()
@@ -211,7 +230,21 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                         channel = %hex::encode(history_pointer.clone().bytes()),
                         "handle_channel_change produced number-channel trie action (override)",
                     );
-                    Ok(action)
+                    Ok(Some(action))
+                }
+                // A fully-netted change (a produce and its dependent consume
+                // cancelled by `ChannelChange::cancel_common`) is a
+                // legitimate no-op: the channel ends exactly at base. The
+                // guard sits AFTER the override — mergeable channels derive
+                // their action from the fold's diff, not from added/removed.
+                None if changes.added.is_empty() && changes.removed.is_empty() => {
+                    tracing::debug!(
+                        target: "f1r3fly.merge.step",
+                        step = "compute_trie_actions.DATUM_NETTED_NOOP",
+                        channel = %hex::encode(history_pointer.clone().bytes()),
+                        "fully-netted datum change (produce+consume cancelled) -> no-op",
+                    );
+                    Ok(None)
                 }
                 None => make_trie_action(
                     history_pointer,
@@ -230,10 +263,14 @@ pub fn compute_trie_actions<C: Clone, P: Clone, A: Clone, K: Clone>(
                             }),
                         )
                     },
-                ),
+                )
+                .map(Some),
             }
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<Option<_>>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
 
     // Process joins changes
     let joins_channels_to_body_map = &changes.consume_channels_to_join_serialized_map;
@@ -622,6 +659,120 @@ mod tests {
             result.is_err(),
             "a datum removal absent from the base must hard-error (record incoherence), not \
              silently no-op"
+        );
+    }
+
+    /// A continuation INSTALLED by one chain and COMM-FIRED by a dependent
+    /// chain in the same merge scope nets to an EMPTY cont change
+    /// (`ChannelChange::cancel_common`) whose map entry survives the
+    /// combine. That fully-netted entry is a legitimate no-op — the
+    /// consume pointer ends exactly at base — and must produce no trie
+    /// action and no join action, never the "empty consume change"
+    /// merging-logic error, which kills every propose whose scope spans an
+    /// install+fire pair.
+    #[test]
+    fn netted_install_fire_cont_change_is_a_noop_not_an_error() {
+        let kont: Vec<u8> = vec![0xcc; 48];
+        let channel = Blake2b256Hash::from_bytes(vec![0x03; 32]);
+
+        let install = StateChange {
+            datums_changes: DashMap::new(),
+            cont_changes: {
+                let m = DashMap::new();
+                m.insert(vec![channel.clone()], ChannelChange {
+                    added: vec![kont.clone()],
+                    removed: vec![],
+                });
+                m
+            },
+            consume_channels_to_join_serialized_map: DashMap::new(),
+        };
+        let fire = StateChange {
+            datums_changes: DashMap::new(),
+            cont_changes: {
+                let m = DashMap::new();
+                m.insert(vec![channel.clone()], ChannelChange {
+                    added: vec![],
+                    removed: vec![kont],
+                });
+                m
+            },
+            consume_channels_to_join_serialized_map: DashMap::new(),
+        };
+        let combined = install.combine(fire);
+
+        // Base holds no continuations anywhere.
+        let base_reader: Box<dyn HistoryReader<Blake2b256Hash, (), (), (), ()>> =
+            Box::new(StubHistoryReaderBinary {
+                data_map: HashMap::new(),
+            });
+        let mergeable_chs: NumberChannelsDiff = BTreeMap::new();
+        let no_override =
+            |_: &Blake2b256Hash,
+             _: &ChannelChange<Vec<u8>>,
+             _: &NumberChannelsDiff|
+             -> Result<Option<HotStoreTrieAction<(), (), (), ()>>, HistoryError> {
+                Ok(None)
+            };
+
+        let actions = compute_trie_actions(&combined, &base_reader, &mergeable_chs, no_override)
+            .expect("a fully-netted cont change is a no-op, not a merge error");
+        assert!(actions.is_empty(), "no trie action may be emitted for a netted install+fire pair");
+    }
+
+    /// The datum-side twin: a seed's produce and its dependent consume in
+    /// one merge scope net to an empty datum change; the channel ends
+    /// exactly at base and must produce no trie action, never the "empty
+    /// channel change for produce or join" error.
+    #[test]
+    fn netted_produce_consume_datum_change_is_a_noop_not_an_error() {
+        let datum: Vec<u8> = vec![0xab; 32];
+        let channel = Blake2b256Hash::from_bytes(vec![0x04; 32]);
+
+        let seed = StateChange {
+            datums_changes: {
+                let m = DashMap::new();
+                m.insert(channel.clone(), ChannelChange {
+                    added: vec![datum.clone()],
+                    removed: vec![],
+                });
+                m
+            },
+            cont_changes: DashMap::new(),
+            consume_channels_to_join_serialized_map: DashMap::new(),
+        };
+        let consume = StateChange {
+            datums_changes: {
+                let m = DashMap::new();
+                m.insert(channel.clone(), ChannelChange {
+                    added: vec![],
+                    removed: vec![datum],
+                });
+                m
+            },
+            cont_changes: DashMap::new(),
+            consume_channels_to_join_serialized_map: DashMap::new(),
+        };
+        let combined = seed.combine(consume);
+
+        let base_reader: Box<dyn HistoryReader<Blake2b256Hash, (), (), (), ()>> =
+            Box::new(StubHistoryReaderBinary {
+                data_map: HashMap::new(),
+            });
+        let mergeable_chs: NumberChannelsDiff = BTreeMap::new();
+        let no_override =
+            |_: &Blake2b256Hash,
+             _: &ChannelChange<Vec<u8>>,
+             _: &NumberChannelsDiff|
+             -> Result<Option<HotStoreTrieAction<(), (), (), ()>>, HistoryError> {
+                Ok(None)
+            };
+
+        let actions = compute_trie_actions(&combined, &base_reader, &mergeable_chs, no_override)
+            .expect("a fully-netted datum change is a no-op, not a merge error");
+        assert!(
+            actions.is_empty(),
+            "no trie action may be emitted for a netted produce+consume pair"
         );
     }
 }

--- a/rspace++/src/rspace/merger/state_change_merger.rs
+++ b/rspace++/src/rspace/merger/state_change_merger.rs
@@ -356,9 +356,37 @@ fn make_trie_action<C: Clone, P: Clone, A: Clone, K: Clone>(
 ) -> Result<HotStoreTrieAction<C, P, A, K>, HistoryError> {
     let init = init_value(history_pointer)?;
 
+    // Removing an item the base does not hold is record incoherence — the
+    // availability splitters keep only chains whose consumes are available
+    // at the base, and `ChannelChange::combine` nets producer→consumer
+    // pairs before this point, so a residual absent-removal means the
+    // applied diffs disagree with the base they claim to extend. Hard
+    // error, never a silent no-op: a silent no-op is how stale diffs
+    // "apply" cleanly while the resulting state diverges from the record.
     let new_val = {
-        // Use multiset diff: remove each item in 'removed' exactly once from 'init'
-        let mut result = StateChange::multiset_diff(&init, &changes.removed);
+        let mut remove_counts: std::collections::HashMap<&Vec<u8>, usize> =
+            std::collections::HashMap::new();
+        for item in &changes.removed {
+            *remove_counts.entry(item).or_insert(0) += 1;
+        }
+        let mut result: Vec<ByteVector> = Vec::with_capacity(init.len());
+        for item in &init {
+            match remove_counts.get_mut(item) {
+                Some(count) if *count > 0 => *count -= 1,
+                _ => result.push(item.clone()),
+            }
+        }
+        let unmatched: usize = remove_counts.values().sum();
+        if unmatched > 0 {
+            return Err(HistoryError::MergeError(format!(
+                "channel {}: {} removed datum(s) absent from the base (base holds {}, diff \
+                 removes {}) — applied diffs are incoherent with the base state",
+                hex::encode(history_pointer.clone().bytes()),
+                unmatched,
+                init.len(),
+                changes.removed.len(),
+            )));
+        }
         result.extend(changes.added.clone());
         result
     };
@@ -546,5 +574,54 @@ mod tests {
             }
             other => panic!("expected TrieInsertBinaryProduce, got {:?}", other),
         }
+    }
+
+    /// Removing a datum that is NOT in the base is record incoherence, and
+    /// it must be a hard error, never a silent no-op. Upstream layers
+    /// guarantee the shape cannot occur legitimately: the availability
+    /// splitters keep only chains whose consumes are available at the base,
+    /// and `ChannelChange::combine` nets producer→consumer pairs within one
+    /// application before this point. A silent no-op here is how stale diffs
+    /// apply "cleanly" onto a base without the work they assumed — the
+    /// applied state diverges from the record while every check passes.
+    #[test]
+    fn removal_absent_from_base_is_an_error_not_a_noop() {
+        let phantom_removed: Vec<u8> = vec![0xdd; 32];
+        let datum_new: Vec<u8> = vec![0xee; 32];
+        let channel_hash = Blake2b256Hash::from_bytes(vec![0x02; 32]);
+
+        // Base holds NOTHING on the channel.
+        let base_reader: Box<dyn HistoryReader<Blake2b256Hash, (), (), (), ()>> =
+            Box::new(StubHistoryReaderBinary {
+                data_map: HashMap::new(),
+            });
+
+        let datums_changes = DashMap::new();
+        datums_changes.insert(channel_hash, ChannelChange {
+            added: vec![datum_new],
+            removed: vec![phantom_removed],
+        });
+        let changes = StateChange {
+            datums_changes,
+            cont_changes: DashMap::new(),
+            consume_channels_to_join_serialized_map: DashMap::new(),
+        };
+
+        let mergeable_chs: NumberChannelsDiff = BTreeMap::new();
+        let no_override =
+            |_: &Blake2b256Hash,
+             _: &ChannelChange<Vec<u8>>,
+             _: &NumberChannelsDiff|
+             -> Result<Option<HotStoreTrieAction<(), (), (), ()>>, HistoryError> {
+                Ok(None)
+            };
+
+        let result = compute_trie_actions(&changes, &base_reader, &mergeable_chs, no_override);
+
+        assert!(
+            result.is_err(),
+            "a datum removal absent from the base must hard-error (record incoherence), not \
+             silently no-op"
+        );
     }
 }


### PR DESCRIPTION
Two self-contained rspace merge-apply hardenings (no dependency on the layers below — placed here so they merge early).

- Removing a datum that is absent from the base is now a hard error naming the channel and counts — applied diffs incoherent with the base state must never silently no-op.
- A fully-netted channel change (adds cancel removes) is a no-op instead of a spurious merge failure; pinned end-to-end by a spec where the netted COMM lands exactly once.

Co-Authored-By: Claude <noreply@anthropic.com>

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
