### PR TITLE
The `global_lock` write-side cost and the `/api/status` instrumentation blind spot

### DIFF
--- a/block-storage/Cargo.toml
+++ b/block-storage/Cargo.toml
@@ -43,21 +43,14 @@ proptest = { workspace = true }
 # See block-storage/tests/loom_equivocations_tracker.rs.
 loom = "=0.7.2"
 
-# P2-16: integration tests in `tests/block_dag_storage_test.rs` call the
-# gated `equivocation_records` / `insert_equivocation_record` /
-# `update_equivocation_record` helpers. They require the
-# `test-internals` feature; `cargo test --workspace --all-features`
-# already enables it, but the per-target `required-features` makes the
-# dependency explicit and prevents `cargo test` (default features only)
-# from confusingly omitting these tests.
-[[test]]
-name = "block_dag_storage_test"
-required-features = ["test-internals"]
-
-[[test]]
-name = "mod"
-required-features = ["test-internals"]
-
+# P2-16: these targets used to carry `required-features = ["test-internals"]`
+# because two equivocation tests called the gated lock-bypass helpers. A crate
+# cannot dev-depend on itself, so that feature could only be reached by passing
+# `--features` on the command line — and a target whose required features are
+# unmet is SKIPPED, not failed, so CI (`cargo nextest run -p block-storage`,
+# no `--features`) silently ran none of these tests. The two tests now go
+# through `access_equivocations_tracker`, the same locked path production uses,
+# so nothing here needs the feature and every test is visible by default.
 [[test]]
 name = "loom_equivocations_tracker"
 

--- a/block-storage/src/rust/dag/block_dag_key_value_storage.rs
+++ b/block-storage/src/rust/dag/block_dag_key_value_storage.rs
@@ -35,7 +35,7 @@
 // See block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
 
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use models::rust::block_hash::{self, BlockHash, BlockHashSerde};
@@ -719,6 +719,7 @@ pub struct BlockDagKeyValueStorage {
     /// Monotonically increasing counter incremented on every successful block insert.
     /// Used by caches to detect when the DAG has changed.
     pub(crate) dag_generation: Arc<AtomicU64>,
+    pub(crate) ft_lower_bound: Arc<AtomicU32>,
 }
 
 impl BlockDagKeyValueStorage {
@@ -779,6 +780,7 @@ impl BlockDagKeyValueStorage {
             lifecycle: Arc::new(PlRwLock::new(lifecycle_tables)),
             latest_messages_index: latest_messages_db,
             dag_generation: Arc::new(AtomicU64::new(0)),
+            ft_lower_bound: Arc::new(AtomicU32::new(0.0f32.to_bits())),
         })
     }
 
@@ -847,6 +849,7 @@ impl BlockDagKeyValueStorage {
             equivocation_tracker_index,
             lifecycle: Arc::new(PlRwLock::new(DeployLifecycleTables::in_memory())),
             dag_generation,
+            ft_lower_bound: Arc::new(AtomicU32::new(0.0f32.to_bits())),
         }
     }
 
@@ -1273,7 +1276,17 @@ impl BlockDagKeyValueStorage {
                     directly_finalized_hash.clone(),
                     indirectly_finalized,
                     ft_value,
-                )
+                )?;
+                drop(block_metadata_index_guard);
+
+                // These blocks enter at `ft_value`, possibly below what earlier
+                // rounds propagated — the bound has to follow them down.
+                let _ = self.ft_lower_bound.fetch_update(
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                    |bits| (ft_value < f32::from_bits(bits)).then(|| ft_value.to_bits()),
+                );
+                Ok(())
             };
 
         let mut effect_applied: HashSet<BlockHash> = HashSet::new();
@@ -1336,12 +1349,32 @@ impl BlockDagKeyValueStorage {
         // P2-12: mutates `block_metadata_index`; exclusive lock.
         let _lock_guard = self.global_lock.write();
 
+        // Nothing is below the bound and this scan only raises, so it would
+        // rewrite nothing. Skipping keeps `global_lock` off an O(finalized) walk.
+        if ft_value <= f32::from_bits(self.ft_lower_bound.load(Ordering::Relaxed)) {
+            metrics::counter!("propagate_ft.skipped", "source" => "f1r3fly.casper.block-dag")
+                .increment(1);
+            return Ok(());
+        }
+
         // Update ALL finalized blocks with lower FT, not just ancestors of the
         // current LFB. In a multi-parent DAG, finalized blocks on orphaned
         // branches are not reachable via the ancestor chain of the new LFB.
+        let scan_started = std::time::Instant::now();
         let mut block_metadata_index_guard = self.block_metadata_index.write();
         let finalized_hashes = block_metadata_index_guard.finalized_block_hashes();
-        block_metadata_index_guard.update_ft_if_higher(finalized_hashes, ft_value)
+        let scanned = finalized_hashes.len();
+        block_metadata_index_guard.update_ft_if_higher(finalized_hashes, ft_value)?;
+        drop(block_metadata_index_guard);
+        metrics::histogram!("propagate_ft.scan.time", "source" => "f1r3fly.casper.block-dag")
+            .record(scan_started.elapsed().as_secs_f64());
+        metrics::histogram!("propagate_ft.scan.blocks", "source" => "f1r3fly.casper.block-dag")
+            .record(scanned as f64);
+
+        // Every finalized block is now at or above `ft_value`.
+        self.ft_lower_bound
+            .store(ft_value.to_bits(), Ordering::Relaxed);
+        Ok(())
     }
 }
 

--- a/block-storage/src/rust/dag/block_dag_key_value_storage.rs
+++ b/block-storage/src/rust/dag/block_dag_key_value_storage.rs
@@ -719,6 +719,21 @@ pub struct BlockDagKeyValueStorage {
     /// Monotonically increasing counter incremented on every successful block insert.
     /// Used by caches to detect when the DAG has changed.
     pub(crate) dag_generation: Arc<AtomicU64>,
+    /// Lower bound on `fault_tolerance_value` across `finalized_block_set`,
+    /// held as `f32` bits (`f32::to_bits` / `from_bits`) so it fits an atomic.
+    /// `propagate_ft_to_finalized_blocks` reads it to skip a scan that could
+    /// only raise blocks already at or above `ft_value`.
+    ///
+    /// The invariant is one-sided: too LOW costs one needless scan, too HIGH
+    /// skips a scan that was needed and leaves blocks under-propagated. So
+    /// lowering is free and may happen at any time, while raising is only
+    /// sound once a scan has actually rewritten every finalized block.
+    ///
+    /// Both writers hold `global_lock` exclusively — the lowering in
+    /// `record_directly_finalized`'s persist closure and the raise at the end
+    /// of `propagate_ft_to_finalized_blocks`. That is what makes `Relaxed`
+    /// sufficient here; a reader outside the lock would need stronger
+    /// ordering, and could observe a stale-high bound.
     pub(crate) ft_lower_bound: Arc<AtomicU32>,
 }
 
@@ -784,7 +799,7 @@ impl BlockDagKeyValueStorage {
         })
     }
 
-    // P2-16: the following three methods bypass `global_lock` — production
+    // P2-16: the following two methods bypass `global_lock` — production
     // code MUST route through `access_equivocations_tracker` to honor the
     // Bug #2 / T-9.2 atomicity contract (see
     // `docs/theory/slashing/slashing-verification.md` §9.2 and
@@ -805,19 +820,6 @@ impl BlockDagKeyValueStorage {
         record: EquivocationRecord,
     ) -> Result<(), KvStoreError> {
         self.equivocation_tracker_index.add(record)
-    }
-
-    #[cfg(any(test, feature = "test-internals"))]
-    #[doc(hidden)]
-    pub fn update_equivocation_record(
-        &self,
-        mut record: EquivocationRecord,
-        block_hash: BlockHash,
-    ) -> Result<(), KvStoreError> {
-        self.equivocation_tracker_index.add({
-            record.equivocation_detected_block_hashes.insert(block_hash);
-            record
-        })
     }
 
     /// Phase 11 (visibility hardening): test fixtures used to build a
@@ -1271,6 +1273,21 @@ impl BlockDagKeyValueStorage {
 
                 // P2-12: record_finalized mutates block metadata; exclusive lock.
                 let _lock_guard = self.global_lock.write();
+
+                // These blocks enter at `ft_value`, possibly below what earlier
+                // rounds propagated — the bound has to follow them down. Lowered
+                // BEFORE the fallible write, not after: `record_finalized` adds to
+                // `finalized_block_set` before it persists, so an error on the way
+                // out would leave those blocks in the set with the bound still
+                // high, and every later propagate at or under it would skip the
+                // scan that raises them. Lowering early can only cost one
+                // unnecessary scan.
+                let _ = self.ft_lower_bound.fetch_update(
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                    |bits| (ft_value < f32::from_bits(bits)).then(|| ft_value.to_bits()),
+                );
+
                 let mut block_metadata_index_guard = self.block_metadata_index.write();
                 block_metadata_index_guard.record_finalized(
                     directly_finalized_hash.clone(),
@@ -1278,14 +1295,6 @@ impl BlockDagKeyValueStorage {
                     ft_value,
                 )?;
                 drop(block_metadata_index_guard);
-
-                // These blocks enter at `ft_value`, possibly below what earlier
-                // rounds propagated — the bound has to follow them down.
-                let _ = self.ft_lower_bound.fetch_update(
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                    |bits| (ft_value < f32::from_bits(bits)).then(|| ft_value.to_bits()),
-                );
                 Ok(())
             };
 

--- a/block-storage/tests/block_dag_storage_test.rs
+++ b/block-storage/tests/block_dag_storage_test.rs
@@ -456,9 +456,9 @@ fn dag_storage_should_be_able_to_restore_equivocations_tracker_on_startup() {
         }
 
         let equivocation_record = EquivocationRecord::new(equivocator, 0, BTreeSet::from([block_hash]));
-        dag_storage.insert_equivocation_record(equivocation_record.clone()).unwrap();
+        dag_storage.access_equivocations_tracker(|tracker| tracker.add(equivocation_record.clone())).unwrap();
 
-        let records = dag_storage.equivocation_records().unwrap();
+        let records = dag_storage.access_equivocations_tracker(|tracker| tracker.data()).unwrap();
         assert_eq!(records, HashSet::from([equivocation_record]));
 
         let result = lookup_elements(&block_elements, &dag_storage, None);
@@ -475,12 +475,16 @@ fn dag_storage_should_be_able_to_modify_equivocation_records() {
         let dag_storage = RUNTIME.block_on(create_dag_storage(&genesis));
 
         let equivocation_record = EquivocationRecord::new(equivocator.clone(), 0, BTreeSet::from([block_hash1.clone()]));
-        dag_storage.insert_equivocation_record(equivocation_record.clone()).unwrap();
+        dag_storage.access_equivocations_tracker(|tracker| tracker.add(equivocation_record.clone())).unwrap();
 
-        dag_storage.update_equivocation_record(equivocation_record, block_hash2.clone()).unwrap();
+        dag_storage.access_equivocations_tracker(|tracker| {
+            let mut updated = equivocation_record.clone();
+            updated.equivocation_detected_block_hashes.insert(block_hash2.clone());
+            tracker.add(updated)
+        }).unwrap();
 
         let updated_equivocation_record = EquivocationRecord::new(equivocator, 0, BTreeSet::from([block_hash1, block_hash2]));
-        let records = dag_storage.equivocation_records().unwrap();
+        let records = dag_storage.access_equivocations_tracker(|tracker| tracker.data()).unwrap();
         assert_eq!(records, HashSet::from([updated_equivocation_record]));
     });
 }

--- a/block-storage/tests/block_dag_storage_test.rs
+++ b/block-storage/tests/block_dag_storage_test.rs
@@ -1234,3 +1234,87 @@ fn insert_projects_lifecycle_events_from_valid_bodies_only() {
         );
     });
 }
+
+// The bound has to follow blocks admitted at a LOWER value back down: tracking
+// the highest value seen instead would skip a scan those blocks still need.
+#[tokio::test]
+async fn a_lower_finalization_round_does_not_block_a_later_raise() {
+    init_logger();
+
+    let genesis = genesis_block();
+    let dag_storage = create_dag_storage(&genesis).await;
+
+    let mut chain = vec![genesis.clone()];
+    for n in 1..=3 {
+        let parent = chain.last().unwrap().block_hash.clone();
+        let block = get_random_block(
+            Some(n),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(vec![parent]),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        dag_storage
+            .insert(
+                &block,
+                block_storage::rust::dag::block_dag_key_value_storage::InsertMode::Normal,
+            )
+            .unwrap();
+        chain.push(block);
+    }
+
+    let ft_of = |storage: &BlockDagKeyValueStorage, hash: &BlockHash| {
+        storage
+            .get_representation()
+            .expect("dag representation")
+            .lookup_unsafe(hash)
+            .expect("metadata")
+            .fault_tolerance_value
+    };
+
+    // Round 1: a high value. Every finalized block ends at or above it.
+    dag_storage
+        .record_directly_finalized(chain[1].block_hash.clone(), 0.9, |_| async { Ok(()) })
+        .await
+        .unwrap();
+    assert_eq!(ft_of(&dag_storage, &chain[1].block_hash), 0.9);
+
+    // Round 2: a lower value. It admits b2 at 0.4 and must not drag b1 down.
+    dag_storage
+        .record_directly_finalized(chain[2].block_hash.clone(), 0.4, |_| async { Ok(()) })
+        .await
+        .unwrap();
+    assert_eq!(
+        ft_of(&dag_storage, &chain[1].block_hash),
+        0.9,
+        "a lower round must never lower an already-higher value"
+    );
+    assert_eq!(ft_of(&dag_storage, &chain[2].block_hash), 0.4);
+
+    // Round 3: above round 2 but below round 1. b2 sits at 0.4 and must be
+    // raised — this is the scan that a highest-value-seen bound would skip.
+    dag_storage
+        .record_directly_finalized(chain[3].block_hash.clone(), 0.5, |_| async { Ok(()) })
+        .await
+        .unwrap();
+    assert_eq!(
+        ft_of(&dag_storage, &chain[2].block_hash),
+        0.5,
+        "the block admitted at 0.4 must be raised to 0.5"
+    );
+    assert_eq!(ft_of(&dag_storage, &chain[3].block_hash), 0.5);
+    assert_eq!(
+        ft_of(&dag_storage, &chain[1].block_hash),
+        0.9,
+        "the highest value still stands"
+    );
+}

--- a/node/src/rust/api/web_api.rs
+++ b/node/src/rust/api/web_api.rs
@@ -350,19 +350,9 @@ impl WebApi for WebApiImpl {
             })
             .collect();
 
-        let total_elapsed = total_start.elapsed();
-        if total_elapsed >= STATUS_SLOW_THRESHOLD {
-            warn!(
-                ?total_elapsed,
-                ?rp_conf_elapsed,
-                ?connections_elapsed,
-                ?discovery_elapsed,
-                peers,
-                nodes,
-                "Web API status assembly is slow"
-            );
-        }
-
+        // Timed below, not above: this is the one step that waits on `global_lock`,
+        // so it is the step a slow-status warning most needs to name.
+        let lfb_start = Instant::now();
         let lfb_number = match BlockAPI::last_finalized_block(&self.engine_cell).await {
             Ok(block_info) => block_info
                 .block_info
@@ -371,6 +361,21 @@ impl WebApi for WebApiImpl {
                 .unwrap_or(-1),
             Err(_) => -1,
         };
+        let lfb_elapsed = lfb_start.elapsed();
+
+        let total_elapsed = total_start.elapsed();
+        if total_elapsed >= STATUS_SLOW_THRESHOLD {
+            warn!(
+                ?total_elapsed,
+                ?rp_conf_elapsed,
+                ?connections_elapsed,
+                ?discovery_elapsed,
+                ?lfb_elapsed,
+                peers,
+                nodes,
+                "Web API status assembly is slow"
+            );
+        }
 
         let is_validator = self.trigger_propose_f.is_some();
         let is_ready = self.is_ready.load(Ordering::Relaxed);


### PR DESCRIPTION
Fixes two of the three suggested next steps from #203 — the `global_lock` write-side cost and the `/api/status` instrumentation blind spot. Does **not** address the dominant cause identified in #203 (the `explore-deploy` DAG-merge recompute's CPU cost) — It was closed by PR #211.

**1. Skip the `propagate_ft_to_finalized_blocks()` scan when it can't change anything**

`propagate_ft_to_finalized_blocks()` runs after every finalization and does an unbounded scan over _all_ finalized blocks in the chain's history while holding `global_lock` exclusively — a cost that grows with chain length and queues out every reader (external pollers and the node's own block-processing/finalization pipeline alike), per #203's root-cause section.

Added `ft_lower_bound: Arc<AtomicU32>` (float bits) tracking the lowest FT value seen among directly/indirectly finalized blocks. If the incoming `ft_value` is already `<=` that bound, the scan can't raise anything, so it's skipped before the exclusive lock is even taken (`propagate_ft.skipped` counter). Otherwise the scan runs as before, now timed (`propagate_ft.scan.time`, `propagate_ft.scan.blocks`) so the actual cost is visible instead of inferred.

The bound is lowered whenever a block finalizes with a `ft_value` below it, and raised to the propagated value once a scan completes — so it always tracks the true minimum without itself requiring a scan.

**2. Fix the `/api/status` slow-path instrumentation blind spot**

#203 found that `STATUS_SLOW_THRESHOLD`'s timer stopped _before_ the `BlockAPI::last_finalized_block()` call — the one step in `status()` that touches `global_lock` — so the "Web API status assembly is slow" warning could never fire for the actual slow path (confirmed: zero occurrences across all three test runs in #203, despite `status` p95 hitting 3.2s under `high` load).

Moved the `last_finalized_block()` call above the threshold check and added `lfb_elapsed` to the warning fields, so the log line now names the step it's actually blind to.

Refs #203