### PR TITLE
feat(release): candidate digest modes with OCIR as the canonical gate registry (Phase 3)

### DIFF
--- a/.github/scripts/promote-release.sh
+++ b/.github/scripts/promote-release.sh
@@ -17,8 +17,15 @@ set -euo pipefail
 #       "stable_tag": null | {"sha": "<commit the tag resolves to>"},
 #       "stable_release": null | {"prerelease": false, "assets": ["..."]},
 #       "registry": {"stable_tag_digest": null | "sha256:...",
-#                    "latest_digest": null | "sha256:..."}
+#                    "latest_digest": null | "sha256:..."},
+#       "ocir": {"stable_tag_digest": null | "sha256:...",
+#                "latest_digest": null | "sha256:..."}
 #     }
+#
+# OCIR is the canonical registry for candidate gates and Docker Hub is the
+# public mirror. Both receive the stable tag and the latest alias. The OCIR
+# repository path never enters a plan or evidence document; the workflow
+# resolves it from secrets and the plan carries only digests.
 #
 # Every existing object must already match the candidate. A mismatch stops
 # promotion (section 4.4 and section 15). A matching object is skipped, which
@@ -54,6 +61,7 @@ plan() {
 	local evidence="$1" report="$2" state="$3" output="$4"
 	local source_sha target_version stable_tag candidate_tag index_ref index_digest
 	local evidence_sha report_sha highest tag_sha release_json registry_digest latest_digest
+	local ocir_registry_digest ocir_latest_digest
 	require_file "$evidence"
 	require_file "$report"
 	require_file "$state"
@@ -120,6 +128,15 @@ plan() {
 			fail "registry tag $stable_tag resolves to $registry_digest, not the candidate index $index_digest"
 	fi
 	latest_digest="$(jq -r '.registry.latest_digest // empty' "$state")"
+	ocir_registry_digest="$(jq -r '.ocir.stable_tag_digest // empty' "$state")"
+	if [ -n "$ocir_registry_digest" ]; then
+		require_digest "$ocir_registry_digest" "OCIR stable tag digest"
+		[ "$ocir_registry_digest" = "$index_digest" ] ||
+			fail "OCIR tag $stable_tag resolves to $ocir_registry_digest, not the candidate index $index_digest"
+	fi
+	ocir_latest_digest="$(jq -r '.ocir.latest_digest // empty' "$state")"
+	[ "$(jq -r '.images.ocir_index_digest' "$evidence")" = "$index_digest" ] ||
+		fail "candidate evidence OCIR index digest differs from the Docker Hub index digest"
 
 	mkdir -p "$(dirname "$output")"
 	jq -n \
@@ -137,6 +154,8 @@ plan() {
 		--argjson create_release "$([ "$release_json" = null ] && echo true || echo false)" \
 		--argjson copy_image "$([ -z "$registry_digest" ] && echo true || echo false)" \
 		--argjson move_latest "$([ "$latest_digest" != "$index_digest" ] && echo true || echo false)" \
+		--argjson copy_image_ocir "$([ -z "$ocir_registry_digest" ] && echo true || echo false)" \
+		--argjson move_latest_ocir "$([ "$ocir_latest_digest" != "$index_digest" ] && echo true || echo false)" \
 		--argjson binaries "$(jq -c '{
 			"f1r3node-linux-amd64": .artifacts.linux_amd64.binary_sha256,
 			"f1r3node-linux-arm64": .artifacts.linux_arm64.binary_sha256}' "$evidence")" '
@@ -154,7 +173,13 @@ plan() {
 				candidate_index: $index_ref,
 				index_digest: $index_digest,
 				stable_reference: ($image_repository + ":" + $stable_tag),
-				latest_reference: ($image_repository + ":latest")
+				latest_reference: ($image_repository + ":latest"),
+				ocir: {
+					canonical: true,
+					index_digest: $index_digest,
+					stable_tag: $stable_tag,
+					latest_tag: "latest"
+				}
 			},
 			binaries: $binaries,
 			actions: {
@@ -162,6 +187,8 @@ plan() {
 				create_release: $create_release,
 				copy_image: $copy_image,
 				move_latest: $move_latest,
+				copy_image_ocir: $copy_image_ocir,
+				move_latest_ocir: $move_latest_ocir,
 				open_next_version_pr: true
 			}
 		}' >"$output"
@@ -198,6 +225,7 @@ stable_evidence() {
 		gate_report_sha256: .gate_report_sha256,
 		images: {
 			docker_hub: (.image.repository + "@" + .image.index_digest),
+			ocir_index_digest: .image.ocir.index_digest,
 			stable_reference: .image.stable_reference
 		},
 		binaries: .binaries,

--- a/.github/scripts/release-evidence.sh
+++ b/.github/scripts/release-evidence.sh
@@ -317,15 +317,20 @@ generate_evidence() {
 			images: {
 				publication_state: "not_published",
 				docker_hub: null,
-				ocir: null
+				ocir_index_digest: null
 			},
 			created_at: $created_at
 		}' >"$output"
 	validate_evidence "$output"
 }
 
+# The OCIR index digest is recorded, never the OCIR repository path: the
+# path is repository-secret material and evidence is public. The same image
+# blobs and the same manifest list produce the same content-addressed digest
+# in both registries, so the two digests must be equal. A difference means
+# the registries hold different candidates, and publication must stop.
 record_images() {
-	local evidence="$1" index_ref="$2" amd64_digest="$3" arm64_digest="$4"
+	local evidence="$1" index_ref="$2" amd64_digest="$3" arm64_digest="$4" ocir_digest="$5"
 	require_file "$evidence"
 	validate_evidence "$evidence"
 	[ "$(jq -r '.publication_mode' "$evidence")" = evidence_only ] ||
@@ -334,16 +339,20 @@ record_images() {
 		fail "image index reference must be repository@sha256:digest"
 	require_artifact_digest "$amd64_digest" "linux amd64 image digest"
 	require_artifact_digest "$arm64_digest" "linux arm64 image digest"
+	require_artifact_digest "$ocir_digest" "OCIR image index digest"
+	[ "$ocir_digest" = "${index_ref#*@}" ] ||
+		fail "OCIR index digest $ocir_digest differs from the Docker Hub index digest ${index_ref#*@}"
 	local updated
 	updated="$(jq \
 		--arg docker_hub "$index_ref" \
 		--arg amd64 "$amd64_digest" \
 		--arg arm64 "$arm64_digest" \
+		--arg ocir_digest "$ocir_digest" \
 		'.publication_mode = "canary"
 		| .images = {
 			publication_state: "published",
 			docker_hub: $docker_hub,
-			ocir: null,
+			ocir_index_digest: $ocir_digest,
 			linux_amd64_digest: $amd64,
 			linux_arm64_digest: $arm64
 		}' "$evidence")"
@@ -386,12 +395,13 @@ validate_evidence() {
 			(.publication_mode == "evidence_only"
 				and .images.publication_state == "not_published"
 				and .images.docker_hub == null
-				and .images.ocir == null)
+				and .images.ocir_index_digest == null)
 			or
 			(.publication_mode == "canary"
 				and .images.publication_state == "published"
 				and (.images.docker_hub | type == "string" and test("^[a-z0-9./_-]+@sha256:[0-9a-f]{64}$"))
-				and .images.ocir == null
+				and (.images.ocir_index_digest | type == "string" and test("^sha256:[0-9a-f]{64}$"))
+				and .images.ocir_index_digest == (.images.docker_hub | split("@")[1])
 				and (.images.linux_amd64_digest | type == "string" and test("^sha256:[0-9a-f]{64}$"))
 				and (.images.linux_arm64_digest | type == "string" and test("^sha256:[0-9a-f]{64}$")))
 		)
@@ -408,7 +418,7 @@ usage() {
 		"usage: $0 inspect-source SOURCE_DIR" \
 		"       $0 required-jobs" \
 		"       $0 generate SOURCE_DIR REPOSITORY RUN_JSON JOBS_JSON ARTIFACTS_JSON ARTIFACTS_DIR OUTPUT" \
-		"       $0 record-images EVIDENCE_JSON INDEX_REF AMD64_DIGEST ARM64_DIGEST" \
+		"       $0 record-images EVIDENCE_JSON INDEX_REF AMD64_DIGEST ARM64_DIGEST OCIR_INDEX_DIGEST" \
 		"       $0 validate EVIDENCE_JSON" >&2
 	exit 2
 }
@@ -428,8 +438,8 @@ generate)
 	generate_evidence "$2" "$3" "$4" "$5" "$6" "$7" "$8"
 	;;
 record-images)
-	[ "$#" -eq 5 ] || usage
-	record_images "$2" "$3" "$4" "$5"
+	[ "$#" -eq 6 ] || usage
+	record_images "$2" "$3" "$4" "$5" "$6"
 	;;
 validate)
 	[ "$#" -eq 2 ] || usage

--- a/.github/scripts/release-gate-evidence.sh
+++ b/.github/scripts/release-gate-evidence.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Gate-evidence writer (docs/release-process.md section 8.1).
+#
+# A gate workflow that runs in candidate mode calls this script at the end
+# of a successful run. The script binds the document to the candidate from
+# release-evidence.json, so a workflow cannot publish evidence for a source
+# or image other than the one it validated. release-gates.sh consumes the
+# result; test-release-gate-evidence.sh proves the two agree.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EVIDENCE_TOOL="$SCRIPT_DIR/release-evidence.sh"
+
+fail() {
+	printf 'release gate evidence error: %s\n' "$1" >&2
+	exit 1
+}
+
+require_file() {
+	[ -f "$1" ] || fail "missing file: $1"
+}
+
+require_positive_integer() {
+	[[ "$1" =~ ^[1-9][0-9]*$ ]] || fail "$2 must be a positive integer"
+}
+
+# Common envelope. RUN_JSON is the GitHub API document for the gate run
+# itself; the envelope records its id, attempt, and workflow path.
+envelope() {
+	local gate="$1" evidence="$2" run_json="$3" workflow_path="$4"
+	require_file "$evidence"
+	require_file "$run_json"
+	"$EVIDENCE_TOOL" validate "$evidence"
+	[ "$(jq -r '.publication_mode' "$evidence")" = canary ] ||
+		fail "gate evidence requires canary candidate evidence"
+	jq -e --arg path "$workflow_path" '.path == $path' "$run_json" >/dev/null ||
+		fail "gate run does not use workflow $workflow_path"
+	require_positive_integer "$(jq -r '.id' "$run_json")" "gate run id"
+	require_positive_integer "$(jq -r '.run_attempt' "$run_json")" "gate run attempt"
+	jq -n \
+		--arg gate "$gate" \
+		--arg source_sha "$(jq -r '.source_sha' "$evidence")" \
+		--arg candidate_tag "$(jq -r '.candidate_tag' "$evidence")" \
+		--arg image_index_digest "$(jq -r '.images.ocir_index_digest' "$evidence")" \
+		--argjson run_id "$(jq -r '.id' "$run_json")" \
+		--argjson run_attempt "$(jq -r '.run_attempt' "$run_json")" \
+		--arg workflow_path "$workflow_path" '
+		{
+			schema_version: 1,
+			gate: $gate,
+			source_sha: $source_sha,
+			candidate_tag: $candidate_tag,
+			image_index_digest: $image_index_digest,
+			workflow_run: {
+				id: $run_id,
+				attempt: $run_attempt,
+				path: $workflow_path,
+				conclusion: "success"
+			}
+		}'
+}
+
+write_oci_validation() {
+	local evidence="$1" run_json="$2" jobs_json="$3" output="$4"
+	local base required
+	require_file "$jobs_json"
+	base="$(envelope oci_validation "$evidence" "$run_json" .github/workflows/oci-validation.yml)"
+	# The two architecture summary jobs are the required conclusions. Their
+	# names carry the reusable-workflow prefix in the run's job listing.
+	required="$(jq -c '
+		[.jobs[] | select(.name | test("Integration Tests \\((amd64|arm64)\\)$"))
+			| {name: .name, conclusion: .conclusion}]
+		| sort_by(.name)' "$jobs_json")"
+	[ "$(jq 'length' <<<"$required")" -eq 2 ] ||
+		fail "OCI validation run must report exactly the amd64 and arm64 integration summary jobs"
+	jq -e '[.[] | select(.conclusion != "success")] | length == 0' <<<"$required" >/dev/null ||
+		fail "a required OCI validation job did not succeed"
+	mkdir -p "$(dirname "$output")"
+	jq \
+		--arg pin "$(jq -r '.system_integration_sha' "$evidence")" \
+		--argjson required "$required" '
+		. + {
+			mode: "candidate",
+			system_integration_sha: $pin,
+			required_jobs: $required
+		}' <<<"$base" >"$output"
+}
+
+# SOAK_RESULT_JSON is produced by the soak workflow from its own run state:
+#   {
+#     "soak_kind": "weekend",
+#     "requested_duration_seconds": 216000,
+#     "completed": true,
+#     "artifact_mode": "candidate",
+#     "retry_attempt": 0,
+#     "coverage_preserved": true,
+#     "preflight": {"status": "success"}
+#   }
+write_stability_soak() {
+	local evidence="$1" run_json="$2" soak_result_json="$3" output="$4"
+	local base
+	require_file "$soak_result_json"
+	base="$(envelope stability_soak "$evidence" "$run_json" .github/workflows/merge-recovery-soak.yml)"
+	jq -e '
+		.soak_kind == "weekend"
+		and .requested_duration_seconds == 216000
+		and .completed == true
+		and .artifact_mode == "candidate"
+		and (.retry_attempt | type == "number" and . >= 0 and . <= 1)
+		and (.coverage_preserved | type == "boolean")
+		and (.preflight.status | type == "string")' "$soak_result_json" >/dev/null ||
+		fail "soak result does not describe a completed candidate-mode 60h stability soak"
+	mkdir -p "$(dirname "$output")"
+	jq --slurpfile result "$soak_result_json" '. + $result[0]' <<<"$base" >"$output"
+}
+
+write_verdict() {
+	local evidence="$1" verdict="$2" output="$3"
+	require_file "$evidence"
+	"$EVIDENCE_TOOL" validate "$evidence"
+	case "$verdict" in
+	pass | regress | inconclusive) ;;
+	*) fail "verdict must be pass, regress, or inconclusive" ;;
+	esac
+	mkdir -p "$(dirname "$output")"
+	jq -n \
+		--arg source_sha "$(jq -r '.source_sha' "$evidence")" \
+		--arg candidate_tag "$(jq -r '.candidate_tag' "$evidence")" \
+		--arg verdict "$verdict" '
+		{schema_version: 1, source_sha: $source_sha, candidate_tag: $candidate_tag, verdict: $verdict}' >"$output"
+}
+
+write_candidate_marker() {
+	local evidence="$1" output="$2"
+	require_file "$evidence"
+	"$EVIDENCE_TOOL" validate "$evidence"
+	mkdir -p "$(dirname "$output")"
+	jq '{candidate_tag: .candidate_tag, source_sha: .source_sha}' "$evidence" >"$output"
+}
+
+usage() {
+	printf '%s\n' \
+		"usage: $0 oci-validation EVIDENCE_JSON RUN_JSON JOBS_JSON OUTPUT" \
+		"       $0 stability-soak EVIDENCE_JSON RUN_JSON SOAK_RESULT_JSON OUTPUT" \
+		"       $0 verdict EVIDENCE_JSON VERDICT OUTPUT" \
+		"       $0 candidate-marker EVIDENCE_JSON OUTPUT" >&2
+	exit 2
+}
+
+command="${1:-}"
+case "$command" in
+oci-validation)
+	[ "$#" -eq 5 ] || usage
+	write_oci_validation "$2" "$3" "$4" "$5"
+	;;
+stability-soak)
+	[ "$#" -eq 5 ] || usage
+	write_stability_soak "$2" "$3" "$4" "$5"
+	;;
+verdict)
+	[ "$#" -eq 4 ] || usage
+	write_verdict "$2" "$3" "$4"
+	;;
+candidate-marker)
+	[ "$#" -eq 3 ] || usage
+	write_candidate_marker "$2" "$3"
+	;;
+*) usage ;;
+esac

--- a/.github/scripts/release-gate-evidence.sh
+++ b/.github/scripts/release-gate-evidence.sh
@@ -38,11 +38,17 @@ envelope() {
 		fail "gate run does not use workflow $workflow_path"
 	require_positive_integer "$(jq -r '.id' "$run_json")" "gate run id"
 	require_positive_integer "$(jq -r '.run_attempt' "$run_json")" "gate run attempt"
+	# The document records the SHA-256 of the exact evidence file the run
+	# resolved before testing. The publishing job must pass that same file
+	# (carried from the test job as a run artifact), never a fresh download
+	# of the mutable release asset, and the promotion controller requires
+	# this digest to equal the evidence it evaluates.
 	jq -n \
 		--arg gate "$gate" \
 		--arg source_sha "$(jq -r '.source_sha' "$evidence")" \
 		--arg candidate_tag "$(jq -r '.candidate_tag' "$evidence")" \
 		--arg image_index_digest "$(jq -r '.images.ocir_index_digest' "$evidence")" \
+		--arg evidence_sha256 "$(sha256sum "$evidence" | awk '{print $1}')" \
 		--argjson run_id "$(jq -r '.id' "$run_json")" \
 		--argjson run_attempt "$(jq -r '.run_attempt' "$run_json")" \
 		--arg workflow_path "$workflow_path" '
@@ -52,6 +58,7 @@ envelope() {
 			source_sha: $source_sha,
 			candidate_tag: $candidate_tag,
 			image_index_digest: $image_index_digest,
+			candidate_evidence_sha256: $evidence_sha256,
 			workflow_run: {
 				id: $run_id,
 				attempt: $run_attempt,

--- a/.github/scripts/release-gates.sh
+++ b/.github/scripts/release-gates.sh
@@ -163,8 +163,9 @@ gate_slashing() {
 
 # Shared checks for a gate document that must bind to the candidate.
 candidate_binding_reason() {
-	local doc="$1" evidence="$2" gate="$3"
-	jq -r --slurpfile ev "$evidence" --arg gate "$gate" '
+	local doc="$1" evidence="$2" gate="$3" evidence_sha
+	evidence_sha="$(sha256sum "$evidence" | awk '{print $1}')"
+	jq -r --slurpfile ev "$evidence" --arg gate "$gate" --arg evidence_sha "$evidence_sha" '
 		$ev[0] as $e
 		| if type != "object" then "document is not an object"
 		elif .schema_version != 1 then "schema_version is " + ((.schema_version // "null") | tostring)
@@ -172,6 +173,7 @@ candidate_binding_reason() {
 		elif .source_sha != $e.source_sha then "document source " + (.source_sha // "null") + " is not the candidate source"
 		elif .candidate_tag != $e.candidate_tag then "document candidate tag is " + (.candidate_tag // "null")
 		elif .image_index_digest != ($e.images.docker_hub | split("@")[1]) then "document image digest " + (.image_index_digest // "null") + " is not the candidate image"
+		elif .candidate_evidence_sha256 != $evidence_sha then "document was built from evidence " + (.candidate_evidence_sha256 // "null")[0:12] + ", not the evidence under evaluation"
 		elif (.workflow_run.id | type != "number") then "document has no workflow run id"
 		elif (.workflow_run.attempt | type != "number") then "document has no workflow run attempt"
 		elif .workflow_run.conclusion != "success" then "document workflow conclusion is " + (.workflow_run.conclusion // "null")

--- a/.github/scripts/test-promote-release.sh
+++ b/.github/scripts/test-promote-release.sh
@@ -51,7 +51,7 @@ mkdir -p "$GATES"
 INDEX_DIGEST="sha256:$(printf 'index' | sha256sum | awk '{print $1}')"
 REPO_REF=docker.io/f1r3flyindustries/f1r3fly-rust
 "$EVIDENCE_TOOL" record-images "$GATES/release-evidence.json" "$REPO_REF@$INDEX_DIGEST" \
-	"sha256:$(printf 'amd64' | sha256sum | awk '{print $1}')" "sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')"
+	"sha256:$(printf 'amd64' | sha256sum | awk '{print $1}')" "sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')" "$INDEX_DIGEST"
 EVIDENCE="$GATES/release-evidence.json"
 CANDIDATE_TAG="$(jq -r '.candidate_tag' "$EVIDENCE")"
 cp "$TMP/ci-run.json" "$TMP/ci-jobs.json" "$GATES/"
@@ -87,7 +87,7 @@ state() {
 }
 
 # --- Fresh promotion: every action planned ----------------------------------
-state '{stable_tags: ["v0.4.45"], stable_tag: null, stable_release: null, registry: {stable_tag_digest: null, latest_digest: null}}' >"$TMP/fresh.json"
+state '{stable_tags: ["v0.4.45"], stable_tag: null, stable_release: null, registry: {stable_tag_digest: null, latest_digest: null}, ocir: {stable_tag_digest: null, latest_digest: null}}' >"$TMP/fresh.json"
 PLAN="$TMP/plan.json"
 "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/fresh.json" "$PLAN" 2>/dev/null
 jq -e --arg sha "$SOURCE_SHA" --arg digest "$INDEX_DIGEST" --arg tag "$CANDIDATE_TAG" '
@@ -95,20 +95,21 @@ jq -e --arg sha "$SOURCE_SHA" --arg digest "$INDEX_DIGEST" --arg tag "$CANDIDATE
 	and .image.index_digest == $digest
 	and .image.stable_reference == "docker.io/f1r3flyindustries/f1r3fly-rust:v0.4.46"
 	and .image.latest_reference == "docker.io/f1r3flyindustries/f1r3fly-rust:latest"
-	and .actions == {create_tag: true, create_release: true, copy_image: true, move_latest: true, open_next_version_pr: true}
+	and .actions == {create_tag: true, create_release: true, copy_image: true, move_latest: true, copy_image_ocir: true, move_latest_ocir: true, open_next_version_pr: true}
+	and .image.ocir == {canonical: true, index_digest: $digest, stable_tag: "v0.4.46", latest_tag: "latest"}
 	and (.binaries | keys) == ["f1r3node-linux-amd64", "f1r3node-linux-arm64"]' "$PLAN" >/dev/null
 "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/fresh.json" "$TMP/plan-repeat.json" 2>/dev/null
 cmp "$PLAN" "$TMP/plan-repeat.json"
 
 # --- Resume: existing objects that match are skipped -----------------------
 state "{stable_tags: [\"v0.4.45\", \"v0.4.46\"], stable_tag: {sha: \"$SOURCE_SHA\"}, stable_release: {prerelease: false, assets: [\"f1r3node-linux-amd64\", \"f1r3node-linux-arm64\", \"checksums.txt\", \"release-evidence.json\", \"gate-report.json\", \"stable-release-evidence.json\", \"stable-release-evidence.json.sha256\"]},
-	registry: {stable_tag_digest: \"$INDEX_DIGEST\", latest_digest: \"$INDEX_DIGEST\"}}" >"$TMP/resume.json"
+	registry: {stable_tag_digest: \"$INDEX_DIGEST\", latest_digest: \"$INDEX_DIGEST\"}, ocir: {stable_tag_digest: \"$INDEX_DIGEST\", latest_digest: \"$INDEX_DIGEST\"}}" >"$TMP/resume.json"
 "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/resume.json" "$TMP/resume-plan.json" 2>/dev/null
-jq -e '.actions == {create_tag: false, create_release: false, copy_image: false, move_latest: false, open_next_version_pr: true}' "$TMP/resume-plan.json" >/dev/null
+jq -e '.actions == {create_tag: false, create_release: false, copy_image: false, move_latest: false, copy_image_ocir: false, move_latest_ocir: false, open_next_version_pr: true}' "$TMP/resume-plan.json" >/dev/null
 state "{stable_tags: [\"v0.4.45\", \"v0.4.46\"], stable_tag: {sha: \"$SOURCE_SHA\"}, stable_release: null,
-	registry: {stable_tag_digest: null, latest_digest: \"sha256:$(printf 'older' | sha256sum | awk '{print $1}')\"}}" >"$TMP/partial.json"
+	registry: {stable_tag_digest: null, latest_digest: \"sha256:$(printf 'older' | sha256sum | awk '{print $1}')\"}, ocir: {stable_tag_digest: \"$INDEX_DIGEST\", latest_digest: null}}" >"$TMP/partial.json"
 "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/partial.json" "$TMP/partial-plan.json" 2>/dev/null
-jq -e '.actions == {create_tag: false, create_release: true, copy_image: true, move_latest: true, open_next_version_pr: true}' "$TMP/partial-plan.json" >/dev/null
+jq -e '.actions == {create_tag: false, create_release: true, copy_image: true, move_latest: true, copy_image_ocir: false, move_latest_ocir: true, open_next_version_pr: true}' "$TMP/partial-plan.json" >/dev/null
 
 # --- Stop conditions ---------------------------------------------------------
 OTHER_SHA=fedcba9876543210fedcba9876543210fedcba98
@@ -116,6 +117,8 @@ state "{stable_tags: [\"v0.4.45\", \"v0.4.46\"], stable_tag: {sha: \"$OTHER_SHA\
 expect_failure 'stable tag points elsewhere' "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/bad-tag.json" "$TMP/x.json"
 state "{stable_tags: [\"v0.4.45\"], stable_tag: null, stable_release: null, registry: {stable_tag_digest: \"sha256:$(printf 'other' | sha256sum | awk '{print $1}')\", latest_digest: null}}" >"$TMP/bad-registry.json"
 expect_failure 'registry stable tag points elsewhere' "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/bad-registry.json" "$TMP/x.json"
+state "{stable_tags: [\"v0.4.45\"], stable_tag: null, stable_release: null, registry: {stable_tag_digest: null, latest_digest: null}, ocir: {stable_tag_digest: \"sha256:$(printf 'other' | sha256sum | awk '{print $1}')\", latest_digest: null}}" >"$TMP/bad-ocir.json"
+expect_failure 'OCIR stable tag points elsewhere' "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/bad-ocir.json" "$TMP/x.json"
 state '{stable_tags: ["v0.4.45", "v0.4.47"], stable_tag: null, stable_release: null, registry: {stable_tag_digest: null, latest_digest: null}}' >"$TMP/overtaken.json"
 expect_failure 'higher stable version published first' "$TOOL" plan "$EVIDENCE" "$REPORT" "$TMP/overtaken.json" "$TMP/x.json"
 state "{stable_tags: [\"v0.4.45\"], stable_tag: null, stable_release: {prerelease: true, assets: []}, registry: {stable_tag_digest: null, latest_digest: null}}" >"$TMP/release-no-tag.json"
@@ -145,6 +148,7 @@ jq -e --arg sha "$SOURCE_SHA" --arg digest "$INDEX_DIGEST" --arg tag "$CANDIDATE
 	--arg esha "$(sha256sum "$EVIDENCE" | awk '{print $1}')" '
 	.schema_version == 1 and .stable_tag == "v0.4.46" and .candidate_tag == $tag and .source_sha == $sha
 	and .images.docker_hub == ("docker.io/f1r3flyindustries/f1r3fly-rust@" + $digest)
+	and .images.ocir_index_digest == $digest
 	and .promoted_at == "2026-08-20T00:00:00Z"
 	and .candidate_evidence_sha256 == $esha' "$STABLE" >/dev/null
 expect_failure 'stable digest differs from candidate' "$TOOL" stable-evidence "$PLAN" "sha256:$(printf 'other' | sha256sum | awk '{print $1}')" 2026-08-20T00:00:00Z "$TMP/x.json"

--- a/.github/scripts/test-promote-release.sh
+++ b/.github/scripts/test-promote-release.sh
@@ -58,10 +58,11 @@ cp "$TMP/ci-run.json" "$TMP/ci-jobs.json" "$GATES/"
 jq '.path = ".github/workflows/slashing-tests.yml" | .id = 555' "$TMP/ci-run.json" >"$GATES/slashing-run.json"
 jq -n '{jobs: ([{name: "Example-based UC tests"}, {name: "Property-based theorem tests"}, {name: "Loom exhaustive interleaving (T-9.2)"},
 	{name: "Pre-fix regression backstops (1)"}] | map(. + {status: "completed", conclusion: "success"}))}' >"$GATES/slashing-jobs.json"
+EVIDENCE_SHA256="$(sha256sum "$GATES/release-evidence.json" | awk '{print $1}')"
 binding() {
-	jq -n --arg gate "$1" --arg sha "$SOURCE_SHA" --arg tag "$CANDIDATE_TAG" --arg digest "$INDEX_DIGEST" --arg path "$2" '{
+	jq -n --arg gate "$1" --arg sha "$SOURCE_SHA" --arg tag "$CANDIDATE_TAG" --arg digest "$INDEX_DIGEST" --arg esha "$EVIDENCE_SHA256" --arg path "$2" '{
 		schema_version: 1, gate: $gate, source_sha: $sha, candidate_tag: $tag, image_index_digest: $digest,
-		workflow_run: {id: 7, attempt: 1, path: $path, conclusion: "success"}}'
+		candidate_evidence_sha256: $esha, workflow_run: {id: 7, attempt: 1, path: $path, conclusion: "success"}}'
 }
 binding oci_validation .github/workflows/oci-validation.yml | jq --arg pin "$PIN" '. + {mode: "candidate", system_integration_sha: $pin,
 	required_jobs: [{name: "OCI validation", conclusion: "success"}]}' >"$GATES/oci-validation-evidence.json"

--- a/.github/scripts/test-release-evidence.sh
+++ b/.github/scripts/test-release-evidence.sh
@@ -91,7 +91,7 @@ jq -e '
 	and (.ci.required_jobs | length) == 25
 	and .images.publication_state == "not_published"
 	and .images.docker_hub == null
-	and .images.ocir == null
+	and .images.ocir_index_digest == null
 ' --arg source_sha "$SOURCE_SHA" "$OUTPUT" >/dev/null
 
 expect_failure() {
@@ -123,16 +123,20 @@ INDEX_REF="docker.io/f1r3flyindustries/f1r3fly-rust@sha256:$(printf 'index' | sh
 AMD64_DIGEST="sha256:$(printf 'amd64' | sha256sum | awk '{print $1}')"
 ARM64_DIGEST="sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')"
 cp "$OUTPUT" "$TMP/canary-evidence.json"
-"$TOOL" record-images "$TMP/canary-evidence.json" "$INDEX_REF" "$AMD64_DIGEST" "$ARM64_DIGEST"
+"$TOOL" record-images "$TMP/canary-evidence.json" "$INDEX_REF" "$AMD64_DIGEST" "$ARM64_DIGEST" "${INDEX_REF#*@}"
 jq -e '
 	.publication_mode == "canary"
 	and .images.publication_state == "published"
-	and .images.ocir == null
+	and .images.ocir_index_digest == (.images.docker_hub | split("@")[1])
 ' "$TMP/canary-evidence.json" >/dev/null
 "$TOOL" validate "$TMP/canary-evidence.json"
-expect_failure 'record-images rejects canary input' "$TOOL" record-images "$TMP/canary-evidence.json" "$INDEX_REF" "$AMD64_DIGEST" "$ARM64_DIGEST"
+expect_failure 'record-images rejects canary input' "$TOOL" record-images "$TMP/canary-evidence.json" "$INDEX_REF" "$AMD64_DIGEST" "$ARM64_DIGEST" "${INDEX_REF#*@}"
 cp "$OUTPUT" "$TMP/bad-ref.json"
-expect_failure 'record-images rejects a tag reference' "$TOOL" record-images "$TMP/bad-ref.json" "docker.io/f1r3flyindustries/f1r3fly-rust:v0.4.46-canary.812" "$AMD64_DIGEST" "$ARM64_DIGEST"
+expect_failure 'record-images rejects a tag reference' "$TOOL" record-images "$TMP/bad-ref.json" "docker.io/f1r3flyindustries/f1r3fly-rust:v0.4.46-canary.812" "$AMD64_DIGEST" "$ARM64_DIGEST" "${INDEX_REF#*@}"
+cp "$OUTPUT" "$TMP/ocir-mismatch.json"
+expect_failure 'record-images rejects a divergent OCIR digest' "$TOOL" record-images "$TMP/ocir-mismatch.json" "$INDEX_REF" "$AMD64_DIGEST" "$ARM64_DIGEST" "$AMD64_DIGEST"
+jq '.images.ocir_index_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"' "$TMP/canary-evidence.json" >"$TMP/tampered-ocir.json"
+expect_failure 'OCIR digest differs from Docker Hub index' "$TOOL" validate "$TMP/tampered-ocir.json"
 jq '.images.linux_amd64_digest = "sha256:bad"' "$TMP/canary-evidence.json" >"$TMP/tampered-canary.json"
 expect_failure 'invalid canary image digest' "$TOOL" validate "$TMP/tampered-canary.json"
 printf 'release evidence tests passed\n'

--- a/.github/scripts/test-release-gate-evidence.sh
+++ b/.github/scripts/test-release-gate-evidence.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Producer and evaluator agreement: every document that
+# release-gate-evidence.sh writes must pass release-gates.sh, and a run
+# whose image or source differs from the candidate must be refused by the
+# writer before it can reach the evaluator.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVIDENCE_TOOL="$ROOT/.github/scripts/release-evidence.sh"
+GATES_TOOL="$ROOT/.github/scripts/release-gates.sh"
+TOOL="$ROOT/.github/scripts/release-gate-evidence.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+REPOSITORY=example/repository
+PIN=0123456789abcdef0123456789abcdef01234567
+
+SOURCE="$TMP/source"
+ARTIFACTS="$TMP/artifacts"
+mkdir -p "$SOURCE/node" "$SOURCE/.github" \
+	"$ARTIFACTS/artifacts-docker-amd64" "$ARTIFACTS/artifacts-docker-arm64" "$ARTIFACTS/release"
+printf '%s\n' '[package]' 'name = "node"' 'version = "0.4.46"' >"$SOURCE/node/Cargo.toml"
+printf '%s\n' 'FROM scratch' 'LABEL version="0.4.46"' >"$SOURCE/node/Dockerfile"
+printf '%s\n' 'version = 4' '[[package]]' 'name = "node"' 'version = "0.4.46"' >"$SOURCE/Cargo.lock"
+printf 'SYSTEM_INTEGRATION_REF=%s\n' "$PIN" >"$SOURCE/.github/oci-validation.env"
+git -C "$SOURCE" init -q
+git -C "$SOURCE" config user.name 'Gate Evidence Test'
+git -C "$SOURCE" config user.email 'test@example.com'
+git -C "$SOURCE" add .
+git -C "$SOURCE" commit -qm 'test fixture'
+git -C "$SOURCE" tag v0.4.45
+SOURCE_SHA="$(git -C "$SOURCE" rev-parse HEAD)"
+for f in artifacts-docker-amd64/rust-node-docker.tar.gz artifacts-docker-arm64/rust-node-docker.tar.gz release/f1r3node-linux-amd64 release/f1r3node-linux-arm64; do
+	printf '%s\n' "$f" >"$ARTIFACTS/$f"
+done
+run_doc() {
+	jq -n --arg path "$1" --argjson id "$2" --argjson attempt "$3" --arg sha "$4" --arg event "${5:-push}" \
+		--arg branch "${6:-master}" --arg repo "$REPOSITORY" '{
+		id: $id, run_number: ($id % 1000), run_attempt: $attempt, path: $path, event: $event, head_branch: $branch,
+		status: "completed", conclusion: "success", head_sha: $sha, repository: {full_name: $repo},
+		updated_at: "2026-08-16T00:00:00Z"}'
+}
+run_doc .github/workflows/ci.yml 123456789 1 "$SOURCE_SHA" >"$TMP/ci-run.json"
+"$EVIDENCE_TOOL" required-jobs | jq '[to_entries[] | {id: (.key + 1000), name: .value, status: "completed",
+	conclusion: "success", completed_at: "2026-08-16T00:00:00Z"}] | {jobs: .}' >"$TMP/ci-jobs.json"
+cat >"$TMP/artifacts.json" <<EOF
+{"artifacts": [
+  {"id": 201, "name": "artifacts-docker-amd64", "expired": false, "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "workflow_run": {"id": 123456789}},
+  {"id": 202, "name": "artifacts-docker-arm64", "expired": false, "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "workflow_run": {"id": 123456789}}
+]}
+EOF
+GATES="$TMP/gates"
+mkdir -p "$GATES"
+EVIDENCE="$GATES/release-evidence.json"
+"$EVIDENCE_TOOL" generate "$SOURCE" "$REPOSITORY" "$TMP/ci-run.json" "$TMP/ci-jobs.json" "$TMP/artifacts.json" "$ARTIFACTS" "$EVIDENCE"
+cp "$EVIDENCE" "$TMP/evidence-only.json"
+INDEX_DIGEST="sha256:$(printf 'index' | sha256sum | awk '{print $1}')"
+"$EVIDENCE_TOOL" record-images "$EVIDENCE" "docker.io/f1r3flyindustries/f1r3fly-rust@$INDEX_DIGEST" \
+	"sha256:$(printf 'amd64' | sha256sum | awk '{print $1}')" "sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')" "$INDEX_DIGEST"
+cp "$TMP/ci-run.json" "$TMP/ci-jobs.json" "$GATES/"
+run_doc .github/workflows/slashing-tests.yml 555 1 "$SOURCE_SHA" >"$GATES/slashing-run.json"
+jq -n '{jobs: ([{name: "Example-based UC tests"}, {name: "Property-based theorem tests"}, {name: "Loom exhaustive interleaving (T-9.2)"},
+	{name: "Pre-fix regression backstops (1)"}] | map(. + {status: "completed", conclusion: "success"}))}' >"$GATES/slashing-jobs.json"
+
+expect_failure() {
+	local label="$1"
+	shift
+	if "$@" >"$TMP/out" 2>"$TMP/err"; then
+		printf 'expected failure: %s\n' "$label" >&2
+		exit 1
+	fi
+}
+
+# --- OCI validation document ------------------------------------------------
+run_doc .github/workflows/oci-validation.yml 777 2 "$SOURCE_SHA" workflow_dispatch master >"$TMP/oci-run.json"
+jq -n '{jobs: [
+	{name: "Validate Candidate Input", status: "completed", conclusion: "success"},
+	{name: "Run OCI Validation / Integration Tests (amd64-docker-1)", status: "completed", conclusion: "success"},
+	{name: "Run OCI Validation / Integration Tests (amd64)", status: "completed", conclusion: "success"},
+	{name: "Run OCI Validation / Integration Tests (arm64)", status: "completed", conclusion: "success"}]}' >"$TMP/oci-jobs.json"
+"$TOOL" oci-validation "$EVIDENCE" "$TMP/oci-run.json" "$TMP/oci-jobs.json" "$GATES/oci-validation-evidence.json"
+jq -e --arg sha "$SOURCE_SHA" --arg digest "$INDEX_DIGEST" --arg pin "$PIN" '
+	.schema_version == 1 and .gate == "oci_validation" and .source_sha == $sha and .image_index_digest == $digest
+	and .workflow_run == {id: 777, attempt: 2, path: ".github/workflows/oci-validation.yml", conclusion: "success"}
+	and .mode == "candidate" and .system_integration_sha == $pin and (.required_jobs | length) == 2' "$GATES/oci-validation-evidence.json" >/dev/null
+jq '(.jobs[] | select(.name | endswith("(arm64)")) | .conclusion) = "failure"' "$TMP/oci-jobs.json" >"$TMP/oci-jobs-failed.json"
+expect_failure 'OCI document with a failed summary job' "$TOOL" oci-validation "$EVIDENCE" "$TMP/oci-run.json" "$TMP/oci-jobs-failed.json" "$TMP/x.json"
+jq '.jobs |= map(select(.name | endswith("(arm64)") | not))' "$TMP/oci-jobs.json" >"$TMP/oci-jobs-missing.json"
+expect_failure 'OCI document without the arm64 summary job' "$TOOL" oci-validation "$EVIDENCE" "$TMP/oci-run.json" "$TMP/oci-jobs-missing.json" "$TMP/x.json"
+jq '.path = ".github/workflows/ci.yml"' "$TMP/oci-run.json" >"$TMP/oci-run-wrong.json"
+expect_failure 'OCI document from another workflow' "$TOOL" oci-validation "$EVIDENCE" "$TMP/oci-run-wrong.json" "$TMP/oci-jobs.json" "$TMP/x.json"
+expect_failure 'OCI document for an evidence-only candidate' "$TOOL" oci-validation "$TMP/evidence-only.json" "$TMP/oci-run.json" "$TMP/oci-jobs.json" "$TMP/x.json"
+
+# --- Soak document and verdict ------------------------------------------------
+run_doc .github/workflows/merge-recovery-soak.yml 888 1 "$SOURCE_SHA" workflow_dispatch master >"$TMP/soak-run.json"
+jq -n '{soak_kind: "weekend", requested_duration_seconds: 216000, completed: true, artifact_mode: "candidate",
+	retry_attempt: 0, coverage_preserved: true, preflight: {status: "success"}}' >"$TMP/soak-result.json"
+"$TOOL" stability-soak "$EVIDENCE" "$TMP/soak-run.json" "$TMP/soak-result.json" "$GATES/soak-evidence.json"
+jq -e '.gate == "stability_soak" and .soak_kind == "weekend" and .preflight.status == "success"' "$GATES/soak-evidence.json" >/dev/null
+jq '.requested_duration_seconds = 86400' "$TMP/soak-result.json" >"$TMP/soak-short.json"
+expect_failure 'soak document with a short duration' "$TOOL" stability-soak "$EVIDENCE" "$TMP/soak-run.json" "$TMP/soak-short.json" "$TMP/x.json"
+jq '.artifact_mode = "source"' "$TMP/soak-result.json" >"$TMP/soak-source.json"
+expect_failure 'soak document in source mode' "$TOOL" stability-soak "$EVIDENCE" "$TMP/soak-run.json" "$TMP/soak-source.json" "$TMP/x.json"
+"$TOOL" verdict "$EVIDENCE" pass "$GATES/verdict.json"
+expect_failure 'unknown verdict' "$TOOL" verdict "$EVIDENCE" maybe "$TMP/x.json"
+
+# --- Candidate marker ---------------------------------------------------------
+"$TOOL" candidate-marker "$EVIDENCE" "$TMP/release-candidate.json"
+jq -e --arg sha "$SOURCE_SHA" '.candidate_tag == "v0.4.46-canary.789" and .source_sha == $sha' "$TMP/release-candidate.json" >/dev/null
+
+# --- The evaluator accepts everything the writer produced ----------------------
+"$GATES_TOOL" evaluate "$GATES" "$REPOSITORY" "$TMP/gate-report.json" 2>/dev/null
+jq -e '.promotable == true' "$TMP/gate-report.json" >/dev/null
+
+# A regress verdict from the writer holds promotion until review.
+"$TOOL" verdict "$EVIDENCE" regress "$GATES/verdict.json"
+status=0
+"$GATES_TOOL" evaluate "$GATES" "$REPOSITORY" "$TMP/regress-report.json" 2>/dev/null || status=$?
+[ "$status" -eq 10 ] || { printf 'regress verdict should hold, got exit %s\n' "$status" >&2; exit 1; }
+
+printf 'release gate evidence tests passed\n'

--- a/.github/scripts/test-release-gate-evidence.sh
+++ b/.github/scripts/test-release-gate-evidence.sh
@@ -109,8 +109,22 @@ expect_failure 'unknown verdict' "$TOOL" verdict "$EVIDENCE" maybe "$TMP/x.json"
 jq -e --arg sha "$SOURCE_SHA" '.candidate_tag == "v0.4.46-canary.789" and .source_sha == $sha' "$TMP/release-candidate.json" >/dev/null
 
 # --- The evaluator accepts everything the writer produced ----------------------
+# The workflow fetches the run each document names; here the run fixtures
+# are the same documents the writer consumed.
+cp "$TMP/oci-run.json" "$GATES/oci-validation-run.json"
+cp "$TMP/soak-run.json" "$GATES/soak-run.json"
+jq -e --arg esha "$(sha256sum "$EVIDENCE" | awk '{print $1}')" '.candidate_evidence_sha256 == $esha' "$GATES/oci-validation-evidence.json" >/dev/null
 "$GATES_TOOL" evaluate "$GATES" "$REPOSITORY" "$TMP/gate-report.json" 2>/dev/null
 jq -e '.promotable == true' "$TMP/gate-report.json" >/dev/null
+
+# A document built from different evidence is refused by the evaluator even
+# though every other field matches: the run must carry its verified file.
+TAMPERED="$TMP/tampered-evidence"
+cp -R "$GATES" "$TAMPERED"
+jq '.created_at = "2026-08-16T00:00:01Z"' "$EVIDENCE" >"$TAMPERED/release-evidence.json"
+status=0
+"$GATES_TOOL" evaluate "$TAMPERED" "$REPOSITORY" "$TMP/tampered-report.json" 2>/dev/null || status=$?
+[ "$status" -eq 20 ] || { printf 'evidence substitution should fail, got exit %s\n' "$status" >&2; exit 1; }
 
 # A regress verdict from the writer holds promotion until review.
 "$TOOL" verdict "$EVIDENCE" regress "$GATES/verdict.json"

--- a/.github/scripts/test-release-gates.sh
+++ b/.github/scripts/test-release-gates.sh
@@ -56,7 +56,7 @@ INDEX_DIGEST="sha256:$(printf 'index' | sha256sum | awk '{print $1}')"
 "$EVIDENCE_TOOL" record-images "$GATES/release-evidence.json" \
 	"docker.io/f1r3flyindustries/f1r3fly-rust@$INDEX_DIGEST" \
 	"sha256:$(printf 'amd64' | sha256sum | awk '{print $1}')" \
-	"sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')"
+	"sha256:$(printf 'arm64' | sha256sum | awk '{print $1}')" "$INDEX_DIGEST"
 CANDIDATE_TAG="$(jq -r '.candidate_tag' "$GATES/release-evidence.json")"
 
 # --- Gate documents -------------------------------------------------------

--- a/.github/scripts/test-release-gates.sh
+++ b/.github/scripts/test-release-gates.sh
@@ -68,11 +68,12 @@ jq -n '{jobs: (
 	+ [range(1; 12) | {name: ("Pre-fix regression backstops (" + tostring + ")")}]
 	+ [{name: "TLA+ invariant check", status: "completed", conclusion: "skipped"}]
 	| map(. + {status: "completed", conclusion: (.conclusion // "success")}))}' >"$GATES/slashing-jobs.json"
+EVIDENCE_SHA256="$(sha256sum "$GATES/release-evidence.json" | awk '{print $1}')"
 binding() {
-	jq -n --arg gate "$1" --arg sha "$SOURCE_SHA" --arg tag "$CANDIDATE_TAG" --arg digest "$INDEX_DIGEST" \
+	jq -n --arg gate "$1" --arg sha "$SOURCE_SHA" --arg tag "$CANDIDATE_TAG" --arg digest "$INDEX_DIGEST" --arg esha "$EVIDENCE_SHA256" \
 		--arg path "$2" --argjson id "$3" '{
 		schema_version: 1, gate: $gate, source_sha: $sha, candidate_tag: $tag, image_index_digest: $digest,
-		workflow_run: {id: $id, attempt: 1, path: $path, conclusion: "success"}}'
+		candidate_evidence_sha256: $esha, workflow_run: {id: $id, attempt: 1, path: $path, conclusion: "success"}}'
 }
 binding oci_validation .github/workflows/oci-validation.yml 777 | jq --arg pin "$PIN" '. + {
 	mode: "candidate", system_integration_sha: $pin,
@@ -156,6 +157,7 @@ fail_case 'required CI job id differs from evidence' ci-jobs.json '(.jobs[] | se
 fail_case 'slashing run for another commit' slashing-run.json ".head_sha = \"$OTHER_SHA\"" slashing
 fail_case 'slashing matrix job failed' slashing-jobs.json '(.jobs[] | select(.name == "Pre-fix regression backstops (7)") | .conclusion) = "failure"' slashing
 fail_case 'slashing matrix absent' slashing-jobs.json '.jobs |= map(select(.name | startswith("Pre-fix") | not))' slashing
+fail_case 'OCI document built from other evidence' oci-validation-evidence.json '.candidate_evidence_sha256 = "0000000000000000000000000000000000000000000000000000000000000000"' oci_validation
 fail_case 'OCI validation on another image' oci-validation-evidence.json '.image_index_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"' oci_validation
 fail_case 'OCI validation in pull-request mode' oci-validation-evidence.json '.mode = "pull-request"' oci_validation
 fail_case 'OCI validation with another system-integration pin' oci-validation-evidence.json ".system_integration_sha = \"$OTHER_SHA\"" oci_validation

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -6,7 +6,9 @@ ruby -ryaml - \
 	"$ROOT/.github/workflows/release.yml" \
 	"$ROOT/.github/workflows/release-evidence.yml" \
 	"$ROOT/.github/workflows/soak-in.yml" \
-	"$ROOT/.github/workflows/canary-publish.yml" <<'RUBY'
+	"$ROOT/.github/workflows/canary-publish.yml" \
+	"$ROOT/.github/workflows/oci-validation.yml" \
+	"$ROOT/.github/workflows/merge-recovery-soak.yml" <<'RUBY'
 def trigger(document)
   document["on"] || document[true]
 end
@@ -15,7 +17,7 @@ def fail_if(condition, message)
   abort(message) if condition
 end
 
-release_path, evidence_path, soakin_path, canary_path = ARGV
+release_path, evidence_path, soakin_path, canary_path, oci_path, soak_path = ARGV
 release = YAML.load_file(release_path)
 evidence = YAML.load_file(evidence_path)
 soakin = YAML.load_file(soakin_path)
@@ -131,5 +133,33 @@ forbidden = [
 end
 fail_if(File.read(canary_path).match?(/create-github-app-token|release-action@/), "canary publish must not mint tokens or use release actions")
 fail_if(release_text.match?(/create-github-app-token|release-action@/), "release promotion must not mint tokens or use release actions")
+# Gate workflows (Phase 3): candidate mode publishes section 8.1 documents
+# from one job that alone holds contents: write under release-credentials,
+# and the candidate image is pulled by digest, never rebuilt, in that mode.
+canary_text = File.read(canary_path)
+fail_if(!canary_text.include?("Publish canary images to OCIR"), "canary publish must dual-publish the index to OCIR")
+fail_if(!canary_text.match?(/record-images[^\n]*\\\n(?:[^\n]*\n){4}[^\n]*ocir-index-digest/m), "canary publish must record the OCIR index digest")
+{ "oci-validation" => oci_path, "merge-recovery-soak" => soak_path }.each do |label, path|
+  doc = YAML.load_file(path)
+  publish = doc.dig("jobs", "publish_candidate_evidence")
+  fail_if(!publish.is_a?(Hash), "#{label} must define the publish_candidate_evidence job")
+  fail_if(publish["environment"] != "release-credentials", "#{label} gate publication must use the release-credentials environment")
+  fail_if(publish.dig("permissions", "contents") != "write", "#{label} gate publication needs contents: write at the job level")
+  fail_if(publish["if"].to_s !~ /candidate_tag != ''/, "#{label} gate publication must run only in candidate mode")
+  doc.fetch("jobs").each do |name, job|
+    next if name == "publish_candidate_evidence"
+    fail_if(job.dig("permissions", "contents") == "write", "#{label} job #{name} must not hold contents: write")
+  end
+  text = File.read(path)
+  fail_if(!text.include?("release-gate-evidence.sh"), "#{label} must write gate documents with release-gate-evidence.sh")
+  fail_if(!text.include?("name: release-candidate"), "#{label} must upload the release-candidate marker artifact")
+end
+# The OCI image steps live in the reusable workflow; the soak's live inline.
+reusable_text = File.read("#{File.dirname(oci_path)}/reusable-oci-validation.yml")
+fail_if(!reusable_text.match?(/docker pull --platform [^\n]*@\$\{ARCH_DIGEST\}/), "OCI validation candidate mode must pull the image by digest")
+fail_if(!reusable_text.match?(/Build Docker Image\n\s+if: inputs\.candidate_tag == ''/m), "OCI validation must skip the source build in candidate mode")
+soak_text = File.read(soak_path)
+fail_if(!soak_text.match?(/docker pull --platform [^\n]*@\$\{amd64_digest\}/), "soak candidate mode must pull the image by digest")
+fail_if(!soak_text.match?(/Build node image\n\s+if: needs\.schedule_gate\.outputs\.candidate_tag == ''/m), "soak must skip the source build in candidate mode")
 puts "release workflow tests passed"
 RUBY

--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -14,9 +14,12 @@
 #   - Canary image publication reuses the protected-branch-image-publish
 #     environment. The release-credentials environment arrives with
 #     Phase 4 stable promotion.
-#   - OCIR canary references are NOT recorded or published here: the
-#     registry location is repository-secret material and evidence is
-#     public. The OCIR canary path is deferred to Phase 3.
+#   - The same index is published to Docker Hub and to OCIR. OCIR is the
+#     canonical registry for candidate gates; Docker Hub is the public
+#     mirror. Evidence records the OCIR index digest only, never the OCIR
+#     repository path, because that path is repository-secret material
+#     and evidence is public. record-images requires both digests to be
+#     equal, so a registry that holds a different candidate stops the run.
 #
 # Idempotency and identity (release invariants 2 and 4): the identity
 # gate runs BEFORE any registry or repository mutation. A fresh
@@ -363,18 +366,79 @@ jobs:
               exit 1
             }
           done
-          ci-control/.github/scripts/release-evidence.sh record-images \
-            "$RUNNER_TEMP/release-evidence/release-evidence.json" \
-            "docker.io/${DOCKER_IMAGE_NAME}@${index_digest}" \
-            "$amd64_digest" \
-            "$arm64_digest"
-          sha256sum "$RUNNER_TEMP/release-evidence/release-evidence.json" \
-            > "$RUNNER_TEMP/release-evidence/release-evidence.json.sha256"
+          printf '%s\n' "$index_digest" > "$RUNNER_TEMP/docker-hub-index-digest"
+          printf '%s\n' "$amd64_digest" > "$RUNNER_TEMP/amd64-digest"
+          printf '%s\n' "$arm64_digest" > "$RUNNER_TEMP/arm64-digest"
 
       - name: Log out of Docker Hub
         if: always()
         shell: bash -euo pipefail {0}
         run: docker logout || true
+
+      - name: Log in to OCIR
+        if: steps.eligibility.outputs.eligible == 'true' && steps.identity.outputs.publish == 'true'
+        env:
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCIR_AUTH_TOKEN: ${{ secrets.OCIR_AUTH_TOKEN }}
+        shell: bash -euo pipefail {0}
+        run: |
+          printf '%s' "$OCIR_AUTH_TOKEN" | docker login "$OCIR_REGISTRY" --username "$OCIR_USERNAME" --password-stdin
+
+      - name: Publish canary images to OCIR
+        if: steps.eligibility.outputs.eligible == 'true' && steps.identity.outputs.publish == 'true'
+        env:
+          CANDIDATE_TAG: ${{ steps.evidence.outputs.candidate_tag }}
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
+        shell: bash -euo pipefail {0}
+        run: |
+          # OCIR is the canonical registry for candidate gates (the soak and
+          # OCI validation run inside OCI). The same image blobs and the same
+          # manifest list are pushed here, so the index digest must equal the
+          # Docker Hub index digest; record-images enforces that equality.
+          # The OCIR repository path is secret material: only the digest is
+          # recorded in the public evidence, and this step prints no reference.
+          amd64_digest="$(cat "$RUNNER_TEMP/amd64-digest")"
+          arm64_digest="$(cat "$RUNNER_TEMP/arm64-digest")"
+          img="${OCIR_BASE}:${CANDIDATE_TAG}"
+          docker tag "${DOCKER_IMAGE_NAME}:amd64" "${img}-amd64"
+          docker tag "${DOCKER_IMAGE_NAME}:arm64" "${img}-arm64"
+          docker push "${img}-amd64" >/dev/null
+          docker push "${img}-arm64" >/dev/null
+          ocir_digest_of() {
+            docker inspect --format '{{join .RepoDigests "\n"}}' "$1" \
+              | sed -n "s|^${OCIR_BASE}@||p" | head -1
+          }
+          [ "$(ocir_digest_of "${img}-amd64")" = "$amd64_digest" ] || { echo "::error::OCIR amd64 manifest digest differs from Docker Hub"; exit 1; }
+          [ "$(ocir_digest_of "${img}-arm64")" = "$arm64_digest" ] || { echo "::error::OCIR arm64 manifest digest differs from Docker Hub"; exit 1; }
+          docker manifest create "$img" \
+            --amend "${OCIR_BASE}@${amd64_digest}" \
+            --amend "${OCIR_BASE}@${arm64_digest}"
+          ocir_index_digest="$(docker manifest push "$img" | tail -1)"
+          [[ "$ocir_index_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "::error::OCIR manifest push did not return an index digest"; exit 1; }
+          printf '%s\n' "$ocir_index_digest" > "$RUNNER_TEMP/ocir-index-digest"
+          echo "OCIR index digest: ${ocir_index_digest}"
+
+      - name: Log out of OCIR
+        if: always()
+        env:
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+        shell: bash -euo pipefail {0}
+        run: |
+          if [ -n "$OCIR_REGISTRY" ]; then docker logout "$OCIR_REGISTRY" || true; fi
+
+      - name: Record published images
+        if: steps.eligibility.outputs.eligible == 'true' && steps.identity.outputs.publish == 'true'
+        shell: bash -euo pipefail {0}
+        run: |
+          ci-control/.github/scripts/release-evidence.sh record-images \
+            "$RUNNER_TEMP/release-evidence/release-evidence.json" \
+            "docker.io/${DOCKER_IMAGE_NAME}@$(cat "$RUNNER_TEMP/docker-hub-index-digest")" \
+            "$(cat "$RUNNER_TEMP/amd64-digest")" \
+            "$(cat "$RUNNER_TEMP/arm64-digest")" \
+            "$(cat "$RUNNER_TEMP/ocir-index-digest")"
+          sha256sum "$RUNNER_TEMP/release-evidence/release-evidence.json" \
+            > "$RUNNER_TEMP/release-evidence/release-evidence.json.sha256"
 
       - name: Create immutable canary tag
         if: steps.eligibility.outputs.eligible == 'true' && steps.identity.outputs.publish == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,10 @@ jobs:
         shell: bash -euo pipefail {0}
         run: .github/scripts/test-promote-release.sh
 
+      - name: Verify release gate evidence
+        shell: bash -euo pipefail {0}
+        run: .github/scripts/test-release-gate-evidence.sh
+
       - name: Verify release workflows
         shell: bash -euo pipefail {0}
         run: .github/scripts/test-release-workflows.sh

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -70,6 +70,15 @@ on:
         required: false
         default: "0"
         type: string
+      restart_of_run_id:
+        description: >-
+          Candidate restart mode only: run id of the original candidate soak
+          this run continues. The schedule gate verifies that run's
+          soak-window artifact (same candidate_tag, retry_attempt 0, and
+          end_epoch equal to window_end_epoch) before it accepts the restart.
+        required: false
+        default: ""
+        type: string
       candidate_tag:
         description: >-
           Exact-candidate mode (release-process section 10): soak the
@@ -186,11 +195,13 @@ jobs:
       checkpoint_4: ${{ steps.resolve.outputs.checkpoint_4 }}
       checkpoint_5: ${{ steps.resolve.outputs.checkpoint_5 }}
       candidate_tag: ${{ steps.resolve.outputs.candidate_tag }}
+      restart_verified: ${{ steps.resolve.outputs.restart_verified }}
     steps:
       - name: Resolve schedule
         id: resolve
         env:
           INPUT_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+          INPUT_RESTART_OF_RUN_ID: ${{ inputs.restart_of_run_id }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SCHEDULE: ${{ github.event.schedule }}
           INPUT_SCHEDULED_SLOT: ${{ inputs.scheduled_slot_epoch }}
@@ -326,6 +337,44 @@ jobs:
               if [ -n "$INPUT_WINDOW_END" ] && [ "$INPUT_SERIES" != "weekend" ]; then
                 echo "::error::a candidate restart must belong to the weekend series"
                 exit 1
+              fi
+              restart_verified=false
+              if [ -n "$INPUT_WINDOW_END" ]; then
+                # A candidate restart is accepted only as the continuation of
+                # one specific original run. That run's soak-window artifact
+                # (written by its own schedule gate, so only that run could
+                # have produced it) must name this candidate, be the first
+                # attempt, and carry the exact window end this restart soaks
+                # to. Without that, a caller could dispatch a short "restart"
+                # and publish it as preserved 60-hour coverage.
+                if ! [[ "$INPUT_RESTART_OF_RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+                  echo "::error::a candidate restart requires restart_of_run_id"
+                  exit 1
+                fi
+                prior="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${INPUT_RESTART_OF_RUN_ID}")"
+                jq -e --arg repository "$GITHUB_REPOSITORY" '
+                  .path == ".github/workflows/merge-recovery-soak.yml"
+                  and .repository.full_name == $repository
+                  and .event == "workflow_dispatch"
+                  and .status == "completed"
+                  and .conclusion != "success"' <<<"$prior" >/dev/null || {
+                  echo "::error::restart_of_run_id ${INPUT_RESTART_OF_RUN_ID} is not a completed, unsuccessful dispatch of this workflow"
+                  exit 1
+                }
+                artifact_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${INPUT_RESTART_OF_RUN_ID}/artifacts?per_page=100" \
+                  --jq '[.artifacts[] | select(.name == "soak-window" and .expired == false)] | first | .id // empty')"
+                [ -n "$artifact_id" ] || { echo "::error::the original run carries no soak-window artifact"; exit 1; }
+                gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "$RUNNER_TEMP/soak-window.zip"
+                unzip -q -o "$RUNNER_TEMP/soak-window.zip" -d "$RUNNER_TEMP/soak-window"
+                jq -e --arg tag "$INPUT_CANDIDATE_TAG" --argjson end "$INPUT_WINDOW_END" '
+                  .candidate_tag == $tag
+                  and .retry_attempt == 0
+                  and .soak_kind == "weekend"
+                  and .end_epoch == $end' "$RUNNER_TEMP/soak-window/soak-window.json" >/dev/null || {
+                  echo "::error::the original run's soak window does not match this restart (candidate, attempt, kind, or end epoch)"
+                  exit 1
+                }
+                restart_verified=true
               fi
               target_ref="$INPUT_CANDIDATE_TAG"
             fi
@@ -665,7 +714,24 @@ jobs:
             echo "checkpoint_4=$cp4"
             echo "checkpoint_5=$cp5"
             echo "candidate_tag=${INPUT_CANDIDATE_TAG:-}"
+            echo "restart_verified=${restart_verified:-false}"
           } >> "$GITHUB_OUTPUT"
+          if [ -n "${INPUT_CANDIDATE_TAG:-}" ]; then
+            mkdir -p "$RUNNER_TEMP/soak-window"
+            jq -n --arg tag "$INPUT_CANDIDATE_TAG" --arg kind "$kind" --argjson retry "$retry_attempt" \
+              --argjson end "${end_epoch:-0}" --argjson duration "$duration_seconds" '{
+              candidate_tag: $tag, soak_kind: $kind, retry_attempt: $retry,
+              end_epoch: $end, duration_seconds: $duration}' > "$RUNNER_TEMP/soak-window/soak-window.json"
+          fi
+
+      - name: Record the candidate soak window
+        if: inputs.candidate_tag != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: soak-window
+          path: ${{ runner.temp }}/soak-window/soak-window.json
+          retention-days: 30
+          if-no-files-found: error
 
   # Advisory docs link sweep for the 60h stability soak. Checks the
   # external URLs that the blocking CI Link Checker no longer covers
@@ -1208,6 +1274,7 @@ jobs:
             -f series="$KIND" \
             -f skip_integration_preflight="${SKIP_PREFLIGHT:-false}" \
             -f candidate_tag="${CANDIDATE_TAG:-}" \
+            -f restart_of_run_id="$GITHUB_RUN_ID" \
             -f retry_attempt=1
           echo "::notice::restarted $KIND soak for the remaining $((remaining / 3600))h of the window (ends $(date -u -d "@${END_EPOCH}" +%FT%TZ))"
 
@@ -1444,6 +1511,15 @@ jobs:
           [ "$pulled" = "$amd64_digest" ] || { echo "::error::pulled image digest does not match the candidate amd64 digest"; exit 1; }
           docker tag "${OCIR_BASE}@${amd64_digest}" "$DOCKER_IMAGE_NAME:latest"
           echo "Candidate ${CANDIDATE_TAG} amd64 image ${amd64_digest} loaded for the soak."
+
+      - name: Keep the verified candidate evidence for this run
+        if: needs.schedule_gate.outputs.candidate_tag != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: candidate-evidence
+          path: ${{ runner.temp }}/candidate/release-evidence.json
+          retention-days: 30
+          if-no-files-found: error
 
       - name: Extract subprocess binary
         shell: bash -euo pipefail {0}
@@ -1904,29 +1980,42 @@ jobs:
           name: merge-recovery-soak-${{ needs.schedule_gate.outputs.duration_seconds }}s-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/soak-results
 
+      - name: Download the evidence this run soaked
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: candidate-evidence
+          path: ${{ runner.temp }}/gate
+
       - name: Write and publish the stability-soak gate documents
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATE_TAG: ${{ needs.schedule_gate.outputs.candidate_tag }}
+          TARGET_SHA: ${{ needs.schedule_gate.outputs.target_sha }}
           RETRY_ATTEMPT: ${{ needs.schedule_gate.outputs.retry_attempt }}
-          END_EPOCH: ${{ needs.schedule_gate.outputs.end_epoch }}
+          RESTART_VERIFIED: ${{ needs.schedule_gate.outputs.restart_verified }}
         shell: bash -euo pipefail {0}
         run: |
+          # The evidence comes from this run's own artifact, written by the
+          # soak job before the soak started, so the document binds to the
+          # image that was actually soaked.
           work="$RUNNER_TEMP/gate"
-          mkdir -p "$work"
-          gh release download "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern release-evidence.json --pattern release-evidence.json.sha256 --dir "$work"
-          (cd "$work" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          ci-control/.github/scripts/release-evidence.sh validate "$work/release-evidence.json"
+          [ "$(jq -r '.source_sha' "$work/release-evidence.json")" = "$TARGET_SHA" ] || {
+            echo "::error::carried evidence names a different source than the soaked target"
+            exit 1
+          }
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" > "$work/run.json"
           verdict_file="$RUNNER_TEMP/soak-results/report/verdict.json"
           [ -f "$verdict_file" ] || { echo "::error::soak results carry no report/verdict.json"; exit 1; }
           verdict="$(jq -r '.verdict' "$verdict_file")"
           # One restart is permitted when it soaks the remainder of the
-          # original window (section 10 condition 8). retry_within_window
-          # always dispatches with window_end_epoch, so a retry_attempt of 1
-          # with an end epoch preserved the full 60-hour coverage.
+          # original window (section 10 condition 8). Coverage counts as
+          # preserved only when the schedule gate verified this run as the
+          # continuation of a specific original candidate run through that
+          # run's soak-window artifact. An unverified restart is published
+          # truthfully as coverage_preserved false, which fails the gate.
           coverage=true
-          if [ "${RETRY_ATTEMPT:-0}" != "0" ] && [ -z "$END_EPOCH" ]; then coverage=false; fi
+          if [ "${RETRY_ATTEMPT:-0}" != "0" ] && [ "${RESTART_VERIFIED:-false}" != "true" ]; then coverage=false; fi
           jq -n --argjson retry "${RETRY_ATTEMPT:-0}" --argjson coverage "$coverage" '{
             soak_kind: "weekend",
             requested_duration_seconds: 216000,

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -70,6 +70,16 @@ on:
         required: false
         default: "0"
         type: string
+      candidate_tag:
+        description: >-
+          Exact-candidate mode (release-process section 10): soak the
+          published candidate image by digest from OCIR and publish the
+          stability-soak gate document on the candidate prerelease. Requires
+          duration weekend-60h and the integration preflight. The target is
+          the candidate source SHA; target_ref is ignored.
+        required: false
+        default: ""
+        type: string
       canary:
         description: Run a 30-minute non-publishing OCI protection canary
         required: false
@@ -175,10 +185,12 @@ jobs:
       checkpoint_3: ${{ steps.resolve.outputs.checkpoint_3 }}
       checkpoint_4: ${{ steps.resolve.outputs.checkpoint_4 }}
       checkpoint_5: ${{ steps.resolve.outputs.checkpoint_5 }}
+      candidate_tag: ${{ steps.resolve.outputs.candidate_tag }}
     steps:
       - name: Resolve schedule
         id: resolve
         env:
+          INPUT_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_SCHEDULE: ${{ github.event.schedule }}
           INPUT_SCHEDULED_SLOT: ${{ inputs.scheduled_slot_epoch }}
@@ -294,6 +306,29 @@ jobs:
               duration_seconds=79200
             fi
             target_ref="$INPUT_TARGET_REF"
+            if [ -n "${INPUT_CANDIDATE_TAG:-}" ]; then
+              # Exact-candidate mode: the soak target is the candidate tag,
+              # which the canary publisher created on the source SHA. The
+              # soak job verifies the tag against the candidate evidence
+              # before it pulls the image by digest.
+              if ! [[ "$INPUT_CANDIDATE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-canary\.[1-9][0-9]*$ ]]; then
+                echo "::error::candidate_tag must be a standard canary tag"
+                exit 1
+              fi
+              if [ "${INPUT_CANARY:-false}" = "true" ] || [ "${INPUT_PREFLIGHT_ONLY:-false}" = "true" ] || [ "${INPUT_SKIP_PREFLIGHT:-false}" = "true" ] || [ "${INPUT_INJECT_PROTECTION_BREACH:-false}" = "true" ]; then
+                echo "::error::candidate_tag cannot be combined with canary, preflight_only, skip_integration_preflight, or injection inputs"
+                exit 1
+              fi
+              if [ -z "$INPUT_WINDOW_END" ] && [ "$INPUT_DURATION" != "weekend-60h" ]; then
+                echo "::error::candidate_tag requires duration weekend-60h (the 60h stability soak is the release gate)"
+                exit 1
+              fi
+              if [ -n "$INPUT_WINDOW_END" ] && [ "$INPUT_SERIES" != "weekend" ]; then
+                echo "::error::a candidate restart must belong to the weekend series"
+                exit 1
+              fi
+              target_ref="$INPUT_CANDIDATE_TAG"
+            fi
             should_run=true
             trigger_source=manual
             slot_delay_seconds=0
@@ -629,6 +664,7 @@ jobs:
             echo "checkpoint_3=$cp3"
             echo "checkpoint_4=$cp4"
             echo "checkpoint_5=$cp5"
+            echo "candidate_tag=${INPUT_CANDIDATE_TAG:-}"
           } >> "$GITHUB_OUTPUT"
 
   # Advisory docs link sweep for the 60h stability soak. Checks the
@@ -1145,6 +1181,7 @@ jobs:
           KIND: ${{ needs.schedule_gate.outputs.kind }}
           TARGET_REF: ${{ needs.schedule_gate.outputs.target_ref }}
           SKIP_PREFLIGHT: ${{ needs.schedule_gate.outputs.skip_integration_preflight }}
+          CANDIDATE_TAG: ${{ needs.schedule_gate.outputs.candidate_tag }}
           WORKFLOW_REF: ${{ github.ref_name }}
         shell: bash -euo pipefail {0}
         run: |
@@ -1170,6 +1207,7 @@ jobs:
             -f window_end_epoch="$END_EPOCH" \
             -f series="$KIND" \
             -f skip_integration_preflight="${SKIP_PREFLIGHT:-false}" \
+            -f candidate_tag="${CANDIDATE_TAG:-}" \
             -f retry_attempt=1
           echo "::notice::restarted $KIND soak for the remaining $((remaining / 3600))h of the window (ends $(date -u -d "@${END_EPOCH}" +%FT%TZ))"
 
@@ -1357,6 +1395,7 @@ jobs:
           persist-credentials: false
 
       - name: Build node image
+        if: needs.schedule_gate.outputs.candidate_tag == ''
         working-directory: node-under-test
         shell: bash -euo pipefail {0}
         run: |
@@ -1368,6 +1407,43 @@ jobs:
             --tag "$DOCKER_IMAGE_NAME:latest" \
             --load \
             .
+
+      - name: Resolve candidate image by digest
+        if: needs.schedule_gate.outputs.candidate_tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_TAG: ${{ needs.schedule_gate.outputs.candidate_tag }}
+          TARGET_SHA: ${{ needs.schedule_gate.outputs.target_sha }}
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCIR_AUTH_TOKEN: ${{ secrets.OCIR_AUTH_TOKEN }}
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
+        shell: bash -euo pipefail {0}
+        run: |
+          # Candidate artifact mode (docs/release-process.md section 10): the
+          # soak runs the published candidate image, pulled by its linux/amd64
+          # manifest digest from OCIR, the canonical gate registry. Nothing is
+          # rebuilt; the subprocess binary is extracted from this image by the
+          # next step. The OCIR reference is secret material and is not printed.
+          work="$RUNNER_TEMP/candidate"
+          mkdir -p "$work"
+          gh release download "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern release-evidence.json --pattern release-evidence.json.sha256 --dir "$work"
+          (cd "$work" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          evidence="$work/release-evidence.json"
+          ci-control/.github/scripts/release-evidence.sh validate "$evidence"
+          [ "$(jq -r '.publication_mode' "$evidence")" = canary ] || { echo "::error::candidate has no published images"; exit 1; }
+          [ "$(jq -r '.candidate_tag' "$evidence")" = "$CANDIDATE_TAG" ] || { echo "::error::evidence candidate tag differs from the requested tag"; exit 1; }
+          [ "$(jq -r '.source_sha' "$evidence")" = "$TARGET_SHA" ] || { echo "::error::candidate source $(jq -r '.source_sha' "$evidence") differs from the resolved target ${TARGET_SHA}"; exit 1; }
+          amd64_digest="$(jq -r '.images.linux_amd64_digest' "$evidence")"
+          docker context use default
+          printf '%s' "$OCIR_AUTH_TOKEN" | docker login "$OCIR_REGISTRY" --username "$OCIR_USERNAME" --password-stdin
+          docker pull --platform linux/amd64 "${OCIR_BASE}@${amd64_digest}" >/dev/null
+          docker logout "$OCIR_REGISTRY" || true
+          pulled="$(docker inspect --format '{{join .RepoDigests "\n"}}' "${OCIR_BASE}@${amd64_digest}" | sed -n "s|^${OCIR_BASE}@||p" | head -1)"
+          [ "$pulled" = "$amd64_digest" ] || { echo "::error::pulled image digest does not match the candidate amd64 digest"; exit 1; }
+          docker tag "${OCIR_BASE}@${amd64_digest}" "$DOCKER_IMAGE_NAME:latest"
+          echo "Candidate ${CANDIDATE_TAG} amd64 image ${amd64_digest} loaded for the soak."
 
       - name: Extract subprocess binary
         shell: bash -euo pipefail {0}
@@ -1791,6 +1867,96 @@ jobs:
         # real result, even a red one, and a restart would only spend a
         # second VM reproducing it.
         run: echo "completed=true" >> "$GITHUB_OUTPUT"
+
+  # Exact-candidate mode only: publish the section 8.1 stability-soak
+  # document and the regression verdict on the candidate prerelease, and
+  # upload the release-candidate marker that lets release.yml resume. Runs
+  # whenever the soak ran its course, including a red verdict: a regress
+  # verdict is evidence too, and the promotion controller holds on it until
+  # maintainer review. The ONS verdict email above already alerts the
+  # soak-report list for every weekend verdict, pass or regress.
+  publish_candidate_evidence:
+    name: Publish Candidate Gate Evidence
+    needs: [schedule_gate, soak]
+    if: >-
+      always() &&
+      needs.schedule_gate.outputs.candidate_tag != '' &&
+      needs.schedule_gate.outputs.kind == 'weekend' &&
+      needs.soak.outputs.completed == 'true' &&
+      needs.soak.outputs.preflight == 'passed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    environment: release-credentials
+    steps:
+      - name: Checkout trusted release controls
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: ci-control
+          persist-credentials: false
+
+      - name: Download soak results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: merge-recovery-soak-${{ needs.schedule_gate.outputs.duration_seconds }}s-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/soak-results
+
+      - name: Write and publish the stability-soak gate documents
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE_TAG: ${{ needs.schedule_gate.outputs.candidate_tag }}
+          RETRY_ATTEMPT: ${{ needs.schedule_gate.outputs.retry_attempt }}
+          END_EPOCH: ${{ needs.schedule_gate.outputs.end_epoch }}
+        shell: bash -euo pipefail {0}
+        run: |
+          work="$RUNNER_TEMP/gate"
+          mkdir -p "$work"
+          gh release download "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern release-evidence.json --pattern release-evidence.json.sha256 --dir "$work"
+          (cd "$work" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" > "$work/run.json"
+          verdict_file="$RUNNER_TEMP/soak-results/report/verdict.json"
+          [ -f "$verdict_file" ] || { echo "::error::soak results carry no report/verdict.json"; exit 1; }
+          verdict="$(jq -r '.verdict' "$verdict_file")"
+          # One restart is permitted when it soaks the remainder of the
+          # original window (section 10 condition 8). retry_within_window
+          # always dispatches with window_end_epoch, so a retry_attempt of 1
+          # with an end epoch preserved the full 60-hour coverage.
+          coverage=true
+          if [ "${RETRY_ATTEMPT:-0}" != "0" ] && [ -z "$END_EPOCH" ]; then coverage=false; fi
+          jq -n --argjson retry "${RETRY_ATTEMPT:-0}" --argjson coverage "$coverage" '{
+            soak_kind: "weekend",
+            requested_duration_seconds: 216000,
+            completed: true,
+            artifact_mode: "candidate",
+            retry_attempt: $retry,
+            coverage_preserved: $coverage,
+            preflight: {status: "success"}
+          }' > "$work/soak-result.json"
+          ci-control/.github/scripts/release-gate-evidence.sh stability-soak \
+            "$work/release-evidence.json" "$work/run.json" "$work/soak-result.json" "$work/soak-evidence.json"
+          ci-control/.github/scripts/release-gate-evidence.sh verdict \
+            "$work/release-evidence.json" "$verdict" "$work/verdict.json"
+          ci-control/.github/scripts/release-gate-evidence.sh candidate-marker \
+            "$work/release-evidence.json" "$work/release-candidate.json"
+          # --clobber: a rerun of the same candidate replaces its own documents.
+          gh release upload "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" --clobber \
+            "$work/soak-evidence.json" "$work/verdict.json"
+          echo "Published soak-evidence.json and verdict.json (${verdict}) on ${CANDIDATE_TAG}."
+          if [ "$verdict" = regress ]; then
+            echo "::warning::regress verdict for ${CANDIDATE_TAG}; promotion holds until a maintainer uploads maintainer-review.json (docs/release-process.md section 8)"
+          fi
+
+      - name: Upload candidate marker
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/gate/release-candidate.json
+          retention-days: 30
+          if-no-files-found: error
 
   preflight_finalize:
     name: Finalize Integration Preflight Status

--- a/.github/workflows/oci-validation.yml
+++ b/.github/workflows/oci-validation.yml
@@ -4,17 +4,28 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Pull request number to validate
-        required: true
+        description: Pull request number to validate (pull-request mode)
+        required: false
+        default: ""
       head_sha:
-        description: Expected pull request head SHA reviewed by the maintainer
-        required: true
+        description: Expected pull request head SHA reviewed by the maintainer (pull-request mode)
+        required: false
+        default: ""
       approval_comment_id:
-        description: Pull request comment ID containing /full-oci-validate <pr_number> <head_sha>
-        required: true
+        description: Pull request comment ID containing /full-oci-validate <pr_number> <head_sha> (pull-request mode)
+        required: false
+        default: ""
+      candidate_tag:
+        description: Candidate tag (vMAJOR.MINOR.PATCH-canary.RUN) for exact-candidate mode; leave empty for pull-request mode
+        required: false
+        default: ""
 
+# Pull-request mode builds an unpublished image from the reviewed PR head.
+# Exact-candidate mode (docs/release-process.md section 9) validates the
+# published candidate image by digest from OCIR and publishes the section
+# 8.1 gate document on the candidate prerelease.
 concurrency:
-  group: full-oci-validation-${{ github.event.inputs.pr_number }}
+  group: full-oci-validation-${{ github.event.inputs.candidate_tag || github.event.inputs.pr_number }}
   cancel-in-progress: false
 
 permissions:
@@ -38,7 +49,7 @@ env:
 
 jobs:
   validate_pr:
-    name: Validate PR Input
+    name: Validate Input
     if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -46,11 +57,14 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      head_repo: ${{ steps.pr.outputs.head_repo }}
-      head_sha: ${{ steps.pr.outputs.head_sha }}
-      head_ref: ${{ steps.pr.outputs.head_ref }}
-      base_ref: ${{ steps.pr.outputs.base_ref }}
-      system_integration_ref: ${{ steps.pr.outputs.system_integration_ref }}
+      head_repo: ${{ steps.pr.outputs.head_repo || steps.candidate.outputs.head_repo }}
+      head_sha: ${{ steps.pr.outputs.head_sha || steps.candidate.outputs.head_sha }}
+      head_ref: ${{ steps.pr.outputs.head_ref || steps.candidate.outputs.head_ref }}
+      base_ref: ${{ steps.pr.outputs.base_ref || steps.candidate.outputs.base_ref }}
+      system_integration_ref: ${{ steps.pr.outputs.system_integration_ref || steps.candidate.outputs.system_integration_ref }}
+      candidate_tag: ${{ steps.candidate.outputs.candidate_tag }}
+      candidate_amd64_digest: ${{ steps.candidate.outputs.candidate_amd64_digest }}
+      candidate_arm64_digest: ${{ steps.candidate.outputs.candidate_arm64_digest }}
     steps:
       - name: Checkout workflow configuration
         uses: actions/checkout@v5
@@ -58,8 +72,55 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
+      - name: Validate candidate
+        id: candidate
+        if: github.event.inputs.candidate_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          CANDIDATE_TAG: ${{ github.event.inputs.candidate_tag }}
+          ACTOR: ${{ github.actor }}
+        shell: bash -euo pipefail {0}
+        run: |
+          if ! [[ "$CANDIDATE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-canary\.[1-9][0-9]*$ ]]; then
+            echo "candidate_tag must be a standard canary tag."
+            exit 1
+          fi
+          actor_permission=$(gh api "repos/${GH_REPO}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null || true)
+          if [ "$actor_permission" != "admin" ] && [ "$actor_permission" != "maintain" ]; then
+            echo "${ACTOR} has ${actor_permission:-no} permission; exact-candidate validation requires maintain or admin permission."
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/candidate"
+          gh release download "$CANDIDATE_TAG" --repo "$GH_REPO" \
+            --pattern release-evidence.json --pattern release-evidence.json.sha256 \
+            --dir "$RUNNER_TEMP/candidate"
+          (cd "$RUNNER_TEMP/candidate" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          evidence="$RUNNER_TEMP/candidate/release-evidence.json"
+          .github/scripts/release-evidence.sh validate "$evidence"
+          [ "$(jq -r '.publication_mode' "$evidence")" = canary ] || { echo "candidate has no published images"; exit 1; }
+          [ "$(jq -r '.candidate_tag' "$evidence")" = "$CANDIDATE_TAG" ] || { echo "evidence candidate tag differs from the requested tag"; exit 1; }
+          source_sha="$(jq -r '.source_sha' "$evidence")"
+          ref_json="$(gh api "repos/${GH_REPO}/git/ref/tags/${CANDIDATE_TAG}")"
+          tag_sha="$(jq -r '.object.sha' <<<"$ref_json")"
+          if [ "$(jq -r '.object.type' <<<"$ref_json")" = tag ]; then
+            tag_sha="$(gh api "repos/${GH_REPO}/git/tags/${tag_sha}" --jq '.object.sha')"
+          fi
+          [ "$tag_sha" = "$source_sha" ] || { echo "tag ${CANDIDATE_TAG} resolves to ${tag_sha}, not the evidence source ${source_sha}"; exit 1; }
+          {
+            echo "head_repo=${GH_REPO}"
+            echo "head_sha=${source_sha}"
+            echo "head_ref=refs/tags/${CANDIDATE_TAG}"
+            echo "base_ref=master"
+            echo "system_integration_ref=$(jq -r '.system_integration_sha' "$evidence")"
+            echo "candidate_tag=${CANDIDATE_TAG}"
+            echo "candidate_amd64_digest=$(jq -r '.images.linux_amd64_digest' "$evidence")"
+            echo "candidate_arm64_digest=$(jq -r '.images.linux_arm64_digest' "$evidence")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Validate pull request
         id: pr
+        if: github.event.inputs.candidate_tag == ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -265,6 +326,67 @@ jobs:
       head_repo: ${{ needs.validate_pr.outputs.head_repo }}
       head_sha: ${{ needs.validate_pr.outputs.head_sha }}
       system_integration_ref: ${{ needs.validate_pr.outputs.system_integration_ref }}
+      candidate_tag: ${{ needs.validate_pr.outputs.candidate_tag }}
+      candidate_amd64_digest: ${{ needs.validate_pr.outputs.candidate_amd64_digest }}
+      candidate_arm64_digest: ${{ needs.validate_pr.outputs.candidate_arm64_digest }}
+    secrets:
+      OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+      OCIR_NAMESPACE: ${{ secrets.OCIR_NAMESPACE }}
+      OCIR_REPO: ${{ secrets.OCIR_REPO }}
+      OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+      OCIR_AUTH_TOKEN: ${{ secrets.OCIR_AUTH_TOKEN }}
+
+  publish_candidate_evidence:
+    name: Publish Candidate Gate Evidence
+    needs: [validate_pr, oci_validation]
+    if: needs.validate_pr.outputs.candidate_tag != '' && needs.oci_validation.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    environment: release-credentials
+    steps:
+      - name: Checkout trusted release controls
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: ci-control
+          persist-credentials: false
+
+      - name: Write and publish the OCI validation gate document
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CANDIDATE_TAG: ${{ needs.validate_pr.outputs.candidate_tag }}
+        shell: bash -euo pipefail {0}
+        run: |
+          work="$RUNNER_TEMP/gate"
+          mkdir -p "$work"
+          gh release download "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern release-evidence.json --pattern release-evidence.json.sha256 --dir "$work"
+          (cd "$work" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" > "$work/run.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" \
+            --paginate --jq '.jobs[]' | jq -s '{jobs: .}' > "$work/jobs.json"
+          ci-control/.github/scripts/release-gate-evidence.sh oci-validation \
+            "$work/release-evidence.json" "$work/run.json" "$work/jobs.json" \
+            "$work/oci-validation-evidence.json"
+          ci-control/.github/scripts/release-gate-evidence.sh candidate-marker \
+            "$work/release-evidence.json" "$work/release-candidate.json"
+          # --clobber: a rerun of the same candidate replaces its own gate
+          # document. The document binds to the exact source and image, so a
+          # newer successful run supersedes an older one for the same candidate.
+          gh release upload "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" --clobber \
+            "$work/oci-validation-evidence.json"
+          echo "Published oci-validation-evidence.json on ${CANDIDATE_TAG}."
+
+      - name: Upload candidate marker
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-candidate
+          path: ${{ runner.temp }}/gate/release-candidate.json
+          retention-days: 30
+          if-no-files-found: error
 
   report_result:
     name: Report OCI Validation Result
@@ -297,7 +419,9 @@ jobs:
             description="Full OCI validation failed"
           fi
 
-          gh pr comment "$PR_NUMBER" --body "${description} for ${HEAD_SHA}. Run: ${RUN_URL}"
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body "${description} for ${HEAD_SHA}. Run: ${RUN_URL}"
+          fi
 
           if [ -n "$HEAD_SHA" ]; then
             gh api -X POST "repos/${GH_REPO}/statuses/${HEAD_SHA}" \

--- a/.github/workflows/oci-validation.yml
+++ b/.github/workflows/oci-validation.yml
@@ -118,6 +118,15 @@ jobs:
             echo "candidate_arm64_digest=$(jq -r '.images.linux_arm64_digest' "$evidence")"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Keep the verified candidate evidence for this run
+        if: github.event.inputs.candidate_tag != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: candidate-evidence
+          path: ${{ runner.temp }}/candidate/release-evidence.json
+          retention-days: 30
+          if-no-files-found: error
+
       - name: Validate pull request
         id: pr
         if: github.event.inputs.candidate_tag == ''
@@ -354,17 +363,28 @@ jobs:
           path: ci-control
           persist-credentials: false
 
+      - name: Download the evidence this run validated
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: candidate-evidence
+          path: ${{ runner.temp }}/gate
+
       - name: Write and publish the OCI validation gate document
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATE_TAG: ${{ needs.validate_pr.outputs.candidate_tag }}
+          EXPECTED_SOURCE_SHA: ${{ needs.validate_pr.outputs.head_sha }}
         shell: bash -euo pipefail {0}
         run: |
+          # The evidence comes from this run's own artifact, written by the
+          # validate job before any test ran. A release asset replaced after
+          # resolution cannot change what this document binds to.
           work="$RUNNER_TEMP/gate"
-          mkdir -p "$work"
-          gh release download "$CANDIDATE_TAG" --repo "$GITHUB_REPOSITORY" \
-            --pattern release-evidence.json --pattern release-evidence.json.sha256 --dir "$work"
-          (cd "$work" && awk '{print $1 "  release-evidence.json"}' release-evidence.json.sha256 | sha256sum -c -)
+          ci-control/.github/scripts/release-evidence.sh validate "$work/release-evidence.json"
+          [ "$(jq -r '.source_sha' "$work/release-evidence.json")" = "$EXPECTED_SOURCE_SHA" ] || {
+            echo "::error::carried evidence names a different source than the validated head"
+            exit 1
+          }
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" > "$work/run.json"
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" \
             --paginate --jq '.jobs[]' | jq -s '{jobs: .}' > "$work/jobs.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,11 +255,26 @@ jobs:
           name: gate-evaluation
           path: ${{ runner.temp }}/evaluation
 
+      - name: Log in to registries
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCIR_AUTH_TOKEN: ${{ secrets.OCIR_AUTH_TOKEN }}
+        shell: bash -euo pipefail {0}
+        run: |
+          # Both logins happen before any observation so that a missing
+          # credential fails before the plan, not between tag and image.
+          printf '%s' "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+          printf '%s' "$OCIR_AUTH_TOKEN" | docker login "$OCIR_REGISTRY" --username "$OCIR_USERNAME" --password-stdin
+
       - name: Observe stable state
         id: state
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CANDIDATE_TAG: ${{ needs.gates.outputs.candidate_tag }}
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
         shell: bash -euo pipefail {0}
         run: |
           evidence="$RUNNER_TEMP/evaluation/gates/release-evidence.json"
@@ -280,29 +295,42 @@ jobs:
             release_json="$(jq '{prerelease: .prerelease, assets: [.assets[].name]}' <<<"$rel")"
           fi
           registry_digest() {
+            # $1 = repository reference without tag, $2 = tag. Prints the
+            # index digest, or null when the tag is absent. The OCIR
+            # reference is secret material and must never reach the log.
             local out
-            if out="$(docker buildx imagetools inspect "docker.io/${DOCKER_IMAGE_NAME}:$1" --format '{{json .Manifest.Digest}}' 2>&1)"; then
+            if out="$(docker buildx imagetools inspect "$1:$2" --format '{{json .Manifest.Digest}}' 2>&1)"; then
               jq -r . <<<"$out"
               return 0
             fi
             grep -qiE 'not found|manifest unknown|no such manifest|404' <<<"$out" && { echo null; return 0; }
-            echo "::error::registry inspection for ${DOCKER_IMAGE_NAME}:$1 failed: $out" >&2
+            echo "::error::registry inspection for tag $2 failed" >&2
             return 1
           }
-          stable_digest="$(registry_digest "$stable_tag")"
-          latest_digest="$(registry_digest latest)"
+          stable_digest="$(registry_digest "docker.io/${DOCKER_IMAGE_NAME}" "$stable_tag")"
+          latest_digest="$(registry_digest "docker.io/${DOCKER_IMAGE_NAME}" latest)"
+          ocir_stable_digest="$(registry_digest "$OCIR_BASE" "$stable_tag")"
+          ocir_latest_digest="$(registry_digest "$OCIR_BASE" latest)"
           jq -n \
             --argjson stable_tags "$stable_tags" \
             --argjson stable_tag "$tag_json" \
             --argjson stable_release "$release_json" \
             --arg stable_digest "$stable_digest" \
-            --arg latest_digest "$latest_digest" '{
+            --arg latest_digest "$latest_digest" \
+            --arg ocir_stable_digest "$ocir_stable_digest" \
+            --arg ocir_latest_digest "$ocir_latest_digest" '
+            def digest_or_null: if . == "null" then null else . end;
+            {
               stable_tags: $stable_tags,
               stable_tag: $stable_tag,
               stable_release: $stable_release,
               registry: {
-                stable_tag_digest: (if $stable_digest == "null" then null else $stable_digest end),
-                latest_digest: (if $latest_digest == "null" then null else $latest_digest end)
+                stable_tag_digest: ($stable_digest | digest_or_null),
+                latest_digest: ($latest_digest | digest_or_null)
+              },
+              ocir: {
+                stable_tag_digest: ($ocir_stable_digest | digest_or_null),
+                latest_digest: ($ocir_latest_digest | digest_or_null)
               }
             }' > "$RUNNER_TEMP/stable-state.json"
           cat "$RUNNER_TEMP/stable-state.json"
@@ -316,7 +344,7 @@ jobs:
             "$RUNNER_TEMP/evaluation/gate-report.json" \
             "$RUNNER_TEMP/stable-state.json" \
             "$RUNNER_TEMP/promotion-plan.json"
-          for key in create_tag create_release copy_image move_latest; do
+          for key in create_tag create_release copy_image move_latest copy_image_ocir move_latest_ocir; do
             echo "$key=$(jq -r ".actions.$key" "$RUNNER_TEMP/promotion-plan.json")" >> "$GITHUB_OUTPUT"
           done
           echo "next_version=$(jq -r '.next_version' "$RUNNER_TEMP/promotion-plan.json")" >> "$GITHUB_OUTPUT"
@@ -348,15 +376,6 @@ jobs:
             -f ref="refs/tags/$(jq -r '.stable_tag' "$RUNNER_TEMP/promotion-plan.json")" \
             -f sha="$(jq -r '.source_sha' "$RUNNER_TEMP/promotion-plan.json")" >/dev/null
 
-      - name: Log in to Docker Hub
-        if: steps.plan.outputs.copy_image == 'true' || steps.plan.outputs.move_latest == 'true'
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash -euo pipefail {0}
-        run: |
-          printf '%s' "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-
       - name: Copy candidate image to the stable tag
         id: image
         shell: bash -euo pipefail {0}
@@ -376,6 +395,23 @@ jobs:
             exit 1
           }
           echo "stable_digest=$actual" >> "$GITHUB_OUTPUT"
+
+      - name: Copy candidate image to the OCIR stable tag
+        env:
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
+        shell: bash -euo pipefail {0}
+        run: |
+          plan="$RUNNER_TEMP/promotion-plan.json"
+          expected="$(jq -r '.image.ocir.index_digest' "$plan")"
+          stable_tag="$(jq -r '.image.ocir.stable_tag' "$plan")"
+          if [ "$(jq -r '.actions.copy_image_ocir' "$plan")" = true ]; then
+            docker buildx imagetools create --tag "${OCIR_BASE}:${stable_tag}" "${OCIR_BASE}@${expected}"
+          fi
+          actual="$(docker buildx imagetools inspect "${OCIR_BASE}:${stable_tag}" --format '{{json .Manifest.Digest}}' | jq -r .)"
+          [ "$actual" = "$expected" ] || {
+            echo "::error::OCIR stable tag ${stable_tag} resolves to ${actual}, not the candidate index ${expected}"
+            exit 1
+          }
 
       - name: Publish stable evidence and release
         if: steps.plan.outputs.create_release == 'true'
@@ -410,25 +446,42 @@ jobs:
             "$assets/stable-release-evidence.json" \
             "$assets/stable-release-evidence.json.sha256"
 
-      - name: Move the latest alias
-        if: steps.plan.outputs.move_latest == 'true'
+      - name: Move the latest aliases
+        if: steps.plan.outputs.move_latest == 'true' || steps.plan.outputs.move_latest_ocir == 'true'
+        env:
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
         shell: bash -euo pipefail {0}
         run: |
-          # Aliases move only after the stable tag, image, and release exist.
+          # Aliases move only after the stable tag, images, and release exist.
           plan="$RUNNER_TEMP/promotion-plan.json"
-          latest_ref="$(jq -r '.image.latest_reference' "$plan")"
           expected="$(jq -r '.image.index_digest' "$plan")"
-          docker buildx imagetools create --tag "$latest_ref" "$(jq -r '.image.candidate_index' "$plan")"
-          actual="$(docker buildx imagetools inspect "$latest_ref" --format '{{json .Manifest.Digest}}' | jq -r .)"
-          [ "$actual" = "$expected" ] || {
-            echo "::error::latest resolves to ${actual}, not the candidate index ${expected}"
-            exit 1
+          verify_alias() {
+            local actual
+            actual="$(docker buildx imagetools inspect "$1" --format '{{json .Manifest.Digest}}' | jq -r .)"
+            [ "$actual" = "$expected" ] || {
+              echo "::error::alias $2 resolves to ${actual}, not the candidate index ${expected}"
+              exit 1
+            }
           }
+          if [ "$(jq -r '.actions.move_latest' "$plan")" = true ]; then
+            latest_ref="$(jq -r '.image.latest_reference' "$plan")"
+            docker buildx imagetools create --tag "$latest_ref" "$(jq -r '.image.candidate_index' "$plan")"
+            verify_alias "$latest_ref" "docker-hub latest"
+          fi
+          if [ "$(jq -r '.actions.move_latest_ocir' "$plan")" = true ]; then
+            ocir_latest="${OCIR_BASE}:$(jq -r '.image.ocir.latest_tag' "$plan")"
+            docker buildx imagetools create --tag "$ocir_latest" "${OCIR_BASE}@${expected}"
+            verify_alias "$ocir_latest" "ocir latest"
+          fi
 
-      - name: Log out of Docker Hub
+      - name: Log out of registries
         if: always()
+        env:
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
         shell: bash -euo pipefail {0}
-        run: docker logout || true
+        run: |
+          docker logout || true
+          if [ -n "$OCIR_REGISTRY" ]; then docker logout "$OCIR_REGISTRY" || true; fi
 
       - name: Open the next-version pull request
         env:
@@ -483,7 +536,7 @@ jobs:
             printf -- '- Stable tag: `%s`\n' "$(jq -r '.stable_tag' "$plan")"
             printf -- '- Candidate: `%s`\n' "$(jq -r '.candidate_tag' "$plan")"
             printf -- '- Source SHA: `%s`\n' "$(jq -r '.source_sha' "$plan")"
-            printf -- '- Image: `%s`\n' "$(jq -r '.image.repository + "@" + .image.index_digest' "$plan")"
+            printf -- '- Image: `%s` (same index digest in OCIR)\n' "$(jq -r '.image.repository + "@" + .image.index_digest' "$plan")"
             printf -- '- Next version: `%s`\n' "$(jq -r '.next_version' "$plan")"
             echo
             echo "The release now enters the Shard soak-in phase (docs/release-process.md section 12)."

--- a/.github/workflows/reusable-oci-validation.yml
+++ b/.github/workflows/reusable-oci-validation.yml
@@ -15,6 +15,32 @@ on:
         description: Trusted system-integration ref used for integration tests
         required: true
         type: string
+      candidate_tag:
+        description: Candidate tag for exact-candidate mode; empty builds from source
+        required: false
+        type: string
+        default: ""
+      candidate_amd64_digest:
+        description: Candidate linux/amd64 image manifest digest (candidate mode)
+        required: false
+        type: string
+        default: ""
+      candidate_arm64_digest:
+        description: Candidate linux/arm64 image manifest digest (candidate mode)
+        required: false
+        type: string
+        default: ""
+    secrets:
+      OCIR_REGISTRY:
+        required: false
+      OCIR_NAMESPACE:
+        required: false
+      OCIR_REPO:
+        required: false
+      OCIR_USERNAME:
+        required: false
+      OCIR_AUTH_TOKEN:
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -74,6 +100,7 @@ jobs:
           fi
 
       - name: Build Docker Image
+        if: inputs.candidate_tag == ''
         shell: bash -ex {0}
         run: |
           docker context use default
@@ -85,6 +112,31 @@ jobs:
             --tag ${{ env.DOCKER_IMAGE_NAME }}:${{ matrix.arch }} \
             --load \
             .
+
+      - name: Pull candidate image by digest
+        if: inputs.candidate_tag != ''
+        env:
+          OCIR_REGISTRY: ${{ secrets.OCIR_REGISTRY }}
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCIR_AUTH_TOKEN: ${{ secrets.OCIR_AUTH_TOKEN }}
+          OCIR_BASE: ${{ secrets.OCIR_REGISTRY }}/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPO }}
+          ARCH_DIGEST: ${{ matrix.arch == 'amd64' && inputs.candidate_amd64_digest || inputs.candidate_arm64_digest }}
+        shell: bash -euo pipefail {0}
+        run: |
+          # Exact-candidate mode (docs/release-process.md section 9): the
+          # image under test is the published candidate, pulled by its
+          # architecture manifest digest from OCIR, the canonical gate
+          # registry. Nothing is rebuilt. The OCIR reference is secret
+          # material and is not printed.
+          [[ "$ARCH_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || { echo "::error::candidate ${{ matrix.arch }} digest is not a sha256 digest"; exit 1; }
+          docker context use default
+          printf '%s' "$OCIR_AUTH_TOKEN" | docker login "$OCIR_REGISTRY" --username "$OCIR_USERNAME" --password-stdin
+          docker pull --platform ${{ matrix.platform }} "${OCIR_BASE}@${ARCH_DIGEST}" >/dev/null
+          docker logout "$OCIR_REGISTRY" || true
+          pulled="$(docker inspect --format '{{join .RepoDigests "\n"}}' "${OCIR_BASE}@${ARCH_DIGEST}" | sed -n "s|^${OCIR_BASE}@||p" | head -1)"
+          [ "$pulled" = "$ARCH_DIGEST" ] || { echo "::error::pulled image digest does not match the candidate ${{ matrix.arch }} digest"; exit 1; }
+          docker tag "${OCIR_BASE}@${ARCH_DIGEST}" "${{ env.DOCKER_IMAGE_NAME }}:${{ matrix.arch }}"
+          echo "Candidate ${{ inputs.candidate_tag }} ${{ matrix.arch }} image ${ARCH_DIGEST} loaded."
 
       - name: Export Docker Image
         shell: bash -ex {0}

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -117,6 +117,7 @@ tasks:
       - "Both gate workflows publish Section 8.1 documents with release-gate-evidence.sh from a publish_candidate_evidence job under release-credentials, plus the release-candidate marker that resumes release.yml. test-release-gate-evidence.sh proves the writer against release-gates.sh."
       - "promote-release.sh and release.yml copy the stable tag and latest into OCIR as well as Docker Hub."
       - "The regress alert reuses the soak's existing ONS verdict email; promotion holds until maintainer-review.json is uploaded."
+      - "2026-08-22 multi-agent review of PR #325: gate documents carry candidate_evidence_sha256 and are written from the evidence file the run kept as a same-run artifact, never a re-downloaded release asset; release-gates.sh requires that digest to equal the evidence under evaluation. A candidate soak restart must name restart_of_run_id and match the original run's soak-window artifact (candidate, attempt 0, weekend, end epoch); coverage_preserved is true only for a verified restart."
     acceptance:
       - "merge-recovery-soak.yml and oci-validation.yml consume the candidate image digest without rebuilding"
       - "The canary publisher publishes the same index digest to OCIR and Docker Hub, and evidence records the OCIR digest"

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -108,9 +108,20 @@ tasks:
       - "canary-publish.yml publishes immutable canary tags, prereleases, and images from tested artifacts on release-eligible master runs"
   - id: TASK-013-4
     title: "Phase 3: artifact-based validation (candidate digest modes)"
-    status: pending
+    status: in_progress
+    branch: feature/release-phase3-candidate-digest-validation
+    notes:
+      - "2026-08-22: stacked on Phase 4 (feature/release-phase4-promotion-controller). Registry decision ratified by the maintainer: OCIR is canonical for candidate gates, Docker Hub stays as the dual-published public mirror, no sync service."
+      - "canary-publish.yml pushes the same index to OCIR; evidence records images.ocir_index_digest, which the validator requires to equal the Docker Hub index digest. The OCIR repository path never enters evidence."
+      - "oci-validation.yml gains candidate_tag (exact-candidate mode); reusable-oci-validation.yml pulls each architecture image from OCIR by digest instead of building. merge-recovery-soak.yml gains candidate_tag, pulls the amd64 image by digest, and carries the tag through an in-window restart."
+      - "Both gate workflows publish Section 8.1 documents with release-gate-evidence.sh from a publish_candidate_evidence job under release-credentials, plus the release-candidate marker that resumes release.yml. test-release-gate-evidence.sh proves the writer against release-gates.sh."
+      - "promote-release.sh and release.yml copy the stable tag and latest into OCIR as well as Docker Hub."
+      - "The regress alert reuses the soak's existing ONS verdict email; promotion holds until maintainer-review.json is uploaded."
     acceptance:
       - "merge-recovery-soak.yml and oci-validation.yml consume the candidate image digest without rebuilding"
+      - "The canary publisher publishes the same index digest to OCIR and Docker Hub, and evidence records the OCIR digest"
+      - "One exact-candidate OCI validation run and one candidate weekend soak publish Section 8.1 documents that release-gates.sh evaluates as pass"
+      - "Optional hardening: a read-only OCIR pull token replaces OCIR_AUTH_TOKEN in the soak and OCI validation pull steps (the OCIR_* secrets are repository-scoped and already readable there, verified 2026-08-22)"
   - id: TASK-013-5
     title: "Phase 4: stable promotion controller"
     status: in_progress

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -192,7 +192,7 @@ The evidence document includes these fields:
   },
   "images": {
     "docker_hub": "repository/image@sha256:index-digest",
-    "ocir": "registry/repository/image@sha256:index-digest",
+    "ocir_index_digest": "sha256:index-digest",
     "linux_amd64_digest": "sha256:architecture-digest",
     "linux_arm64_digest": "sha256:architecture-digest"
   },
@@ -204,7 +204,9 @@ Exact field names can change during implementation. The schema version must chan
 
 Phase 1 evidence uses `publication_mode: evidence_only`. Its image record uses `publication_state: not_published` and contains no registry references.
 
-Phase 2 canary evidence uses `publication_mode: canary`. It records the Docker Hub index reference and both architecture digests. The `ocir` field stays null: the OCIR registry location is repository-secret material and evidence is public. The OCIR canary path is deferred to Phase 3.
+Canary evidence uses `publication_mode: canary`. It records the Docker Hub index reference, both architecture digests, and the OCIR index digest. The canary publisher pushes the same image blobs and the same manifest list to both registries, so the two index digests are equal, and the evidence validator requires that equality. The OCIR repository path never appears in evidence: the path is repository-secret material and evidence is public.
+
+OCIR is the canonical registry for candidate gates. Full OCI validation and the 60h stability soak run inside OCI and pull the candidate from OCIR by digest. Docker Hub is the public mirror and receives the same index at canary time and the same stable tag at promotion.
 
 Evidence must not contain credentials, tokens, user data, or local absolute paths.
 
@@ -263,11 +265,13 @@ The full CI and heavy integration gates read the CI run recorded in the candidat
 
 ## 9. Full OCI validation
 
-Candidate OCI validation must consume the published canary image by digest.
+Candidate OCI validation consumes the published canary image by digest. The maintainer dispatches `oci-validation.yml` with `candidate_tag`. The workflow downloads the candidate evidence from the prerelease, verifies its checksum and the tag target, and pulls each architecture image from OCIR by its recorded manifest digest.
 
-The validation workflow extracts the subprocess binary from that image. It must not rebuild the candidate from source.
+The validation workflow extracts the subprocess binary from that image. It does not rebuild the candidate from source.
 
-The existing pull-request OCI mode can continue to build an unpublished image. Candidate mode must use the recorded image digest.
+The pull-request OCI mode continues to build an unpublished image. Candidate mode uses the recorded image digest.
+
+After a successful run, the `publish_candidate_evidence` job writes `oci-validation-evidence.json` (Section 8.1) with `release-gate-evidence.sh`, uploads it to the candidate prerelease, and uploads the `release-candidate` artifact that lets `release.yml` resume.
 
 OCI evidence records these values:
 
@@ -289,9 +293,11 @@ The release dispatch supplies these immutable values:
 - Candidate image index digest
 - Candidate evidence checksum
 
-The soak pulls the image by digest. The soak extracts the subprocess binary from the same image.
+The maintainer dispatches `merge-recovery-soak.yml` with `candidate_tag` and `duration: weekend-60h`. The soak job downloads the candidate evidence, verifies the tag target, pulls the linux/amd64 image from OCIR by its recorded digest, and extracts the subprocess binary from the same image. An in-window restart carries `candidate_tag` forward.
 
-Normal scheduled soak runs can continue to build a source target. A release-eligible run must use candidate artifact mode.
+Normal scheduled soak runs continue to build a source target. A release-eligible run uses candidate artifact mode.
+
+After the soak runs its course, the `publish_candidate_evidence` job writes `soak-evidence.json` and `verdict.json` (Section 8.1) from the run state and the report, uploads both to the candidate prerelease, and uploads the `release-candidate` artifact. A `regress` verdict is published as evidence; the existing ONS verdict email alerts the soak-report list, and promotion holds until a maintainer uploads `maintainer-review.json`.
 
 Stable promotion requires all these conditions:
 
@@ -532,11 +538,11 @@ This table defines the target state after the Section 17 workflow changes are co
 | `canary-publish.yml` | `workflow_run` (CI completed, master push, success), `workflow_dispatch` (ci_run_id) | Event + manual | 10–20 min *estimated* | Publishes the immutable canary when the source is release-eligible; skips cleanly otherwise |
 | `ci-fork-pr.yml` | `pull_request_target` (dev, master) | Event | Seconds, then the gated pipeline after maintainer approval | Fork lane into the gated pipeline |
 | `_integration-pipeline.yml` | `workflow_call` | Called by ci.yml and ci-fork-pr.yml | 35–50 min *measured* | Heavy pipeline: image build, ephemeral runners, integration matrix, smoke tests |
-| `merge-recovery-soak.yml` | `schedule` 02:30 and 03:30 UTC (self-suppressing fallback; the OCI Function scheduler is the primary dispatcher), `workflow_dispatch` | Time + manual | 22 h dev integration soak; 60 h stability soak; preflight-only runs cap at about 3 h | Runs both soaks; release-eligible runs use candidate artifact mode |
+| `merge-recovery-soak.yml` | `schedule` 02:30 and 03:30 UTC (self-suppressing fallback; the OCI Function scheduler is the primary dispatcher), `workflow_dispatch` (`candidate_tag` selects candidate artifact mode) | Time + manual | 22 h dev integration soak; 60 h stability soak; preflight-only runs cap at about 3 h | Runs both soaks; release-eligible runs use candidate artifact mode |
 | `soak-checkpoint-publish.yml` | `workflow_dispatch` from soak tooling | Tooling | About 1 min *measured* | Mid-run checkpoint publication |
 | `soak-dashboard-pages.yml` | `push` to master (dashboard paths), `workflow_dispatch` | Event + manual | 1–2 min *measured* | Dashboard shell redeploys |
 | `soak-preflight-status.yml`, `soak-signal.yml` | `workflow_dispatch` | Tooling + manual | About 1 min *measured* | Preflight status and operator signals |
-| `oci-validation.yml` | `workflow_dispatch` (pull-request mode and trusted exact-candidate mode) | Manual | 1–3 h *estimated*; the OCI daily VM quota can defer a run one day | Full OCI validation |
+| `oci-validation.yml` | `workflow_dispatch` (pull-request mode, or exact-candidate mode with `candidate_tag`) | Manual | 1–3 h *estimated*; the OCI daily VM quota can defer a run one day | Full OCI validation |
 | `reusable-oci-validation.yml` | `workflow_call` | Called by oci-validation.yml | Contained in the caller duration | OCI validation implementation; consumes the candidate digest |
 | `slashing-tests.yml` | `push`, `pull_request`, `schedule` 06:30 UTC daily, `workflow_dispatch` | Event + time + manual | 10–15 min *measured*; the nightly exhaustive tier exceeds 20 min | Slashing suite |
 | `release-evidence.yml` | `workflow_dispatch` (ci_run_id) | Manual | 10–20 min *estimated* (30-min cap) | Exact-run candidate evidence |
@@ -575,6 +581,8 @@ Phase 1 disables automatic stable publication. A manual workflow generates evide
 2. Run the 60h stability soak from the canary digest.
 3. Publish exact commit checks and evidence.
 4. Compare artifact-based results with current workflows.
+
+Phase 3 also makes OCIR the canonical gate registry. The canary publisher dual-publishes the index to OCIR and Docker Hub, and promotion copies the stable tag and the `latest` alias into both registries by digest.
 
 ### Phase 4: Stable promotion
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -248,9 +248,12 @@ Each document binds to the candidate with these fields:
   "source_sha": "0123456789abcdef0123456789abcdef01234567",
   "candidate_tag": "v0.4.46-canary.812",
   "image_index_digest": "sha256:index-digest",
+  "candidate_evidence_sha256": "sha256-of-the-evidence-file-the-run-resolved",
   "workflow_run": {"id": 123456789, "attempt": 1, "path": ".github/workflows/oci-validation.yml", "conclusion": "success"}
 }
 ```
+
+`candidate_evidence_sha256` binds the document to the exact evidence file the gate run resolved before it tested anything. The gate workflow keeps that file as a run artifact and writes the document from the artifact, never from a fresh download of the release asset. The controller requires the digest to equal the evidence it evaluates, so a release asset replaced after the run resolved it cannot be credited with that run's result.
 
 | Asset | Gate | Extra fields |
 |---|---|---|
@@ -293,7 +296,9 @@ The release dispatch supplies these immutable values:
 - Candidate image index digest
 - Candidate evidence checksum
 
-The maintainer dispatches `merge-recovery-soak.yml` with `candidate_tag` and `duration: weekend-60h`. The soak job downloads the candidate evidence, verifies the tag target, pulls the linux/amd64 image from OCIR by its recorded digest, and extracts the subprocess binary from the same image. An in-window restart carries `candidate_tag` forward.
+The maintainer dispatches `merge-recovery-soak.yml` with `candidate_tag` and `duration: weekend-60h`. The soak job downloads the candidate evidence, verifies the tag target, pulls the linux/amd64 image from OCIR by its recorded digest, and extracts the subprocess binary from the same image. The schedule gate records the soak window (candidate, kind, attempt, end epoch) as a run artifact.
+
+An in-window restart carries `candidate_tag` and `restart_of_run_id` forward. The schedule gate accepts a candidate restart only after it reads the original run's window artifact and confirms the same candidate, `retry_attempt` 0, the weekend kind, and an end epoch equal to `window_end_epoch`. The published document reports `coverage_preserved` true only for a verified restart; an unverified restart is published as false and fails the gate.
 
 Normal scheduled soak runs continue to build a source target. A release-eligible run uses candidate artifact mode.
 


### PR DESCRIPTION
## Summary

Phase 3 of EPIC-013 (TASK-013-4): artifact-based validation. Candidate gates consume the published candidate image by digest and publish Section 8.1 gate documents on the candidate prerelease. Stacked on the Phase 4 controller, which defines the contract these documents satisfy.

Registry decision (ratified by the maintainer): **OCIR is the canonical registry for candidate gates, Docker Hub stays as the dual-published public mirror.** No sync service.

- `release-evidence.sh`: `images.ocir` becomes `images.ocir_index_digest`; `record-images` requires it to equal the Docker Hub index digest. The OCIR repository path never enters public evidence.
- `canary-publish.yml`: pushes the same per-arch manifests and index to OCIR, verifies digest equality, records both.
- `release-gate-evidence.sh` (new): writes the Section 8.1 documents bound to the candidate evidence. `test-release-gate-evidence.sh` proves every document against `release-gates.sh`, including the regress hold path.
- `oci-validation.yml`: `candidate_tag` dispatch mode. `reusable-oci-validation.yml` pulls each architecture image from OCIR by manifest digest instead of building. A `publish_candidate_evidence` job under `release-credentials` uploads the gate document and the `release-candidate` marker.
- `merge-recovery-soak.yml`: `candidate_tag` input (weekend-60h only, no preflight skip), carried through in-window restarts. The soak pulls the amd64 image from OCIR by digest. `publish_candidate_evidence` writes `soak-evidence.json` and `verdict.json`, published even on `regress` so promotion holds for maintainer review. The existing ONS verdict email is the regress alert.
- `promote-release.sh` and `release.yml`: the stable tag and `latest` are copied into OCIR as well as Docker Hub.
- `test-release-workflows.sh` guards the gate workflows: one `contents: write` job under `release-credentials`, candidate-only condition, pull by digest, source build skipped in candidate mode.

## Stack and merge procedure

Linear stack, one review-fix commit per layer after the 2026-08-22 multi-agent reviews:

1. #322 Phase 2 (`0.4.46` bump) → `dev` — approved 4/4
2. #323 Phase 4 (promotion controller) → Phase 2 — 3 critical + 6 major resolved in `c62759ac4`
3. #325 Phase 3 (candidate digest modes, OCIR canonical) → Phase 4 — 2 major resolved in `f57ebe6d3`
4. #321 Phase 5 (stack train spec) → Phase 3 — 2 critical + 4 major resolved in `5edeb8c7a`

Merge bottom-up with **merge commits** (no squash, no rebase: the release process binds evidence to exact SHAs). After each merge, confirm GitHub retargeted the next PR to `dev`, or retarget it by hand, before merging it. Every PR shows only its own commits against its base.

## Notes

- `OCIR_*` secrets are repository-scoped (verified with `gh api`), so the soak runner and the reusable jobs can read them. A read-only OCIR pull token is an optional hardening.
- `release-credentials` is now referenced by `release.yml`, `oci-validation.yml`, and `merge-recovery-soak.yml`.

## Verification

All six release test scripts pass, `check-workflow-invariants.sh` holds, `test-soak-schedule-routing.sh` passes, every touched workflow parses.

Refs EPIC-013 TASK-013-4.

## Review resolutions (`f57ebe6d3`)

| Finding | Resolution |
|---|---|
| Gate documents not bound to the artifact actually tested | The resolving job keeps the verified `release-evidence.json` as a same-run artifact; publish jobs write from that artifact (never a re-download) and assert its source. Documents carry `candidate_evidence_sha256`; `release-gates.sh` fails any document whose digest differs from the evidence under evaluation. |
| Caller-controlled restart window could yield false 60h evidence | Candidate restarts require `restart_of_run_id`; the schedule gate verifies that run (completed, unsuccessful dispatch of this workflow) and its `soak-window` artifact (same candidate, `retry_attempt` 0, weekend, `end_epoch == window_end_epoch`). `coverage_preserved` is true only for a verified restart; otherwise published as false and the gate fails. |
