### PR TITLE
ci: repin system-integration to main 3e5b5eb for fresh shared-shard channels

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -16,4 +16,4 @@
 # Bump both in the same commit: `just repin-system-integration <sha>`
 # (scripts/repin-system-integration.sh) rewrites every pin site together and
 # runs the invariants checker.
-SYSTEM_INTEGRATION_REF=56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+SYSTEM_INTEGRATION_REF=3e5b5eb89be3f5ef64c3dc3648bb56ebe30eb263

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -45,7 +45,7 @@ env:
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit,
   # via `just repin-system-integration <sha>`.
-  SYSTEM_INTEGRATION_REF: 56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+  SYSTEM_INTEGRATION_REF: 3e5b5eb89be3f5ef64c3dc3648bb56ebe30eb263
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -139,7 +139,16 @@ env:
   # iterations) and the orchestrator host guardian (every iteration) use it.
   SOAK_HOST_FREE_FLOOR_MB: "8192"
   # Third pin site; keep identical to the other two — bump via scripts/repin-system-integration.sh.
-  SYSTEM_INTEGRATION_REF: 56884ab896a8d37d7fa7cba8eed2a0ffef9c1b6a
+  # Pin history:
+  # 2026-08-23: 56884ab -> 3e5b5eb (system-integration main, PR #128). Carries
+  #   SI PR #127: _deploy_and_wait in test_web_api.py deploys onto a fresh
+  #   string channel per call. Closes the shared-shard finalization timeouts
+  #   (rejection_count 15-24) caused by a second bare-integer produce onto a
+  #   reused @2000-@2002 cell; see docs/work-logs/shared-shard-single-number-
+  #   cell-starvation-2026-08-22.md. Also carries SI PR #129 shard-port
+  #   reservation. Verified: SI PR #127 CI green; f1r3node-rust run
+  #   32615164762 attempt 1 reproduced the timeout on the old pin.
+  SYSTEM_INTEGRATION_REF: 3e5b5eb89be3f5ef64c3dc3648bb56ebe30eb263
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"


### PR DESCRIPTION
## Summary

Bumps `SYSTEM_INTEGRATION_REF` `56884ab` -> `3e5b5eb` at all three pin sites (`.github/oci-validation.env`, `_integration-pipeline.yml`, `merge-recovery-soak.yml`) via `scripts/repin-system-integration.sh`.

The new pin (system-integration `main`, SI PR #128) carries:
- SI PR #127: `_deploy_and_wait` in `test_web_api.py` deploys onto a fresh string channel per call.
- SI PR #129: shard-port reservation.

## Why

The shared-shard finalization timeouts (`rejection_count` 15-24) in the integration pipeline are caused by a second bare-integer produce onto a reused `@2000-@2002` cell, which trips the single-number-cell guard. Root cause is in `docs/work-logs/shared-shard-single-number-cell-starvation-2026-08-22.md`. Fresh channels per deploy remove the reuse.

## Verification

- `check-workflow-invariants.sh` holds (all three pin sites identical).
- `scripts/test-repin-system-integration.sh` passes.
- SI PR #127 CI green on the SI side.
- Run 32615164762 attempt 1 reproduced the timeout on the old pin.

## Follow-up

After merge: cancel stuck run 32615164762 and re-run #316 (dev -> master) CI in full.

Refs #294