### PR TITLE
Fix flaky finalized-win recovery spec

### DIFF
--- a/casper/tests/batch2/finalized_win_pending_rejection_spec.rs
+++ b/casper/tests/batch2/finalized_win_pending_rejection_spec.rs
@@ -290,22 +290,11 @@ async fn finalized_noncanonical_deploy_is_reproposed_after_canonical_rejection()
             .await
             .expect("sync the rejecting merge");
     }
-    fixture.nodes.sort_by(|left, right| {
-        left.validator_id_opt
-            .as_ref()
-            .expect("left validator identity")
-            .public_key
-            .bytes
-            .cmp(
-                &right
-                    .validator_id_opt
-                    .as_ref()
-                    .expect("right validator identity")
-                    .public_key
-                    .bytes,
-            )
-    });
 
+    // Recovery custody is owner-only: the buffer entry lives solely on the
+    // validator that sent the rejected copy's carrier (block_a's proposer,
+    // nodes[0]), so that node must drive the finalization and the recovery
+    // proposal.
     fixture.nodes[0]
         .block_dag_storage
         .record_directly_finalized(merge_block.block_hash.clone(), 1.0, |_| async { Ok(()) })


### PR DESCRIPTION
`finalized_noncanonical_deploy_is_reproposed_after_canonical_rejection` flaked ~50% per fresh test process. Its pubkey-sorted proposer selection is a leftover from dev's recovery-leader fixture alignment (0c1f62f2); under owner custody only the carrier's sender holds the re-proposable copy, and per-process random validator keys made that sort a coin flip against the owner. The recovery propose now runs on the carrier owner, matching the other two tests in the file.

Verified with `cargo test --release`: 22/40 iterations failed before, 0/40 after.

Co-Authored-By: Claude <noreply@anthropic.com>