### PR TITLE
perf(casper): skip repeat-deploy ancestor scan when no deploy sig is …

### DIFF
--- a/block-storage/src/rust/test/indexed_block_dag_storage.rs
+++ b/block-storage/src/rust/test/indexed_block_dag_storage.rs
@@ -34,6 +34,24 @@ impl IndexedBlockDagStorage {
         self.underlying.get_representation_internal()
     }
 
+    /// Passthrough to the underlying storage's test-only deploy-index
+    /// accessor, so tests built on this fixture can manipulate index
+    /// entries (same rationale as `BlockDagKeyValueStorage`'s accessor).
+    #[cfg(any(test, feature = "test-internals"))]
+    #[doc(hidden)]
+    pub fn deploy_index_for_tests(
+        &self,
+    ) -> Arc<
+        parking_lot::RwLock<
+            shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl<
+                crate::rust::dag::block_dag_key_value_storage::DeployId,
+                models::rust::block_hash::BlockHashSerde,
+            >,
+        >,
+    > {
+        self.underlying.deploy_index_for_tests()
+    }
+
     pub fn insert(
         &mut self,
         block: &BlockMessage,

--- a/casper/src/rust/validate.rs
+++ b/casper/src/rust/validate.rs
@@ -538,6 +538,41 @@ impl Validate {
             return Either::Right(ValidBlock::Valid);
         }
 
+        // Fast path on the persistent deploy index. `insert_internal` writes
+        // every deploy sig of every inserted block (valid, invalid and
+        // approved alike) into `deploy_index` before any child of that block
+        // can be validated, so a sig with no index entry has no prior
+        // inclusion anywhere — on any fork, inside or outside the expiration
+        // window — and cannot carry a canonical rejection either (rejected
+        // deploys were themselves carried by an inserted block). When none of
+        // this block's sigs are indexed, the parent-scope scan and the
+        // ancestor traversal below have nothing to find and are skipped —
+        // that traversal's cost grows with the in-window DAG (4ms -> 124ms
+        // per block within one soak iteration, run 31563121791), and fresh
+        // deploys are the overwhelmingly common case. Any hit falls through
+        // to the exact logic below, which stays the sole authority on
+        // whether a prior inclusion is canonical for THIS block's parent
+        // scope: the index is last-write-wins and single-valued, so it can
+        // never answer that question, only prove absence. An index read
+        // error also falls through — the fast path is an optimization,
+        // never a second opinion.
+        let any_sig_indexed = block.body.deploys.iter().any(|pd| {
+            match s.dag.lookup_by_deploy_id(&pd.deploy.sig.to_vec()) {
+                Ok(hit) => hit.is_some(),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "f1r3fly.casper",
+                        "repeat-deploy fast path: deploy index lookup failed ({}); falling back to ancestor scan",
+                        e
+                    );
+                    true
+                }
+            }
+        });
+        if !any_sig_indexed {
+            return Either::Right(ValidBlock::Valid);
+        }
+
         let block_metadata = BlockMetadata::from_block(block, false, None, None);
 
         tracing::debug!(target: "f1r3fly.casper", "before-repeat-deploy-get-parents");

--- a/casper/tests/batch2/validate_test.rs
+++ b/casper/tests/batch2/validate_test.rs
@@ -992,6 +992,119 @@ async fn repeat_deploy_validation_should_not_accept_blocks_with_a_repeated_deplo
     .await
 }
 
+/// The deploy-index fast path, production order: the candidate is validated
+/// BEFORE insertion, so its own sigs are not yet indexed, and deploys never
+/// included in any inserted block clear validation without the parent-scope
+/// scan or the ancestor traversal.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeat_deploy_accepts_fresh_deploys_in_block_not_yet_inserted() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let genesis_deploy = construct_deploy::basic_processed_deploy(0, None).unwrap();
+        let genesis = create_genesis_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            None,
+            None,
+            None,
+            Some(vec![genesis_deploy]),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let fresh_deploy = construct_deploy::basic_processed_deploy(1, None).unwrap();
+        let candidate = build_block(
+            vec![genesis.block_hash.clone()],
+            None,
+            1786500000000,
+            None,
+            None,
+            Some(vec![fresh_deploy]),
+            None,
+            None,
+            None,
+            Some(1),
+        );
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+/// Pins the fast path's contract from both sides. Same repeat shape as
+/// `repeat_deploy_validation_should_not_accept_blocks_with_a_repeated_deploy`
+/// but in production order (candidate built, not inserted): while the sig is
+/// indexed, the fallback ancestor scan flags the repeat; deleting the index
+/// entry flips the verdict to Valid, proving the index probe is consulted
+/// and that the skip rests on the completeness invariant (every inserted
+/// block's sigs reach `deploy_index` — see `insert_internal`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeat_deploy_fast_path_short_circuits_on_deploy_index_absence() {
+    use shared::rust::store::key_value_typed_store::KeyValueTypedStore;
+
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let deploy = construct_deploy::basic_processed_deploy(0, None).unwrap();
+        let genesis = create_genesis_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            None,
+            None,
+            None,
+            Some(vec![deploy.clone()]),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let candidate = build_block(
+            vec![genesis.block_hash.clone()],
+            None,
+            1786500000000,
+            None,
+            None,
+            Some(vec![deploy.clone()]),
+            None,
+            None,
+            None,
+            Some(1),
+        );
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(
+            result,
+            Either::Left(BlockError::Invalid(InvalidBlock::InvalidRepeatDeploy))
+        );
+
+        {
+            let deploy_index_handle = block_dag_storage.deploy_index_for_tests();
+            let deploy_index_guard = deploy_index_handle.write();
+            deploy_index_guard
+                .delete(vec![deploy.deploy.sig.to_vec()])
+                .expect("delete deploy-index entry");
+        }
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
 /// Regression test for `repeat_deploy`'s `rejected_in_scope` exemption.
 ///
 /// Without the exemption, validation rejects any block that re-includes a

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -35,8 +35,8 @@ title: "Encode the 'N deploy(s) not finalized within 45s' soak failure as a dete
 category: technical_debt
 priority: p2
 added_at: 2026-08-11
-blocked_by: root cause unknown (flake vs VM-shape behavior)
-repo_scope: node-side (casper finalization) and/or system-integration (test_load assertion)
+blocked_by: none (root-caused 2026-08-12)
+repo_scope: node-side (casper deploy throughput) and/or system-integration (test_load assertion)
 ---
 ```
 
@@ -48,18 +48,21 @@ the 1200-deploy sustained phase (4.0/sec). The shard was otherwise healthy:
 no guardian breach, RSS peak 16.6GB (vs the 31–37GB envelope observed on
 prior shapes), finalization p95 5928ms over 786 samples earlier in the run.
 
-**Why deferred:** per the causal-diagnosis-before-resources rule, no
-assertion-loosening or timeout-raising without per-component attribution.
-It is not yet known whether this is an intermittent finalization-lag flake,
-a real throughput/finality regression, or an E6.Flex behavior difference
-(first run on 32 cores). The 2026-08-12 02:30Z scheduled run is the next
-data point.
+**Root-caused (2026-08-12):** not a flake, shape effect, or recent
+regression — a sustained deploy-throughput ceiling (~3.4 deploys/s vs the
+test's 4/s) present on both `dev` and `master` and both VM shapes; the
+un-finalized cone never builds (tip−LFB stays 0). Full attribution with
+per-block cost breakdown in
+`docs/discoveries/2026-08-12-finalization-lag-root-cause.md`; node-side
+fixes tracked on `fix/sustained-deploy-throughput`.
 
 **Done means:** the failure mode is reproduced in a deterministic test —
-either a node-side unit/integration test pinning finalization progress under
-a burst-deploy schedule (precedent: the planned floor-divergence regression
-test), or a system-integration harness test with a fixed seed/schedule —
-so the soak stops being the only detector. The 45s assertion itself lives in
+now known to mean pinning sustained-rate deploy inclusion/finalization
+throughput (deploys/s absorbed with a bounded queue) rather than cone
+depth — either a node-side test under a fixed burst-deploy schedule
+(precedent: the planned floor-divergence regression test) or a
+system-integration harness test with a fixed seed/schedule — so the soak
+stops being the only detector. The 45s assertion itself lives in
 system-integration's `test_load.py`; node-side work belongs in `casper`.
 
 ### Feature Ideas


### PR DESCRIPTION
…indexed

- probe the persistent deploy_index before the parent-scope scan and the ancestor BFS in Validate::repeat_deploy: absence of every sig proves no prior inclusion anywhere (insert_internal indexes all deploys of every inserted block before any child validates), so fresh-deploy blocks skip the one validation cost that grows with the in-window DAG (4.3ms -> 124ms/block within a single soak iteration, run 31563121791); any index hit or read error falls through to the exact existing logic unchanged
- expose deploy_index_for_tests passthrough on IndexedBlockDagStorage (test-internals gated, same pattern as sibling accessors)
- tests: fresh-deploy block validates in production order (built, not inserted); deleting the index entry flips the repeat verdict to Valid, pinning that the probe is consulted; all 15 existing repeat-deploy specs pass unchanged; index completeness is already pinned by block-storage's restore_deploy_index_on_startup property test
- docs: BACKLOG-TD-001 unblocked — root cause attributed to a sustained deploy-throughput ceiling (~3.4 vs 4 deploys/s, both branches, both VM shapes), not a finality stall; cone depth stays 0 throughout

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789169791&installation_model_id=426883&pr_number=259&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F259&signature=c490e922a0fcd14ec2549569ab58958d9f94484ffcdc90e095c4db43ad829da5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->