### PR TITLE
docs(release): specify stack deployment trains and phase branches

### DIFF
--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -101,7 +101,8 @@ tasks:
   - id: TASK-013-3
     title: "Phase 2: canary publication (canary-publish.yml)"
     status: in_progress
-    branch: feature/release-process-implementation
+    branch: feature/release-phase2-canary-publication
+    blocked_by: []
     notes:
       - "Implemented as canary-publish.yml: workflow_run on CI completion publishes the immutable canary tag, prerelease, and Docker Hub images by digest from the run's own artifacts; ineligible runs skip cleanly. Evidence upgrades to publication_mode: canary via release-evidence.sh record-images. OCIR canary deferred to Phase 3 (registry location is secret material). Remains in_progress until the first live master run proves it."
     acceptance:
@@ -110,6 +111,7 @@ tasks:
     title: "Phase 3: artifact-based validation (candidate digest modes)"
     status: in_progress
     branch: feature/release-phase3-candidate-digest-validation
+    blocked_by: [TASK-013-3]
     notes:
       - "2026-08-22: stacked on Phase 4 (feature/release-phase4-promotion-controller). Registry decision ratified by the maintainer: OCIR is canonical for candidate gates, Docker Hub stays as the dual-published public mirror, no sync service."
       - "canary-publish.yml pushes the same index to OCIR; evidence records images.ocir_index_digest, which the validator requires to equal the Docker Hub index digest. The OCIR repository path never enters evidence."
@@ -127,6 +129,7 @@ tasks:
     title: "Phase 4: stable promotion controller"
     status: in_progress
     branch: feature/release-phase4-promotion-controller
+    blocked_by: [TASK-013-4]
     notes:
       - "2026-08-22: release-gates.sh evaluates the eight Section 8 gates from JSON documents only (pass, hold, or fail; exit 0, 10, or 20) and promote-release.sh plans Section 11 steps 4 to 14 from observed stable state, verifies binaries, emits stable-release-evidence.json, and bumps the next version. release.yml replaces the held stub: a read-only gates job, then a promote job under release-credentials that copies the image by digest with imagetools create, creates the verified stable tag and release, moves latest, and opens the next-version pull request. test-release-gates.sh, test-promote-release.sh, and the updated test-release-workflows.sh contract guard run in CI."
       - "Section 8.1 defines the gate-evidence contract that Phase 3 must publish as candidate prerelease assets. Until Phase 3 lands, the OCI, soak, and verdict gates hold, so no candidate is promotable end to end."
@@ -140,9 +143,19 @@ tasks:
   - id: TASK-013-6
     title: "Phase 5: Deployment Trains"
     status: pending
+    branch: feature/release-phase5-deployment-trains
+    blocked_by: [TASK-013-5]
+    notes:
+      - "2026-08-22: release-process.md Section 13.1.1 adds schema_version 2 stack manifests. A stack train binds the top-of-stack head as its one candidate; members merge bottom-up with true merge commits. Setup steps 3a to 3c and the validator depend on no earlier phase; canary, digest-bound gates, and promotion depend on Phases 2 to 4."
+      - "ci.yml runs pull-request CI only for bases dev, master, staging, trying, and feature/**. Stacked members that target another member's branch get no CI; train setup dispatches ci.yml on head_sha instead (Section 13.2)."
+      - "Rehearsal candidate for the stack-train step: the key-contention stack PR #299 -> #312 -> #319 -> #311 (EPIC-016), non-publishing, no version reservation."
     acceptance:
       - "deployment-train.yml validates manifests under .github/deployment-trains/ and starts trains"
-      - "One non-publishing rehearsal completes, then the cost-accounting train (PR #216) publishes first"
+      - "The validator accepts schema_version 1 and 2, and rejects a stack member with a foreign base, broken head ancestry, or a squash or rebase merge"
+      - "Setup dispatches ci.yml on head_sha when no successful run exists for that SHA and records the run identifier as CI evidence"
+      - "One non-publishing single-train rehearsal completes"
+      - "One non-publishing stack-train rehearsal completes on a stacked pull-request set"
+      - "The cost-accounting train (PR #216) publishes first"
   - id: TASK-013-7
     title: "Phase 6: Shard soak-in scheduling"
     status: in_progress

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -111,7 +111,7 @@ tasks:
     title: "Phase 3: artifact-based validation (candidate digest modes)"
     status: in_progress
     branch: feature/release-phase3-candidate-digest-validation
-    blocked_by: [TASK-013-3]
+    blocked_by: [TASK-013-5]
     notes:
       - "2026-08-22: stacked on Phase 4 (feature/release-phase4-promotion-controller). Registry decision ratified by the maintainer: OCIR is canonical for candidate gates, Docker Hub stays as the dual-published public mirror, no sync service."
       - "canary-publish.yml pushes the same index to OCIR; evidence records images.ocir_index_digest, which the validator requires to equal the Docker Hub index digest. The OCIR repository path never enters evidence."
@@ -129,7 +129,7 @@ tasks:
     title: "Phase 4: stable promotion controller"
     status: in_progress
     branch: feature/release-phase4-promotion-controller
-    blocked_by: [TASK-013-4]
+    blocked_by: [TASK-013-3]
     notes:
       - "2026-08-22: release-gates.sh evaluates the eight Section 8 gates from JSON documents only (pass, hold, or fail; exit 0, 10, or 20) and promote-release.sh plans Section 11 steps 4 to 14 from observed stable state, verifies binaries, emits stable-release-evidence.json, and bumps the next version. release.yml replaces the held stub: a read-only gates job, then a promote job under release-credentials that copies the image by digest with imagetools create, creates the verified stable tag and release, moves latest, and opens the next-version pull request. test-release-gates.sh, test-promote-release.sh, and the updated test-release-workflows.sh contract guard run in CI."
       - "Section 8.1 defines the gate-evidence contract that Phase 3 must publish as candidate prerelease assets. Until Phase 3 lands, the OCI, soak, and verdict gates hold, so no candidate is promotable end to end."
@@ -144,10 +144,12 @@ tasks:
     title: "Phase 5: Deployment Trains"
     status: pending
     branch: feature/release-phase5-deployment-trains
-    blocked_by: [TASK-013-5]
+    blocked_by: [TASK-013-4]
     notes:
-      - "2026-08-22: release-process.md Section 13.1.1 adds schema_version 2 stack manifests. A stack train binds the top-of-stack head as its one candidate; members merge bottom-up with true merge commits. Setup steps 3a to 3c and the validator depend on no earlier phase; canary, digest-bound gates, and promotion depend on Phases 2 to 4."
-      - "ci.yml runs pull-request CI only for bases dev, master, staging, trying, and feature/**. Stacked members that target another member's branch get no CI; train setup dispatches ci.yml on head_sha instead (Section 13.2)."
+      - "2026-08-22: release-process.md Section 13.1.1 adds schema_version 2 stack manifests. A stack train binds the top-of-stack head as its one candidate; members merge bottom-up with true merge commits. Setup steps 4 to 6 (member chain, head ancestry, merged-member topology) and the validator depend on no earlier phase; canary, digest-bound gates, and promotion depend on Phases 2 to 4."
+      - "2026-08-22 multi-agent review of PR #321: Section 13.2 is one numbered sequence; the member base rule points to the preceding member; merge method is re-validated after each member merge and every recorded member head is verified at promotion, which closes the force-push window; the CI filter text matches ci.yml."
+      - "blocked_by encodes the stack merge order PR #322 -> #323 (Phase 4) -> #325 (Phase 3) -> #321 (Phase 5), which is also the code-dependency order: Phase 3 implements the Section 8.1 contract Phase 4 defines. Phase 4 becomes operational end to end only after Phase 3 publishes gate documents; that is a runtime dependency, not a merge dependency."
+      - "ci.yml runs pull-request CI for bases dev, master, staging, trying, and feature/**. A member whose base is outside that set (fix/**, formal/**) gets no pull-request run; train setup requires one successful ci.yml run for head_sha from any event and dispatches one when none exists (Section 13.2 step 9)."
       - "Rehearsal candidate for the stack-train step: the key-contention stack PR #299 -> #312 -> #319 -> #311 (EPIC-016), non-publishing, no version reservation."
     acceptance:
       - "deployment-train.yml validates manifests under .github/deployment-trains/ and starts trains"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -408,6 +408,39 @@ The manifest can use these states:
 
 Automation records live state outside Git. The manifest records reviewed intent and the final result.
 
+#### 13.1.1 Stack manifests
+
+A stack train releases a set of stacked pull requests as one candidate. The candidate is the head of the top pull request. The top branch contains every lower branch, so full CI and every exact-SHA gate on that one SHA test the whole stack.
+
+A stack manifest uses `schema_version: 2` and adds a `stack` block:
+
+```yaml
+schema_version: 2
+id: key-contention
+state: proposed
+target_version: 0.5.0
+pull_request: 311
+head_sha: 0123456789abcdef0123456789abcdef01234567
+base_branch: master
+publishing: false
+stack:
+  integration_branch: dev
+  members:
+    - pull_request: 299
+    - pull_request: 312
+    - pull_request: 319
+    - pull_request: 311
+required_gates: []
+```
+
+Rules for the `stack` block:
+
+- `members` lists the pull requests from bottom to top. The order is the merge order.
+- `pull_request` and `head_sha` refer to the top member. They keep their `schema_version: 1` meaning.
+- `integration_branch` names the branch that receives each member before `base_branch` receives the stack. The default is `dev`.
+- `publishing: false` marks a rehearsal. A rehearsal runs setup and every gate, reserves no version, and creates no stable tag. The default is `true`.
+- A manifest without a `stack` block is a single-train manifest. Version 1 manifests stay valid.
+
 ### 13.2 Train setup
 
 A maintainer dispatches train setup with the manifest path.
@@ -427,6 +460,15 @@ The setup workflow performs these actions:
 
 Multiple trains can run at the same time. Workflow concurrency keys include the train identifier and target version.
 
+For a stack manifest, setup adds these checks between steps 3 and 6:
+
+- 3a. Verify that each member pull request is open or merged, and that its base is the branch of the next member or `integration_branch`. Reject any other base.
+- 3b. Verify that the head of each member is an ancestor of the head of the next member, and that `head_sha` equals the head of the top member. This check proves that the top branch contains the whole stack.
+- 3c. Verify that no member has merged, or will merge, by squash or rebase. A member that has already merged must have a merge commit on `integration_branch`.
+- 5a. Skip the version reservation when `publishing` is `false`.
+
+`ci.yml` runs on pull requests that target `dev`, `master`, or a `feature/**` branch. A stacked member that targets another member's branch gets no pull-request CI run. For step 6, setup therefore dispatches `ci.yml` on `head_sha` when no successful run exists for that SHA, and waits for the result. The dispatched run identifier is the train's CI evidence.
+
 ### 13.3 Merge requirement
 
 The train pull request must merge before stable publication.
@@ -436,6 +478,10 @@ The promotion controller verifies that `head_sha` is reachable from `master`. A 
 A squash or rebase creates a different release commit. The controller rejects the old evidence and requires a new candidate.
 
 The stable tag still points to the exact soaked commit. The merge proves that the reviewed candidate entered `master` before publication.
+
+For a stack train, the members merge bottom-up into `integration_branch` with true merge commits, and `integration_branch` then merges into `base_branch` with a true merge commit. The top head stays reachable from `base_branch`, so the promotion controller applies the same check without change.
+
+A member that merges by squash or rebase, or that is re-based after setup, changes the stack head. The controller rejects the old evidence and requires a new candidate from the merged stack head. A member that closes without a merge cancels the train.
 
 ### 13.4 Version reservations
 
@@ -476,6 +522,11 @@ The first planned use is the cost-accounting train from pull request #216.
 | `master` advances | Continue with the immutable candidate |
 | Train head changes | Cancel the candidate and run setup again |
 | Train uses squash or rebase | Create a new candidate from the merged SHA |
+| Stack member base is not the next member or the integration branch | Reject setup |
+| Stack member head is not an ancestor of the next member head | Reject setup |
+| Stack member merges by squash or rebase | Create a new candidate from the merged stack head |
+| Stack member closes without a merge | Cancel the train |
+| Integration branch advances past the stack head before the `master` merge | Continue with the immutable candidate; the head stays reachable |
 | Stable version becomes unavailable | Assign a new version and create a new candidate |
 | Promotion stops after tag creation | Resume idempotently and verify every existing object |
 
@@ -600,10 +651,13 @@ The controller (`release.yml`, `release-gates.sh`, `promote-release.sh`) can lan
 
 ### Phase 5: Deployment Trains
 
-1. Add the manifest validator and setup workflow.
+1. Add the manifest validator and setup workflow. The validator accepts `schema_version` 1 and 2.
 2. Run one non-publishing train rehearsal.
-3. Run the cost-accounting train as the first publishing train.
-4. Document the completed train evidence.
+3. Run one non-publishing stack-train rehearsal on a stacked pull-request set.
+4. Run the cost-accounting train as the first publishing train.
+5. Document the completed train evidence.
+
+The manifest validator and the stack ancestry checks (Section 13.2 steps 3a to 3c) depend on no earlier phase. The canary, digest-bound gates, and promotion steps depend on Phases 2 to 4.
 
 ### Phase 6: Shard soak-in on the test net
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -445,29 +445,23 @@ Rules for the `stack` block:
 
 A maintainer dispatches train setup with the manifest path.
 
-The setup workflow performs these actions:
+The setup workflow performs these actions. Steps marked *stack* apply only to a stack manifest and are no-ops for a single-train manifest.
 
 1. Load the manifest from the default branch.
 2. Validate the schema and train identifier.
-3. Verify the pull request and exact head SHA.
-4. Verify the source version against `target_version`.
-5. Verify that the version has no active reservation.
-6. Verify a successful full CI run for the exact head SHA.
-7. Create the train canary from that CI run.
-8. Start standard gates for the candidate.
-9. Start each mandatory feature-specific gate.
-10. Start the on-demand `weekend-60h` soak.
+3. Verify the pull request and exact head SHA. For a stack, `pull_request` and `head_sha` are the top member.
+4. *Stack:* verify the member chain. Members are listed bottom to top. The bottom member must target `integration_branch`. Every later member must target the branch of the member immediately before it in the list. Each member must be open or merged. Reject any other base or state.
+5. *Stack:* verify the head ancestry. The head of each member must be an ancestor of the head of the member immediately after it in the list, and `head_sha` must equal the head of the top member. Record every member head in the train record. This step proves that the top branch contains the whole stack at setup time.
+6. *Stack:* verify merged members. A member that has already merged must have a true merge commit on `integration_branch` whose second parent is the recorded member head. Setup cannot know how an open member *will* merge. That condition is enforced later: Section 13.3 re-validates the chain after every member merge and the promotion controller verifies every recorded member head at promotion time.
+7. Verify the source version against `target_version`.
+8. Verify that the version has no active reservation. Skip this step when `publishing` is `false`.
+9. Verify a successful full CI run for the exact head SHA. `ci.yml` runs pull-request CI for bases `dev`, `master`, `staging`, `trying`, and `feature/**`. A member whose base is outside that set (for example a `fix/**` or `formal/**` branch) gets no pull-request run. Setup therefore requires one successful `ci.yml` run for `head_sha` from any event. When none exists, setup dispatches `ci.yml` on `head_sha`, waits, and records that run identifier as the train's CI evidence.
+10. Create the train canary from that CI run.
+11. Start standard gates for the candidate.
+12. Start each mandatory feature-specific gate.
+13. Start the on-demand `weekend-60h` soak.
 
 Multiple trains can run at the same time. Workflow concurrency keys include the train identifier and target version.
-
-For a stack manifest, setup adds these checks between steps 3 and 6:
-
-- 3a. Verify that each member pull request is open or merged, and that its base is the branch of the next member or `integration_branch`. Reject any other base.
-- 3b. Verify that the head of each member is an ancestor of the head of the next member, and that `head_sha` equals the head of the top member. This check proves that the top branch contains the whole stack.
-- 3c. Verify that no member has merged, or will merge, by squash or rebase. A member that has already merged must have a merge commit on `integration_branch`.
-- 5a. Skip the version reservation when `publishing` is `false`.
-
-`ci.yml` runs on pull requests that target `dev`, `master`, or a `feature/**` branch. A stacked member that targets another member's branch gets no pull-request CI run. For step 6, setup therefore dispatches `ci.yml` on `head_sha` when no successful run exists for that SHA, and waits for the result. The dispatched run identifier is the train's CI evidence.
 
 ### 13.3 Merge requirement
 
@@ -481,7 +475,9 @@ The stable tag still points to the exact soaked commit. The merge proves that th
 
 For a stack train, the members merge bottom-up into `integration_branch` with true merge commits, and `integration_branch` then merges into `base_branch` with a true merge commit. The top head stays reachable from `base_branch`, so the promotion controller applies the same check without change.
 
-A member that merges by squash or rebase, or that is re-based after setup, changes the stack head. The controller rejects the old evidence and requires a new candidate from the merged stack head. A member that closes without a merge cancels the train.
+The chain is re-validated, not trusted from setup. After each member merges, the train workflow re-runs the Section 13.2 steps 4 to 6 against the live branches and the recorded member heads. At promotion, the controller verifies that every recorded member head, not only `head_sha`, is reachable from `base_branch`. A member that is force-pushed or re-based after setup merges a different commit, so its recorded head is not reachable, and the candidate is cancelled under the Section 15 rule "train head changes". That closes the window between setup and merge.
+
+A member that merges by squash or rebase changes the stack head. The controller rejects the old evidence and requires a new candidate from the merged stack head. A member that closes without a merge cancels the train.
 
 ### 13.4 Version reservations
 
@@ -522,8 +518,9 @@ The first planned use is the cost-accounting train from pull request #216.
 | `master` advances | Continue with the immutable candidate |
 | Train head changes | Cancel the candidate and run setup again |
 | Train uses squash or rebase | Create a new candidate from the merged SHA |
-| Stack member base is not the next member or the integration branch | Reject setup |
-| Stack member head is not an ancestor of the next member head | Reject setup |
+| Stack member base is not the preceding member or the integration branch | Reject setup |
+| Stack member head is not an ancestor of the following member head | Reject setup |
+| Recorded member head is not reachable from the base branch at promotion | Cancel the candidate and run setup again |
 | Stack member merges by squash or rebase | Create a new candidate from the merged stack head |
 | Stack member closes without a merge | Cancel the train |
 | Integration branch advances past the stack head before the `master` merge | Continue with the immutable candidate; the head stays reachable |
@@ -657,7 +654,7 @@ The controller (`release.yml`, `release-gates.sh`, `promote-release.sh`) can lan
 4. Run the cost-accounting train as the first publishing train.
 5. Document the completed train evidence.
 
-The manifest validator and the stack ancestry checks (Section 13.2 steps 3a to 3c) depend on no earlier phase. The canary, digest-bound gates, and promotion steps depend on Phases 2 to 4.
+The manifest validator and the stack checks (Section 13.2 steps 4 to 6) depend on no earlier phase. The canary, digest-bound gates, and promotion steps depend on Phases 2 to 4.
 
 ### Phase 6: Shard soak-in on the test net
 


### PR DESCRIPTION
## Summary

Phase 5 specification for EPIC-013 (TASK-013-6): stack Deployment Trains. Documentation only; the validator and setup workflow follow on this branch after Phases 2 to 4 land.

- `docs/release-process.md` Section 13.1.1: `schema_version: 2` stack manifests bind the top-of-stack head as the one candidate; members merge bottom-up with true merge commits; `publishing: false` marks a non-publishing rehearsal with no version reservation. Version 1 manifests stay valid.
- Section 13.2: setup checks member base, head ancestry, and merge method, and dispatches `ci.yml` on `head_sha` because pull-request CI does not run for stacked bases.
- Sections 13.3, 15, 18: stack merge rules, failure responses, rehearsal step, and which parts depend on earlier phases.
- `docs/ToDos.md`: EPIC-013 tasks 3 to 6 carry their `feature/release-phaseN-*` branches and a `blocked_by` chain; TASK-013-6 gains v2 validator and stack-rehearsal acceptance with the key-contention stack (#299 → #312 → #319 → #311) as the rehearsal candidate.

## Stack and merge procedure

Linear stack, one review-fix commit per layer after the 2026-08-22 multi-agent reviews:

1. #322 Phase 2 (`0.4.46` bump) → `dev` — approved 4/4
2. #323 Phase 4 (promotion controller) → Phase 2 — 3 critical + 6 major resolved in `c62759ac4`
3. #325 Phase 3 (candidate digest modes, OCIR canonical) → Phase 4 — 2 major resolved in `f57ebe6d3`
4. #321 Phase 5 (stack train spec) → Phase 3 — 2 critical + 4 major resolved in `5edeb8c7a`

Merge bottom-up with **merge commits** (no squash, no rebase: the release process binds evidence to exact SHAs). After each merge, confirm GitHub retargeted the next PR to `dev`, or retarget it by hand, before merging it. Every PR shows only its own commits against its base.

## Review resolutions (`5edeb8c7a`)

| Finding | Resolution |
|---|---|
| Force-push window after setup unspecified | Setup records every member head; §13.3 re-runs the chain checks after each member merge; the controller verifies every recorded head is reachable from the base branch at promotion. New §15 row. |
| Member base check inverted | Bottom member targets `integration_branch`; every later member targets the immediately preceding member. §15 rows reworded. |
| "Will merge by true merge" unknowable at setup | Topology validated for merged members only; open members enforced by the §13.3 re-validation. |
| CI filter text disagreed with `ci.yml` | Step 9 states the real filter; setup requires one successful `ci.yml` run for `head_sha` from any event and dispatches only when none exists. |
| `blocked_by` contradicted merge order | Chain now follows the stack (#322 → #323 → #325 → #321); runtime dependency of Phase 4 on Phase 3 noted. |
| "Between steps 3 and 6" numbering | §13.2 is one numbered sequence, 1–13. |
