### PR TITLE
fix(casper): bound LFS Block Requester concurrency to tokio's actual worker count, not host CPU count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,6 @@ dependencies = [
  "metrics 0.23.1",
  "metrics-util 0.17.0",
  "models",
- "num_cpus",
  "parking_lot",
  "proptest",
  "prost 0.14.4",

--- a/casper/Cargo.toml
+++ b/casper/Cargo.toml
@@ -36,7 +36,6 @@ itertools = { workspace = true }
 regex = { workspace = true }
 thiserror = { workspace = true }
 # LFS Block Requester dependencies
-num_cpus = "1.0"
 async-stream = "0.3"
 tokio-stream = { workspace = true }
 humantime = { workspace = true }

--- a/casper/src/rust/engine/lfs_block_requester.rs
+++ b/casper/src/rust/engine/lfs_block_requester.rs
@@ -957,7 +957,12 @@ async fn create_stream_with_processor<'a, T: BlockRequesterOps>(
     request_timeout: Duration,
     max_request_timeout: Duration,
 ) -> Result<impl futures::stream::Stream<Item = ST<BlockHash>> + use<'a, T>, CasperError> {
-    let processor_count = num_cpus::get();
+    // num_cpus::get() reads the host's core count, not the pod's cgroup CPU
+    // quota or the tokio runtime's actual worker pool size — see
+    // https://github.com/F1R3FLY-io/f1r3node-rust/issues/147. Bound
+    // concurrency to the runtime's real worker count instead so it tracks
+    // whatever TOKIO_WORKER_THREADS configured in node/src/main.rs.
+    let processor_count = tokio::runtime::Handle::current().metrics().num_workers();
     tracing::info!(
         "LFS Block Requester using {} processor-bounded workers (parEvalMapProcBounded equivalent)",
         processor_count


### PR DESCRIPTION
## Summary

- Replace `num_cpus::get()` with `tokio::runtime::Handle::current().metrics().num_workers()` in `create_stream_with_processor` (LFS Block Requester, `casper/src/rust/engine/lfs_block_requester.rs`), so the semaphore bounding concurrent block-response processing tracks the runtime's actual configured worker-thread count instead of the host's raw core count.
- Remove the now-unused `num_cpus` dependency from `casper/Cargo.toml` (this was its only call site in the workspace).

## Why

`num_cpus::get()` reads the host's physical core count, not the pod's cgroup CPU quota — the same host-affinity-vs-cgroup-quota mismatch that `TOKIO_WORKER_THREADS` was introduced to fix for the tokio runtime builder in `node/src/main.rs`. This call site bypassed that fix entirely: on a high-CPU-limit pod running on a host with many more physical cores, it could still oversubscribe concurrency during LFS (Last Finalized State) catch-up sync.

`Handle::current().metrics().num_workers()` ties the bound to the runtime's real worker pool size, so it automatically tracks whatever `TOKIO_WORKER_THREADS` (or its default) configured — no separate knob to keep in sync.

Related: #147