### PR TITLE
chore(release): prepare v0.4.46 source version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "node"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node"
-version = "0.4.45"
+version = "0.4.46"
 edition = "2021"
 publish = false
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -184,7 +184,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 # drifting from node/Cargo.toml.
 ARG VERSION=unknown
 LABEL maintainer="F1r3fly.io LCA https://f1r3fly.io/"
-LABEL version="0.4.45"
+LABEL version="0.4.46"
 
 # Switch to daemon user (matching build.sbt: daemonUser in Docker := "daemon")
 USER daemon


### PR DESCRIPTION
Bump node/Cargo.toml, node/Dockerfile, and Cargo.lock from 0.4.45 to 0.4.46 so the next master CI run is release-eligible. v0.4.45 is already a stable tag, so canary-publish.yml has stopped at the eligibility check on every master run since it landed. release-evidence.sh inspect-source reports release_eligible: true for this tree.

Phase 2 proof for EPIC-013 / TASK-013-3: the first green master run after this lands publishes v0.4.46-canary.<run>.

## Stack and merge procedure

Linear stack, one review-fix commit per layer after the 2026-08-22 multi-agent reviews:

1. #322 Phase 2 (`0.4.46` bump) → `dev` — approved 4/4
2. #323 Phase 4 (promotion controller) → Phase 2 — 3 critical + 6 major resolved in `c62759ac4`
3. #325 Phase 3 (candidate digest modes, OCIR canonical) → Phase 4 — 2 major resolved in `f57ebe6d3`
4. #321 Phase 5 (stack train spec) → Phase 3 — 2 critical + 4 major resolved in `5edeb8c7a`

Merge bottom-up with **merge commits** (no squash, no rebase: the release process binds evidence to exact SHAs). After each merge, confirm GitHub retargeted the next PR to `dev`, or retarget it by hand, before merging it. Every PR shows only its own commits against its base.
