### PR TITLE
perf(casper): deploy-index fast path for repeat-deploy validation (soak finalization-lag root cause)

### DIFF
--- a/block-storage/src/rust/test/indexed_block_dag_storage.rs
+++ b/block-storage/src/rust/test/indexed_block_dag_storage.rs
@@ -34,6 +34,24 @@ impl IndexedBlockDagStorage {
         self.underlying.get_representation_internal()
     }
 
+    /// Passthrough to the underlying storage's test-only deploy-index
+    /// accessor, so tests built on this fixture can manipulate index
+    /// entries (same rationale as `BlockDagKeyValueStorage`'s accessor).
+    #[cfg(any(test, feature = "test-internals"))]
+    #[doc(hidden)]
+    pub fn deploy_index_for_tests(
+        &self,
+    ) -> Arc<
+        parking_lot::RwLock<
+            shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl<
+                crate::rust::dag::block_dag_key_value_storage::DeployId,
+                models::rust::block_hash::BlockHashSerde,
+            >,
+        >,
+    > {
+        self.underlying.deploy_index_for_tests()
+    }
+
     pub fn insert(
         &mut self,
         block: &BlockMessage,

--- a/casper/src/rust/validate.rs
+++ b/casper/src/rust/validate.rs
@@ -538,6 +538,41 @@ impl Validate {
             return Either::Right(ValidBlock::Valid);
         }
 
+        // Fast path on the persistent deploy index. `insert_internal` writes
+        // every deploy sig of every inserted block (valid, invalid and
+        // approved alike) into `deploy_index` before any child of that block
+        // can be validated, so a sig with no index entry has no prior
+        // inclusion anywhere — on any fork, inside or outside the expiration
+        // window — and cannot carry a canonical rejection either (rejected
+        // deploys were themselves carried by an inserted block). When none of
+        // this block's sigs are indexed, the parent-scope scan and the
+        // ancestor traversal below have nothing to find and are skipped —
+        // that traversal's cost grows with the in-window DAG (4ms -> 124ms
+        // per block within one soak iteration, run 31563121791), and fresh
+        // deploys are the overwhelmingly common case. Any hit falls through
+        // to the exact logic below, which stays the sole authority on
+        // whether a prior inclusion is canonical for THIS block's parent
+        // scope: the index is last-write-wins and single-valued, so it can
+        // never answer that question, only prove absence. An index read
+        // error also falls through — the fast path is an optimization,
+        // never a second opinion.
+        let any_sig_indexed = block.body.deploys.iter().any(|pd| {
+            match s.dag.lookup_by_deploy_id(&pd.deploy.sig.to_vec()) {
+                Ok(hit) => hit.is_some(),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "f1r3fly.casper",
+                        "repeat-deploy fast path: deploy index lookup failed ({}); falling back to ancestor scan",
+                        e
+                    );
+                    true
+                }
+            }
+        });
+        if !any_sig_indexed {
+            return Either::Right(ValidBlock::Valid);
+        }
+
         let block_metadata = BlockMetadata::from_block(block, false, None, None);
 
         tracing::debug!(target: "f1r3fly.casper", "before-repeat-deploy-get-parents");

--- a/casper/tests/batch2/validate_test.rs
+++ b/casper/tests/batch2/validate_test.rs
@@ -992,6 +992,119 @@ async fn repeat_deploy_validation_should_not_accept_blocks_with_a_repeated_deplo
     .await
 }
 
+/// The deploy-index fast path, production order: the candidate is validated
+/// BEFORE insertion, so its own sigs are not yet indexed, and deploys never
+/// included in any inserted block clear validation without the parent-scope
+/// scan or the ancestor traversal.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeat_deploy_accepts_fresh_deploys_in_block_not_yet_inserted() {
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let genesis_deploy = construct_deploy::basic_processed_deploy(0, None).unwrap();
+        let genesis = create_genesis_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            None,
+            None,
+            None,
+            Some(vec![genesis_deploy]),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let fresh_deploy = construct_deploy::basic_processed_deploy(1, None).unwrap();
+        let candidate = build_block(
+            vec![genesis.block_hash.clone()],
+            None,
+            1786500000000,
+            None,
+            None,
+            Some(vec![fresh_deploy]),
+            None,
+            None,
+            None,
+            Some(1),
+        );
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
+/// Pins the fast path's contract from both sides. Same repeat shape as
+/// `repeat_deploy_validation_should_not_accept_blocks_with_a_repeated_deploy`
+/// but in production order (candidate built, not inserted): while the sig is
+/// indexed, the fallback ancestor scan flags the repeat; deleting the index
+/// entry flips the verdict to Valid, proving the index probe is consulted
+/// and that the skip rests on the completeness invariant (every inserted
+/// block's sigs reach `deploy_index` — see `insert_internal`).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn repeat_deploy_fast_path_short_circuits_on_deploy_index_absence() {
+    use shared::rust::store::key_value_typed_store::KeyValueTypedStore;
+
+    with_storage(|mut block_store, mut block_dag_storage| async move {
+        let deploy = construct_deploy::basic_processed_deploy(0, None).unwrap();
+        let genesis = create_genesis_block(
+            &mut block_store,
+            &mut block_dag_storage,
+            None,
+            None,
+            None,
+            Some(vec![deploy.clone()]),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let candidate = build_block(
+            vec![genesis.block_hash.clone()],
+            None,
+            1786500000000,
+            None,
+            None,
+            Some(vec![deploy.clone()]),
+            None,
+            None,
+            None,
+            Some(1),
+        );
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(
+            result,
+            Either::Left(BlockError::Invalid(InvalidBlock::InvalidRepeatDeploy))
+        );
+
+        {
+            let deploy_index_handle = block_dag_storage.deploy_index_for_tests();
+            let deploy_index_guard = deploy_index_handle.write();
+            deploy_index_guard
+                .delete(vec![deploy.deploy.sig.to_vec()])
+                .expect("delete deploy-index entry");
+        }
+
+        let dag = block_dag_storage
+            .get_representation()
+            .expect("dag representation");
+        let mut casper_snapshot = mk_casper_snapshot(dag);
+        let result = Validate::repeat_deploy(&candidate, &mut casper_snapshot, &block_store, 50);
+        assert_eq!(result, Either::Right(ValidBlock::Valid));
+    })
+    .await
+}
+
 /// Regression test for `repeat_deploy`'s `rejected_in_scope` exemption.
 ///
 /// Without the exemption, validation rejects any block that re-includes a

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -35,8 +35,8 @@ title: "Encode the 'N deploy(s) not finalized within 45s' soak failure as a dete
 category: technical_debt
 priority: p2
 added_at: 2026-08-11
-blocked_by: root cause unknown (flake vs VM-shape behavior)
-repo_scope: node-side (casper finalization) and/or system-integration (test_load assertion)
+blocked_by: none (root-caused 2026-08-12)
+repo_scope: node-side (casper deploy throughput) and/or system-integration (test_load assertion)
 ---
 ```
 
@@ -48,18 +48,21 @@ the 1200-deploy sustained phase (4.0/sec). The shard was otherwise healthy:
 no guardian breach, RSS peak 16.6GB (vs the 31–37GB envelope observed on
 prior shapes), finalization p95 5928ms over 786 samples earlier in the run.
 
-**Why deferred:** per the causal-diagnosis-before-resources rule, no
-assertion-loosening or timeout-raising without per-component attribution.
-It is not yet known whether this is an intermittent finalization-lag flake,
-a real throughput/finality regression, or an E6.Flex behavior difference
-(first run on 32 cores). The 2026-08-12 02:30Z scheduled run is the next
-data point.
+**Root-caused (2026-08-12):** not a flake, shape effect, or recent
+regression — a sustained deploy-throughput ceiling (~3.4 deploys/s vs the
+test's 4/s) present on both `dev` and `master` and both VM shapes; the
+un-finalized cone never builds (tip−LFB stays 0). Full attribution with
+per-block cost breakdown in
+`docs/discoveries/2026-08-12-finalization-lag-root-cause.md`; node-side
+fixes tracked on `fix/sustained-deploy-throughput`.
 
 **Done means:** the failure mode is reproduced in a deterministic test —
-either a node-side unit/integration test pinning finalization progress under
-a burst-deploy schedule (precedent: the planned floor-divergence regression
-test), or a system-integration harness test with a fixed seed/schedule —
-so the soak stops being the only detector. The 45s assertion itself lives in
+now known to mean pinning sustained-rate deploy inclusion/finalization
+throughput (deploys/s absorbed with a bounded queue) rather than cone
+depth — either a node-side test under a fixed burst-deploy schedule
+(precedent: the planned floor-divergence regression test) or a
+system-integration harness test with a fixed seed/schedule — so the soak
+stops being the only detector. The 45s assertion itself lives in
 system-integration's `test_load.py`; node-side work belongs in `casper`.
 
 ### Feature Ideas


### PR DESCRIPTION
## What

First node-side fix on the soak finalization-lag track: a deploy-index fast path in `Validate::repeat_deploy` that eliminates the only block-validation cost that grows with chain length.

`repeat_deploy` currently BFS-walks every in-window ancestor of a candidate block, doing a block-store deploy-sig scan per visit. In daily soak run [31563121791](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/31563121791) this cost grew from **4.3ms to 124ms per validated block within a single iteration** as the DAG filled its expiration window — O(DAG-in-window) per block, quadratic over a run.

The fix: probe the persistent `deploy_index` (maintained by `insert_internal` for **every** deploy of **every** inserted block — valid, invalid, and approved modes — before any child of that block can be validated) ahead of both the parent-scope rejection scan and the ancestor BFS. If **none** of the candidate's sigs are indexed, there is provably no prior inclusion anywhere — on any fork, inside or outside the window — and no canonical rejection either (rejected deploys were themselves carried by inserted blocks), so validation returns `Valid` immediately. Fresh deploys are the overwhelmingly common case, so this is the hot path.

**Any index hit — even a stale one from a fork — falls through to the existing exact logic unchanged.** The index is last-write-wins and single-valued, so it can never answer *which* inclusion is canonical for a given parent scope; it only proves absence. The fork-safety semantics documented at the top of `repeat_deploy` (deterministic recovery-exemption, the fix for the roaming `InvalidRepeatDeploy` forks) are untouched. An index read error also falls through: the fast path is an optimization, never a second opinion.

## Why (root cause of the soak failures)

The recurring `N deploy(s) not finalized within 45s` soak failure is **not a flake, not an E6.Flex/32-core shape effect, and not a recent dev regression**:

- Daily run 31563121791 (dev@`71c4d11a`, E6.Flex): **19/19 iterations failed** over 13.9h, both providers.
- Weekend run 31404822218 (**master**@`438f4724`, **pre-E6 shape**): identical signature, 8/8 failed.
- Published history (both series): **zero passing iterations ever recorded** — earlier runs died to infra (RSS ceilings, cert mounts) within 1–2 iterations, masking the pattern. `test_load.py` is deselected in CI, so the soak is the only place it runs; it has plausibly never passed since its sustained phase was added (SI `f7de50f`, 2026-06-22).

Mechanism (per-block node internals from the run): the un-finalized cone never builds — `tip − LFB = 0` after every phase, merge costs are milliseconds. The shard simply sustains **~3.4 deploys/s against the test's 4/s**, so inclusion latency spirals (p50 50–80s) and late-phase deploys miss the 45s drain window. Validation saturates at ~1 block/s arrival × ~1.1s/block, of which:

| Cost | Sustained-phase value |
|---|---|
| precharge+refund system-deploy Rholang, per deploy per node | ≈128ms (user code itself: ~0ms) |
| `repeat_deploy` per validated block | 4.3ms → 124ms (grows with in-window DAG) |
| propose path per block created | ~2.8s (`prepare_user_deploys` 1.3s + `compute_deploys_checkpoint` 1.2s) |

## Scope

This PR removes the *growing* cost. The dominant *flat* cost — precharge/refund overhead at ~128ms/deploy/node, ~65× the user-code cost — is the follow-up that closes most of the 3.4→4 deploys/s gap and is deliberately not attempted here. BACKLOG-TD-001 is updated with the attribution and unblocked (its deterministic test should pin sustained-rate deploy throughput, not cone depth).

## Tests

- **New:** `repeat_deploy_accepts_fresh_deploys_in_block_not_yet_inserted` — production order (candidate built, not inserted): fresh deploys clear via the fast path.
- **New:** `repeat_deploy_fast_path_short_circuits_on_deploy_index_absence` — pins the contract from both sides: with the sig indexed, the fallback scan flags the repeat; after deleting the index entry (via the test-only accessor), the verdict flips to Valid — proving the probe is consulted.
- **Unchanged and green:** all 15 pre-existing repeat-deploy specs — recovery exemptions, divergent-local-view agreement, the proposer/validator agreement property suite, and slashing integration (`uc_07`, `integration_t_invalid_repeat_deploy`).
- **Completeness invariant:** already pinned by block-storage's `dag_storage_should_be_able_to_restore_deploy_index_on_startup` property test, which asserts every deploy sig of every inserted block (including `InsertMode::Invalid`) is retrievable via `lookup_by_deploy_id`.

Support change: `IndexedBlockDagStorage` gains a `test-internals`-gated passthrough to the existing `deploy_index_for_tests` accessor.

## Reviewer flag

The negative filter is sound **iff `deploy_index` is complete for every stored block**. The index write has been part of `insert_internal` since the Scala port, so any database produced by this codebase should satisfy it — but a data directory originating from a node version that did not maintain the index would silently weaken repeat-deploy detection. If such databases exist in the wild, this PR should gain a startup check or index backfill before merging.

## Expected effect

`block_summary.repeat_deploy` in the soak's per-iteration "Node internals" telemetry should drop from tens-of-ms-and-growing to ~constant microseconds. This alone does not close the throughput gap; it removes the superlinear term and is independently verifiable in the next soak run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/F1R3FLY-io/codesmith/f1r3node-rust/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789172278&installation_model_id=426883&pr_number=260&repository=F1R3FLY-io%2Ff1r3node-rust&return_to=https%3A%2F%2Fgithub.com%2FF1R3FLY-io%2Ff1r3node-rust%2Fpull%2F260&signature=c2d09064f26f217ddd433f2eff4d20cf53ba17c725da518d7561e78c4bf836c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->