### PR TITLE
chore(ci): pin SI verdict-sweep branch and re-enable ucc

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -16,4 +16,4 @@
 # Bump both in the same commit: `just repin-system-integration <sha>`
 # (scripts/repin-system-integration.sh) rewrites every pin site together and
 # runs the invariants checker.
-SYSTEM_INTEGRATION_REF=56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+SYSTEM_INTEGRATION_REF=86a5fa108d4996d690eef71d28889859c9cdfd4d

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -45,7 +45,7 @@ env:
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit,
   # via `just repin-system-integration <sha>`.
-  SYSTEM_INTEGRATION_REF: 56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+  SYSTEM_INTEGRATION_REF: 86a5fa108d4996d690eef71d28889859c9cdfd4d
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to
@@ -351,7 +351,7 @@ jobs:
           # previous 20-VM layout (5 identical slots per arch×provider)
           # exhausted it under normal PR traffic.
           pids=()
-          for _ in $(seq 1 2); do ./launch-runner.sh amd64 & pids+=($!); done
+          for _ in $(seq 1 4); do ./launch-runner.sh amd64 & pids+=($!); done
           for _ in $(seq 1 2); do ./launch-runner.sh arm64 & pids+=($!); done
           failed=0
           for pid in "${pids[@]}"; do
@@ -567,11 +567,6 @@ jobs:
   # ci-fork-pr.yml count these legs without modification.
   ucc_tests:
     name: Integration Tests (${{ matrix.arch }}-${{ matrix.provider }}, ucc)
-    # TEMPORARY: disabled while the RSS-guardian kills are investigated. ucc is
-    # the heaviest memory consumer in the pipeline. Re-enable with the launcher
-    # count (2 -> 4 amd64) and the ci.yml amd64 slot gate (2 -> 4) together;
-    # they are one unit and CI fails if they disagree.
-    if: false
     needs: [build_docker_image, launch_ephemeral_runners]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,8 +431,8 @@ jobs:
             --paginate \
             --jq '.jobs[] | select(.name | contains("Integration Tests (amd64-")) | "\(.conclusion // "pending")\t\(.name)"')
           slot_count=$(printf '%s\n' "$slots" | grep -c . || true)
-          if [ "$slot_count" -ne 2 ]; then
-            echo "Expected 2 amd64 integration test slots (docker, subprocess), but found $slot_count:"
+          if [ "$slot_count" -ne 4 ]; then
+            echo "Expected 4 amd64 integration test slots (docker, subprocess, ucc-docker, ucc-subprocess), but found $slot_count:"
             printf '%s\n' "$slots"
             exit 1
           fi

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -110,7 +110,7 @@ env:
   # iterations) and the orchestrator host guardian (every iteration) use it.
   SOAK_HOST_FREE_FLOOR_MB: "8192"
   # Third pin site; keep identical to the other two — bump via scripts/repin-system-integration.sh.
-  SYSTEM_INTEGRATION_REF: 56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+  SYSTEM_INTEGRATION_REF: 86a5fa108d4996d690eef71d28889859c9cdfd4d
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"


### PR DESCRIPTION
**Draft, not for merge as-is.** The pin points at a PR branch head, not a main SHA.

**Pin** — `SYSTEM_INTEGRATION_REF` -> `86a5fa10`, the head of F1R3FLY-io/system-integration#125 (shared-deadline verdict resolution). The point is to run ucc against that resolver before #125 merges. Once it does, repin to the resulting main SHA — that repin is a required follow-up before this can merge.

**ucc re-enabled**, as the one unit its own note described:
- `ucc_tests`: drop `if: false`
- amd64 ephemeral launcher: 2 -> 4 (2 integration legs + 2 ucc legs; arm64 stays 2)
- `ci.yml` amd64 slot gate: 2 -> 4, so the aggregator expects the new job count

**Why now.** Four ucc failures across both providers in one day — `test_guarded_rmw_conflict_no_double_apply`, `test_concurrent_delete_and_set_same_key`, `test_set_cell_concurrent_distinct_elements_union`, `test_single_cell_map_concurrent_adds_all_resolve` — all reported "no coherent terminal verdict". In every one, all five nodes had written terminal `Expired` within 100-185 ms of each other, and `boot` (named in all four) was consistently among the last to decide. Those shards were finality-healthy throughout: floor gap 1, floor pins 11.6-12.6s, all validators advancing. That is the serial-polling race #125 fixes, not a consensus fault.

**Caveat worth watching in this run.** ucc was disabled for RSS-guardian kills, and it is the heaviest memory consumer in the pipeline. Raising the launcher to 4 amd64 restores the VM-per-job ratio, but whether the memory pressure is resolved is exactly what this draft is meant to find out.

Co-Authored-By: Claude <noreply@anthropic.com>