### PR TITLE
feat(release): gate deployment trains on exact-merge CI evidence

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,6 +13,7 @@
 #   SKIP_TESTS=1         - Skip all cargo tests
 #   SKIP_CLIPPY=1        - Skip clippy (already runs on commit, but double-checked here)
 #   SKIP_DENY=1          - Skip soak-charts dependency policy checks
+#   SKIP_CI_TESTS=1      - Skip CI workflow and release-train script tests
 #   QUICK=1              - Run only fast tests (skip --release tests)
 #   VERBOSE=1            - Show all test output (not just failures)
 #   TEST_TIMEOUT=600     - Overall test timeout in seconds (default: 600)
@@ -42,6 +43,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 SKIP_TESTS="${SKIP_TESTS:-0}"
 SKIP_CLIPPY="${SKIP_CLIPPY:-0}"
 SKIP_DENY="${SKIP_DENY:-0}"
+SKIP_CI_TESTS="${SKIP_CI_TESTS:-0}"
 VERBOSE="${VERBOSE:-0}"
 QUICK="${QUICK:-0}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-600}"
@@ -219,6 +221,61 @@ pid_clippy=$!
 ) &
 pid_dashboard=$!
 
+(
+    total=0; passed=0; failed=0; skipped=0; has_failure=0
+
+    run_ci_check() {
+        local label="$1"
+        shift
+        local check_out="$RESULTS_DIR/ci-${label}.out"
+        total=$((total + 1))
+        echo -e "  ${CYAN}[ci-unit]${NC} ${label}..." >&3
+        if timeout "$TEST_TIMEOUT" "$@" > "$check_out" 2>&1; then
+            echo -e "  ${CYAN}[ci-unit]${NC} ${label} ${GREEN}PASS${NC}" >&3
+            passed=$((passed + 1))
+        else
+            local rc=$?
+            if [[ $rc -eq 124 ]]; then
+                echo -e "  ${CYAN}[ci-unit]${NC} ${label} ${RED}TIMEOUT${NC} (${TEST_TIMEOUT}s)" >&3
+            else
+                echo -e "  ${CYAN}[ci-unit]${NC} ${label} ${RED}FAIL${NC}" >&3
+            fi
+            failed=$((failed + 1))
+            has_failure=1
+            {
+                echo ""
+                echo -e "${RED}FAIL${NC}: CI unit ${label}"
+                echo "--- Output (last 80 lines) ---"
+                tail -80 "$check_out"
+                echo "--------------"
+            } >> "$RESULTS_DIR/ci-failures.out"
+        fi
+        rm -f "$check_out"
+    }
+
+    if [[ "$SKIP_CI_TESTS" == "1" ]]; then
+        echo -e "  ${CYAN}[ci-unit]${NC} ${YELLOW}SKIP${NC} (SKIP_CI_TESTS=1)" >&3
+        skipped=4
+    elif ! command -v ruby >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        total=1
+        failed=1
+        has_failure=1
+        {
+            echo ""
+            echo -e "${RED}FAIL${NC}: CI unit dependencies"
+            echo "Ruby and jq are required for CI unit tests."
+        } >> "$RESULTS_DIR/ci-failures.out"
+    else
+        run_ci_check workflow-invariants bash .github/scripts/check-workflow-invariants.sh
+        run_ci_check stack-gate bash .github/scripts/test-ci-stack-gate.sh
+        run_ci_check release-train .github/scripts/test-release-train.sh
+        run_ci_check release-workflows .github/scripts/test-release-workflows.sh
+    fi
+
+    echo "$total $passed $failed $skipped $has_failure" > "$RESULTS_DIR/ci.counts"
+) &
+pid_ci=$!
+
 # --- Cargo test (background) ---
 (
     total=0; passed=0; failed=0; skipped=0; has_failure=0
@@ -280,14 +337,14 @@ pid_dashboard=$!
 pid_test=$!
 
 # Wait for all suites
-wait "$pid_clippy" "$pid_dashboard" "$pid_test" 2>/dev/null || true
+wait "$pid_clippy" "$pid_dashboard" "$pid_ci" "$pid_test" 2>/dev/null || true
 
 # Close saved fd
 exec 3>&-
 
 # Show failure details and aggregate results
 TESTS_TOTAL=0; TESTS_PASSED=0; TESTS_FAILED=0; TESTS_SKIPPED=0; FAILED=0
-for suite in clippy dashboard test; do
+for suite in clippy dashboard ci test; do
     if [[ -f "$RESULTS_DIR/${suite}-failures.out" ]]; then
         echo ""
         echo -e "${CYAN}${suite^} Failure Details:${NC}"
@@ -341,6 +398,7 @@ else
     echo "  SKIP_TESTS=1 git push        - Skip test suite"
     echo "  SKIP_CLIPPY=1 git push       - Skip clippy"
     echo "  SKIP_DENY=1 git push         - Skip soak-charts dependency checks"
+    echo "  SKIP_CI_TESTS=1 git push     - Skip CI workflow unit tests"
     echo "  VERBOSE=1 git push           - Show detailed output"
     echo "  TEST_CRATES=\"casper rholang\" git push  - Test specific crates"
     echo "  TEST_TIMEOUT=300 git push    - Adjust timeout (default: 600s)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,7 +16,8 @@
 #   SKIP_CI_TESTS=1      - Skip CI workflow and release-train script tests
 #   QUICK=1              - Run only fast tests (skip --release tests)
 #   VERBOSE=1            - Show all test output (not just failures)
-#   TEST_TIMEOUT=600     - Overall test timeout in seconds (default: 600)
+#   TEST_TIMEOUT=600     - Per-command timeout in seconds (default: 600)
+#   CASPER_TEST_TIMEOUT=1800 - Casper test timeout in seconds (default: 1800)
 #   TEST_CRATES="casper rholang" - Run tests for specific crates only
 #
 # CI environment detection:
@@ -47,6 +48,7 @@ SKIP_CI_TESTS="${SKIP_CI_TESTS:-0}"
 VERBOSE="${VERBOSE:-0}"
 QUICK="${QUICK:-0}"
 TEST_TIMEOUT="${TEST_TIMEOUT:-600}"
+CASPER_TEST_TIMEOUT="${CASPER_TEST_TIMEOUT:-1800}"
 TEST_CRATES="${TEST_CRATES:-}"
 SOAK_CHARTS_MANIFEST="scripts/soak-charts/Cargo.toml"
 
@@ -111,7 +113,39 @@ cd "$REPO_ROOT"
 
 # Temp directory for test results
 RESULTS_DIR="$(mktemp -d)"
-trap 'rc=$?; rm -rf "$RESULTS_DIR"; echo "[pre-push hook: exit $rc after $(($(date +%s) - _hook_t0))s]" >&2' EXIT
+background_pids=()
+background_jobs_running=0
+
+terminate_process_tree() {
+    local pid="$1" child
+    kill -0 "$pid" 2>/dev/null || return 0
+    kill -STOP "$pid" 2>/dev/null || true
+    while IFS= read -r child; do
+        [[ -n "$child" ]] && terminate_process_tree "$child"
+    done < <(pgrep -P "$pid" 2>/dev/null || true)
+    kill -TERM "$pid" 2>/dev/null || true
+    kill -CONT "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+    local rc="$1" pid
+    trap - EXIT INT TERM
+    if [[ "$background_jobs_running" -eq 1 ]]; then
+        for pid in "${background_pids[@]}"; do
+            terminate_process_tree "$pid"
+        done
+        for pid in "${background_pids[@]}"; do
+            wait "$pid" 2>/dev/null || true
+        done
+    fi
+    rm -rf "$RESULTS_DIR"
+    echo "[pre-push hook: exit $rc after $(($(date +%s) - _hook_t0))s]" >&2
+    exit "$rc"
+}
+
+trap 'cleanup $?' EXIT
+trap 'cleanup 130' INT
+trap 'cleanup 143' TERM
 
 # Save original stdout as fd 3 for progress from background jobs
 exec 3>&1
@@ -121,6 +155,7 @@ echo -e "${CYAN}Running pre-push checks...${NC}"
 echo "================================"
 
 # --- Clippy (background) ---
+background_jobs_running=1
 (
     total=0; passed=0; failed=0; skipped=0; has_failure=0
     if [[ "$SKIP_CLIPPY" == "1" ]]; then
@@ -153,6 +188,7 @@ echo "================================"
     echo "$total $passed $failed $skipped $has_failure" > "$RESULTS_DIR/clippy.counts"
 ) &
 pid_clippy=$!
+background_pids+=("$pid_clippy")
 
 # --- Dashboard renderer checks (background) ---
 (
@@ -220,6 +256,7 @@ pid_clippy=$!
     echo "$total $passed $failed $skipped $has_failure" > "$RESULTS_DIR/dashboard.counts"
 ) &
 pid_dashboard=$!
+background_pids+=("$pid_dashboard")
 
 (
     total=0; passed=0; failed=0; skipped=0; has_failure=0
@@ -255,7 +292,7 @@ pid_dashboard=$!
 
     if [[ "$SKIP_CI_TESTS" == "1" ]]; then
         echo -e "  ${CYAN}[ci-unit]${NC} ${YELLOW}SKIP${NC} (SKIP_CI_TESTS=1)" >&3
-        skipped=4
+        skipped=5
     elif ! command -v ruby >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
         total=1
         failed=1
@@ -267,6 +304,7 @@ pid_dashboard=$!
         } >> "$RESULTS_DIR/ci-failures.out"
     else
         run_ci_check workflow-invariants bash .github/scripts/check-workflow-invariants.sh
+        run_ci_check pre-push-hook .github/scripts/test-pre-push-hook.sh
         run_ci_check stack-gate bash .github/scripts/test-ci-stack-gate.sh
         run_ci_check release-train .github/scripts/test-release-train.sh
         run_ci_check release-workflows .github/scripts/test-release-workflows.sh
@@ -275,6 +313,7 @@ pid_dashboard=$!
     echo "$total $passed $failed $skipped $has_failure" > "$RESULTS_DIR/ci.counts"
 ) &
 pid_ci=$!
+background_pids+=("$pid_ci")
 
 # --- Cargo test (background) ---
 (
@@ -306,16 +345,18 @@ pid_ci=$!
     for crate in "${crates_to_test[@]}"; do
         total=$((total + 1))
         test_out="$RESULTS_DIR/test-${crate}.out"
+        crate_timeout="$TEST_TIMEOUT"
+        if [[ "$crate" == "casper" ]]; then crate_timeout="$CASPER_TEST_TIMEOUT"; fi
         mode_label=""
         if [[ -n "$release_flag" ]]; then mode_label=" (release)"; fi
         echo -e "  ${CYAN}[test]${NC}    ${crate}${mode_label}..." >&3
-        if timeout "$TEST_TIMEOUT" cargo test $release_flag -p "$crate" > "$test_out" 2>&1; then
+        if timeout "$crate_timeout" cargo test $release_flag -p "$crate" > "$test_out" 2>&1; then
             echo -e "  ${CYAN}[test]${NC}    ${crate} ${GREEN}PASS${NC}" >&3
             passed=$((passed + 1))
         else
             rc=$?
             if [[ $rc -eq 124 ]]; then
-                echo -e "  ${CYAN}[test]${NC}    ${crate} ${RED}TIMEOUT${NC} (${TEST_TIMEOUT}s)" >&3
+                echo -e "  ${CYAN}[test]${NC}    ${crate} ${RED}TIMEOUT${NC} (${crate_timeout}s)" >&3
             else
                 echo -e "  ${CYAN}[test]${NC}    ${crate} ${RED}FAIL${NC}" >&3
             fi
@@ -335,9 +376,11 @@ pid_ci=$!
     echo "$total $passed $failed $skipped $has_failure" > "$RESULTS_DIR/test.counts"
 ) &
 pid_test=$!
+background_pids+=("$pid_test")
 
 # Wait for all suites
 wait "$pid_clippy" "$pid_dashboard" "$pid_ci" "$pid_test" 2>/dev/null || true
+background_jobs_running=0
 
 # Close saved fd
 exec 3>&-
@@ -401,6 +444,7 @@ else
     echo "  SKIP_CI_TESTS=1 git push     - Skip CI workflow unit tests"
     echo "  VERBOSE=1 git push           - Show detailed output"
     echo "  TEST_CRATES=\"casper rholang\" git push  - Test specific crates"
-    echo "  TEST_TIMEOUT=300 git push    - Adjust timeout (default: 600s)"
+    echo "  TEST_TIMEOUT=300 git push    - Adjust the general timeout (default: 600s)"
+    echo "  CASPER_TEST_TIMEOUT=2400 git push - Adjust the Casper timeout (default: 1800s)"
     exit 1
 fi

--- a/.github/deployment-trains/key-contention.yml
+++ b/.github/deployment-trains/key-contention.yml
@@ -3,15 +3,15 @@
 # candidate is the head of the top member (#311). publishing: false runs
 # setup and every gate but reserves no version and publishes nothing.
 #
-# The recorded heads are those observed on 2026-08-22. A member that moves
+# The recorded heads are those observed on 2026-08-24. A member that moves
 # after this manifest is reviewed changes the stack head; update head_sha
 # through a normal pull request before running setup again.
 schema_version: 2
 id: key-contention
 state: proposed
-target_version: 0.4.45
+target_version: 0.4.46
 pull_request: 311
-head_sha: 6c70d818a0d2e3269e2293adf03bb87c42eeed82
+head_sha: 5ce541fff1a7a276c712a6425c0407f03ca62d19
 base_branch: master
 publishing: false
 stack:
@@ -20,5 +20,6 @@ stack:
     - pull_request: 299
     - pull_request: 312
     - pull_request: 319
+    - pull_request: 331
     - pull_request: 311
 required_gates: []

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -128,7 +128,8 @@ ok "both pipeline callers pass secrets down"
 #    Heavy branch work keeps only the current head. Each version tag has a release group.
 #    A branch publisher must reject a stale SHA after it gets its lock.
 ci_concurrency_errors=""
-if ! ci_concurrency_errors="$(ruby -ryaml - .github/workflows/ci.yml 2>&1 <<'RUBY'
+if ! ci_concurrency_errors="$(
+	ruby -ryaml - .github/workflows/ci.yml 2>&1 <<'RUBY'
 def environment_name(job)
   value = job["environment"]
   value.is_a?(Hash) ? value["name"] : value

--- a/.github/scripts/check-workflow-invariants.sh
+++ b/.github/scripts/check-workflow-invariants.sh
@@ -124,9 +124,9 @@ EOF
 done
 ok "both pipeline callers pass secrets down"
 
-# 5. Fast checks use ref-and-SHA push groups. Heavy branch work keeps only the
-#    current head, while each version tag has an independent release group.
-#    A branch publisher must also reject a stale SHA after it gets its lock.
+# 5. Fast checks use ref-and-SHA push groups. Exact merge runs use the merge SHA.
+#    Heavy branch work keeps only the current head. Each version tag has a release group.
+#    A branch publisher must reject a stale SHA after it gets its lock.
 ci_concurrency_errors=""
 if ! ci_concurrency_errors="$(ruby -ryaml - .github/workflows/ci.yml 2>&1 <<'RUBY'
 def environment_name(job)
@@ -140,15 +140,15 @@ end
 
 doc = YAML.load_file(ARGV[0])
 jobs = doc.fetch("jobs")
-expected_group = "${{ github.workflow }}-${{ github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref }}"
-expected_cancel = "${{ github.event_name == 'pull_request' }}"
+expected_group = "${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha != '' && format('exact-{0}', inputs.target_sha) || (github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref) }}"
+expected_cancel = "${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.target_sha != '') }}"
 concurrency = doc.fetch("concurrency", {})
-puts "workflow concurrency must separate branch and tag pushes at the same SHA" unless normalized(concurrency["group"]) == normalized(expected_group)
-puts "workflow concurrency must cancel only superseded PR runs" unless normalized(concurrency["cancel-in-progress"]) == normalized(expected_cancel)
+puts "workflow concurrency must separate push and exact-merge work" unless normalized(concurrency["group"]) == normalized(expected_group)
+puts "workflow concurrency must replace superseded PR and exact-merge runs" unless normalized(concurrency["cancel-in-progress"]) == normalized(expected_cancel)
 
 pipeline = jobs.fetch("pipeline", {})
 pipeline_concurrency = pipeline.fetch("concurrency", {})
-expected_pipeline_group = "ci-heavy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}"
+expected_pipeline_group = "ci-heavy-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha != '' && format('exact-{0}', inputs.target_sha) || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref) }}"
 expected_pipeline_cancel = "${{ !startsWith(github.ref, 'refs/tags/') }}"
 puts "heavy pipeline must use a PR-or-ref queue" unless normalized(pipeline_concurrency["group"]) == normalized(expected_pipeline_group)
 puts "heavy branch and PR work must replace obsolete heads without cancelling version tags" unless normalized(pipeline_concurrency["cancel-in-progress"]) == normalized(expected_pipeline_cancel)

--- a/.github/scripts/release-train.sh
+++ b/.github/scripts/release-train.sh
@@ -85,10 +85,41 @@ validate_manifest() {
 		| if has("stack") then .stack.integration_branch = (.stack.integration_branch // "dev") else . end' <<<"$json"
 }
 
+validate_top_merge() {
+	local manifest_json="$1" inputs="$2" output="$3"
+	local n pull head base merge merge_base
+	n="$(jq -r '.pull_request' <<<"$manifest_json")"
+	pull="$inputs/pull-$n.json"
+	require_file "$pull"
+	head="$(jq -r '.head.sha // empty' "$pull")"
+	base="$(jq -r '.base.sha // empty' "$pull")"
+	merge="$(jq -r '.merge_commit_sha // empty' "$pull")"
+	[[ "$head" =~ ^[0-9a-f]{40}$ ]] || fail "top member #$n has no full head SHA"
+	[[ "$base" =~ ^[0-9a-f]{40}$ ]] || fail "top member #$n has no full base SHA"
+	[[ "$merge" =~ ^[0-9a-f]{40}$ ]] || fail "top member #$n has no full synthetic merge SHA"
+	[ "$head" = "$(jq -r '.head_sha' <<<"$manifest_json")" ] ||
+		fail "manifest head_sha $(jq -r '.head_sha' <<<"$manifest_json") is not the head of the top member ($head)"
+	require_file "$inputs/top-merge.json"
+	jq -e --arg merge "$merge" --arg head "$head" '
+		type == "object"
+		and .sha == $merge
+		and (.parents | length == 2)
+		and (.parents[0].sha | type == "string" and test("^[0-9a-f]{40}$"))
+		and .parents[1].sha == $head' "$inputs/top-merge.json" >/dev/null ||
+		fail "top member #$n synthetic merge $merge does not join the observed head"
+	merge_base="$(jq -r '.parents[0].sha' "$inputs/top-merge.json")"
+	require_file "$inputs/top-base.json"
+	jq -e '.status == "ahead" or .status == "identical"' "$inputs/top-base.json" >/dev/null ||
+		fail "top member #$n logical base $base is not an ancestor of synthetic base $merge_base"
+	mkdir -p "$(dirname "$output")"
+	jq -n --argjson n "$n" --arg head "$head" --arg base "$base" --arg merge_base "$merge_base" --arg merge "$merge" \
+		'{head_pull_request: $n, head_sha: $head, base_sha: $base, merge_base_sha: $merge_base, merge_sha: $merge}' >"$output"
+}
+
 # Section 13.2 steps 3 to 6 from the fetched API documents.
 validate_stack() {
 	local manifest_json="$1" inputs="$2" output="$3"
-	local members integration top_sha n lower upper prev_branch prev_merged base
+	local members integration top_sha n lower upper prev_branch prev_merged base integration_base
 	local record_members="[]" merged count
 	jq -e 'has("stack")' <<<"$manifest_json" >/dev/null || fail "validate-stack requires a stack manifest"
 	integration="$(jq -r '.stack.integration_branch' <<<"$manifest_json")"
@@ -113,6 +144,10 @@ validate_stack() {
 			and (.base.ref == $base or ($prev_merged and .base.ref == $integration))' "$inputs/pull-$n.json" >/dev/null ||
 			fail "member #$n must be open or merged and must target $prev_branch$([ "$prev_merged" = true ] && [ "$prev_branch" != "$integration" ] && printf ' (or %s after the preceding member merged)' "$integration")"
 		base="$(jq -r '.base.ref' "$inputs/pull-$n.json")"
+		if [ "$count" -eq 1 ]; then
+			integration_base="$(jq -r '.base.sha // empty' "$inputs/pull-$n.json")"
+			[[ "$integration_base" =~ ^[0-9a-f]{40}$ ]] || fail "bottom member #$n has no full integration base SHA"
+		fi
 		upper="$(jq -r '.head.sha' "$inputs/pull-$n.json")"
 		[[ "$upper" =~ ^[0-9a-f]{40}$ ]] || fail "member #$n has no full head SHA"
 		# Step 5: head ancestry. The lower head must be an ancestor of this
@@ -145,8 +180,14 @@ validate_stack() {
 		lower="$upper"
 	done <<<"$members"
 	[ "$lower" = "$top_sha" ] || fail "manifest head_sha $top_sha is not the head of the top member ($lower)"
+	local top_record
+	top_record="$(mktemp)"
+	validate_top_merge "$manifest_json" "$inputs" "$top_record"
+	require_file "$inputs/integration-base.json"
+	jq -e '.status == "ahead" or .status == "identical"' "$inputs/integration-base.json" >/dev/null ||
+		fail "integration base $integration_base is not an ancestor of the top synthetic base"
 	mkdir -p "$(dirname "$output")"
-	jq --argjson members "$record_members" '
+	jq --argjson members "$record_members" --arg integration_base "$integration_base" --slurpfile top "$top_record" '
 		{
 			schema_version: 1,
 			train_id: .id,
@@ -157,13 +198,18 @@ validate_stack() {
 			integration_branch: .stack.integration_branch,
 			head_sha: .head_sha,
 			head_pull_request: .pull_request,
+			base_sha: $top[0].base_sha,
+			integration_base_sha: $integration_base,
+			merge_base_sha: $top[0].merge_base_sha,
+			merge_sha: $top[0].merge_sha,
 			members: $members,
 			required_gates: .required_gates
 		}' <<<"$manifest_json" >"$output"
+	rm -f "$top_record"
 	printf 'stack of %s members verified; head %s\n' "$count" "$top_sha" >&2
 }
 
-# Section 13.2 step 7: the source at head_sha must carry target_version.
+# Section 13.2 step 7: the exact merge source must carry target_version.
 # Step 8 (reservation) runs for publishing trains only.
 validate_version() {
 	local manifest_json="$1" source_dir="$2" manifests_dir="$3"
@@ -174,7 +220,7 @@ validate_version() {
 	inspect="$("$EVIDENCE_TOOL" inspect-source "$source_dir")"
 	source_version="$(jq -r '.target_version' <<<"$inspect")"
 	[ "$source_version" = "$target" ] ||
-		fail "source version $source_version at head_sha differs from target_version $target"
+		fail "source version $source_version differs from target_version $target"
 	if [ "$publishing" = true ]; then
 		eligible="$(jq -r '.release_eligible' <<<"$inspect")"
 		[ "$eligible" = true ] ||
@@ -195,23 +241,66 @@ validate_version() {
 	printf 'source version %s matches target_version\n' "$target" >&2
 }
 
-# Section 13.2 step 9: choose the CI evidence. RUNS_JSON is the list of
-# ci.yml runs for head_sha from any event. Prints the newest successful
-# run id, or "dispatch" when none exists. A run listed under the repository
-# always carries repository.full_name == the repository, even for a
-# pull_request run from a fork; head_repository names where the head commit
-# lives, so both must match.
 plan_ci() {
-	local runs_json="$1" head_sha="$2" repository="$3" id
+	local runs_json="$1" merge_sha="$2" repository="$3" default_branch="$4" control_sha="$5"
+	local title id
 	require_file "$runs_json"
-	id="$(jq -r --arg sha "$head_sha" --arg repo "$repository" '
-		[.workflow_runs[]
-			| select(.head_sha == $sha and .path == ".github/workflows/ci.yml"
-				and .status == "completed" and .conclusion == "success"
-				and .repository.full_name == $repo
-				and .head_repository.full_name == $repo)]
+	title="CI [exact merge $merge_sha]"
+	id="$(jq -r --arg title "$title" --arg repo "$repository" --arg branch "$default_branch" --arg control "$control_sha" '
+		def trusted:
+			.path == ".github/workflows/ci.yml"
+			and .event == "workflow_dispatch"
+			and .display_title == $title
+			and .head_branch == $branch
+			and .head_sha == $control
+			and .repository.full_name == $repo
+			and .head_repository.full_name == $repo;
+		[.workflow_runs[] | select(trusted and .status == "completed" and .conclusion == "success")]
 		| sort_by(.run_number) | last | .id // empty' "$runs_json")"
-	if [ -n "$id" ]; then printf '%s\n' "$id"; else printf 'dispatch\n'; fi
+	if [ -n "$id" ]; then
+		printf '%s\n' "$id"
+		return
+	fi
+	id="$(jq -r --arg title "$title" --arg repo "$repository" --arg branch "$default_branch" --arg control "$control_sha" '
+		def trusted:
+			.path == ".github/workflows/ci.yml"
+			and .event == "workflow_dispatch"
+			and .display_title == $title
+			and .head_branch == $branch
+			and .head_sha == $control
+			and .repository.full_name == $repo
+			and .head_repository.full_name == $repo;
+		[.workflow_runs[] | select(trusted and (.status == "queued" or .status == "in_progress"))]
+		| sort_by(.run_number) | last | .id // empty' "$runs_json")"
+	if [ -n "$id" ]; then printf 'wait:%s\n' "$id"; else printf 'dispatch\n'; fi
+}
+
+validate_ci_evidence() {
+	local target="$1" jobs="$2" merge="$3" top="$4" head="$5" base="$6" merge_base="$7" run_id="$8" run_attempt="$9" repository="${10}"
+	require_file "$target"
+	require_file "$jobs"
+	jq -e --arg merge "$merge" --argjson top "$top" --arg head "$head" --arg base "$base" \
+		--arg merge_base "$merge_base" --argjson run "$run_id" --argjson attempt "$run_attempt" --arg repo "$repository" '
+		type == "object"
+		and .schema_version == 1
+		and .repository == $repo
+		and .workflow == ".github/workflows/ci.yml"
+		and .event == "workflow_dispatch"
+		and .target_sha == $merge
+		and .top_pull_request == $top
+		and .head_sha == $head
+		and .base_sha == $base
+		and .merge_base_sha == $merge_base
+		and .run_id == $run
+		and .run_attempt == $attempt' "$target" >/dev/null ||
+		fail "CI target evidence does not bind run $run_id attempt $run_attempt to merge $merge"
+	jq -e '
+		def aggregator($arch):
+			[.jobs[] | select(.name == ("Integration Tests (" + $arch + ")"))]
+			| length == 1 and .[0].status == "completed" and .[0].conclusion == "success";
+		type == "object" and (.jobs | type == "array")
+		and aggregator("amd64") and aggregator("arm64")' "$jobs" >/dev/null ||
+		fail "CI run does not contain one successful Heavy Pipeline aggregator for each architecture"
 }
 
 summarize() {
@@ -222,6 +311,7 @@ summarize() {
 		"",
 		"- Target version: `" + .target_version + "`",
 		"- Head: `" + .head_sha + "` (#" + (.head_pull_request | tostring) + ")",
+		"- Exact merge: `" + .merge_sha + "` onto `" + .merge_base_sha + "` (PR base `" + .base_sha + "`, integration base `" + .integration_base_sha + "`)",
 		"- Integration branch: `" + .integration_branch + "` → base `" + .base_branch + "`",
 		"",
 		"| Member | Head | Base | Merged |",
@@ -234,8 +324,10 @@ usage() {
 		"usage: $0 manifest-json MANIFEST_YML" \
 		"       $0 validate-manifest MANIFEST_YML" \
 		"       $0 validate-stack MANIFEST_JSON_FILE INPUTS_DIR OUTPUT" \
+		"       $0 validate-top-merge MANIFEST_JSON_FILE INPUTS_DIR OUTPUT" \
 		"       $0 validate-version MANIFEST_JSON_FILE SOURCE_DIR MANIFESTS_DIR" \
-		"       $0 plan-ci RUNS_JSON HEAD_SHA REPOSITORY" \
+		"       $0 plan-ci RUNS_JSON MERGE_SHA REPOSITORY DEFAULT_BRANCH CONTROL_SHA" \
+		"       $0 validate-ci-evidence TARGET_JSON JOBS_JSON MERGE_SHA TOP_PR HEAD_SHA BASE_SHA MERGE_BASE_SHA RUN_ID RUN_ATTEMPT REPOSITORY" \
 		"       $0 summarize TRAIN_RECORD" >&2
 	exit 2
 }
@@ -255,14 +347,23 @@ validate-stack)
 	require_file "$2"
 	validate_stack "$(cat "$2")" "$3" "$4"
 	;;
+validate-top-merge)
+	[ "$#" -eq 4 ] || usage
+	require_file "$2"
+	validate_top_merge "$(cat "$2")" "$3" "$4"
+	;;
 validate-version)
 	[ "$#" -eq 4 ] || usage
 	require_file "$2"
 	validate_version "$(cat "$2")" "$3" "$4"
 	;;
 plan-ci)
-	[ "$#" -eq 4 ] || usage
-	plan_ci "$2" "$3" "$4"
+	[ "$#" -eq 6 ] || usage
+	plan_ci "$2" "$3" "$4" "$5" "$6"
+	;;
+validate-ci-evidence)
+	[ "$#" -eq 11 ] || usage
+	validate_ci_evidence "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}"
 	;;
 summarize)
 	[ "$#" -eq 2 ] || usage

--- a/.github/scripts/release-train.sh
+++ b/.github/scripts/release-train.sh
@@ -275,6 +275,18 @@ plan_ci() {
 	if [ -n "$id" ]; then printf 'wait:%s\n' "$id"; else printf 'dispatch\n'; fi
 }
 
+validate_current_stack() {
+	local record="$1" current="$2"
+	require_file "$record"
+	require_file "$current"
+	jq -e --slurpfile current "$current" '
+		{train_id, target_version, head_sha, head_pull_request, integration_branch,
+		 integration_base_sha, base_sha, merge_base_sha, merge_sha, members}
+		== ($current[0] | {train_id, target_version, head_sha, head_pull_request, integration_branch,
+		 integration_base_sha, base_sha, merge_base_sha, merge_sha, members})' "$record" >/dev/null ||
+		fail "stack changed while exact-merge CI ran"
+}
+
 validate_ci_evidence() {
 	local target="$1" jobs="$2" merge="$3" top="$4" head="$5" base="$6" merge_base="$7" run_id="$8" run_attempt="$9" repository="${10}"
 	require_file "$target"
@@ -326,6 +338,7 @@ usage() {
 		"       $0 validate-stack MANIFEST_JSON_FILE INPUTS_DIR OUTPUT" \
 		"       $0 validate-top-merge MANIFEST_JSON_FILE INPUTS_DIR OUTPUT" \
 		"       $0 validate-version MANIFEST_JSON_FILE SOURCE_DIR MANIFESTS_DIR" \
+		"       $0 validate-current-stack TRAIN_RECORD CURRENT_RECORD" \
 		"       $0 plan-ci RUNS_JSON MERGE_SHA REPOSITORY DEFAULT_BRANCH CONTROL_SHA" \
 		"       $0 validate-ci-evidence TARGET_JSON JOBS_JSON MERGE_SHA TOP_PR HEAD_SHA BASE_SHA MERGE_BASE_SHA RUN_ID RUN_ATTEMPT REPOSITORY" \
 		"       $0 summarize TRAIN_RECORD" >&2
@@ -356,6 +369,10 @@ validate-version)
 	[ "$#" -eq 4 ] || usage
 	require_file "$2"
 	validate_version "$(cat "$2")" "$3" "$4"
+	;;
+validate-current-stack)
+	[ "$#" -eq 3 ] || usage
+	validate_current_stack "$2" "$3"
 	;;
 plan-ci)
 	[ "$#" -eq 6 ] || usage

--- a/.github/scripts/test-ci-stack-gate.sh
+++ b/.github/scripts/test-ci-stack-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+ruby -ryaml -e '
+  doc = YAML.load_file(ARGV[0])
+  step = doc.dig("jobs", "build_base", "steps").find { |item| item["id"] == "target" }
+  abort "source target step not found" unless step && step["run"].is_a?(String)
+  File.write(ARGV[1], step["run"])
+' "$ROOT/.github/workflows/ci.yml" "$TMP/gate.sh"
+
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"pulls/311"*) cat "$FAKE_PULL" ;;
+  *"commits/"*) cat "$FAKE_COMMIT" ;;
+  *"compare/"*) printf '%s\n' 'ahead' ;;
+  *"pulls"*) printf '%s\n' "$FAKE_CHILDREN" ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 1 ;;
+esac
+SH
+chmod +x "$TMP/bin/gh"
+
+SHA=1111111111111111111111111111111111111111
+MERGE=2222222222222222222222222222222222222222
+BASE=3333333333333333333333333333333333333333
+HEAD=4444444444444444444444444444444444444444
+MERGE_BASE=5555555555555555555555555555555555555555
+jq -n --arg merge "$MERGE" --arg base "$BASE" --arg head "$HEAD" '{
+  state: "open", merge_commit_sha: $merge,
+  head: {sha: $head, repo: {full_name: "example/repository"}}, base: {sha: $base}
+}' >"$TMP/pull.json"
+jq -n --arg merge "$MERGE" --arg base "$MERGE_BASE" --arg head "$HEAD" \
+  '{sha: $merge, parents: [{sha: $base}, {sha: $head}]}' >"$TMP/commit.json"
+
+run_case() {
+  local label="$1" event="$2" ref="$3" base_ref="$4" head_ref="$5" head_repo="$6" children="$7" target="$8" top="$9" expected="${10}"
+  local fake_pull="${11:-$TMP/pull.json}" output="$TMP/output-${label}"
+  : >"$output"
+  PATH="$TMP/bin:$PATH" \
+    GH_TOKEN=test \
+    GITHUB_REPOSITORY=example/repository \
+    GITHUB_SHA="$SHA" \
+    GITHUB_OUTPUT="$output" \
+    RUNNER_TEMP="$TMP" \
+    REQUESTED_TARGET_SHA="$target" \
+    REQUESTED_TOP_PULL_REQUEST="$top" \
+    EVENT_NAME="$event" \
+    EVENT_REF="$ref" \
+    PR_BASE_REF="$base_ref" \
+    PR_HEAD_REF="$head_ref" \
+    PR_HEAD_REPOSITORY="$head_repo" \
+    FAKE_CHILDREN="$children" \
+    FAKE_PULL="$fake_pull" \
+    FAKE_COMMIT="$TMP/commit.json" \
+    bash "$TMP/gate.sh"
+  actual="$(grep '^run_heavy=' "$output" | cut -d= -f2)"
+  [ "$actual" = "$expected" ] || {
+    printf '%s: expected run_heavy=%s, got %s\n' "$label" "$expected" "$actual" >&2
+    return 1
+  }
+}
+
+run_case standalone pull_request refs/pull/1/merge dev feature/one example/repository '[]' '' '' true
+run_case lower-stack pull_request refs/pull/1/merge dev feature/one example/repository '[{}]' '' '' false
+run_case upper-stack pull_request refs/pull/2/merge feature/one feature/two example/repository '[]' '' '' false
+run_case fork pull_request refs/pull/3/merge dev feature/three fork/repository '[]' '' '' false
+run_case dev-push push refs/heads/dev '' '' '' '[]' '' '' true
+run_case staging-push push refs/heads/staging '' '' '' '[]' '' '' false
+run_case exact-merge workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" 311 true
+
+jq --arg other "$SHA" '.merge_commit_sha = $other' "$TMP/pull.json" >"$TMP/stale-pull.json"
+if run_case stale-merge workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" 311 true "$TMP/stale-pull.json" >"$TMP/stale.out" 2>"$TMP/stale.err"; then
+  echo 'stale exact merge passed' >&2
+  exit 1
+fi
+
+printf 'CI stack gate tests passed\n'

--- a/.github/scripts/test-ci-stack-gate.sh
+++ b/.github/scripts/test-ci-stack-gate.sh
@@ -73,7 +73,7 @@ run_case() {
 }
 
 run_case standalone pull_request refs/pull/1/merge dev feature/one example/repository '[]' '' '' true
-run_case lower-stack pull_request refs/pull/1/merge dev feature/one example/repository '[{}]' '' '' false
+run_case bottom-stack-with-child pull_request refs/pull/1/merge dev feature/one example/repository '[{}]' '' '' true
 run_case upper-stack pull_request refs/pull/2/merge feature/one feature/two example/repository '[]' '' '' false
 run_case fork pull_request refs/pull/3/merge dev feature/three fork/repository '[]' '' '' false
 run_case dev-push push refs/heads/dev '' '' '' '[]' '' '' true

--- a/.github/scripts/test-ci-stack-gate.sh
+++ b/.github/scripts/test-ci-stack-gate.sh
@@ -18,7 +18,7 @@ cat >"$TMP/bin/gh" <<'SH'
 case "$*" in
   *"pulls/311"*) cat "$FAKE_PULL" ;;
   *"commits/"*) cat "$FAKE_COMMIT" ;;
-  *"compare/"*) printf '%s\n' 'ahead' ;;
+  *"compare/"*) printf '%s\n' "${FAKE_RELATIONSHIP:-ahead}" ;;
   *"pulls"*) printf '%s\n' "$FAKE_CHILDREN" ;;
   *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 1 ;;
 esac
@@ -39,7 +39,7 @@ jq -n --arg merge "$MERGE" --arg base "$MERGE_BASE" --arg head "$HEAD" \
 
 run_case() {
   local label="$1" event="$2" ref="$3" base_ref="$4" head_ref="$5" head_repo="$6" children="$7" target="$8" top="$9" expected="${10}"
-  local fake_pull="${11:-$TMP/pull.json}" output="$TMP/output-${label}"
+  local fake_pull="${11:-$TMP/pull.json}" relationship="${12:-ahead}" output="$TMP/output-${label}"
   : >"$output"
   PATH="$TMP/bin:$PATH" \
     GH_TOKEN=test \
@@ -57,12 +57,19 @@ run_case() {
     FAKE_CHILDREN="$children" \
     FAKE_PULL="$fake_pull" \
     FAKE_COMMIT="$TMP/commit.json" \
+    FAKE_RELATIONSHIP="$relationship" \
     bash "$TMP/gate.sh"
   actual="$(grep '^run_heavy=' "$output" | cut -d= -f2)"
   [ "$actual" = "$expected" ] || {
     printf '%s: expected run_heavy=%s, got %s\n' "$label" "$expected" "$actual" >&2
     return 1
   }
+  if [ -n "$target" ]; then
+    [ "$(grep '^merge_base_sha=' "$output" | cut -d= -f2)" = "$MERGE_BASE" ] || {
+      printf '%s: exact target did not record the synthetic base\n' "$label" >&2
+      return 1
+    }
+  fi
 }
 
 run_case standalone pull_request refs/pull/1/merge dev feature/one example/repository '[]' '' '' true
@@ -70,12 +77,25 @@ run_case lower-stack pull_request refs/pull/1/merge dev feature/one example/repo
 run_case upper-stack pull_request refs/pull/2/merge feature/one feature/two example/repository '[]' '' '' false
 run_case fork pull_request refs/pull/3/merge dev feature/three fork/repository '[]' '' '' false
 run_case dev-push push refs/heads/dev '' '' '' '[]' '' '' true
+run_case version-tag push refs/tags/v0.4.46 '' '' '' '[]' '' '' true
 run_case staging-push push refs/heads/staging '' '' '' '[]' '' '' false
 run_case exact-merge workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" 311 true
 
 jq --arg other "$SHA" '.merge_commit_sha = $other' "$TMP/pull.json" >"$TMP/stale-pull.json"
 if run_case stale-merge workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" 311 true "$TMP/stale-pull.json" >"$TMP/stale.out" 2>"$TMP/stale.err"; then
   echo 'stale exact merge passed' >&2
+  exit 1
+fi
+if run_case divergent-base workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" 311 true "$TMP/pull.json" diverged >"$TMP/diverged.out" 2>"$TMP/diverged.err"; then
+  echo 'divergent synthetic base passed' >&2
+  exit 1
+fi
+if run_case missing-top workflow_dispatch refs/heads/master '' '' '' '[]' "$MERGE" '' true >"$TMP/missing-top.out" 2>"$TMP/missing-top.err"; then
+  echo 'exact target without a top pull request passed' >&2
+  exit 1
+fi
+if run_case missing-target workflow_dispatch refs/heads/master '' '' '' '[]' '' 311 true >"$TMP/missing-target.out" 2>"$TMP/missing-target.err"; then
+  echo 'top pull request without an exact target passed' >&2
   exit 1
 fi
 

--- a/.github/scripts/test-pre-push-hook.sh
+++ b/.github/scripts/test-pre-push-hook.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$ROOT/.githooks/pre-push"
+HARNESS="$(mktemp -d)"
+trap 'rm -rf "$HARNESS"' EXIT
+mkdir -p "$HARNESS/bin" "$HARNESS/tmp"
+REAL_GIT="$(command -v git)"
+
+cat >"$HARNESS/bin/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-} \${2:-}" in
+  "rev-parse --show-toplevel") exec "$REAL_GIT" "\$@" ;;
+  "ls-remote origin") printf '%s\t%s\n' "\$FAKE_REMOTE_OID" "\${3:-refs/heads/test}" ;;
+  "fetch origin") exit 0 ;;
+  *) exec "$REAL_GIT" "\$@" ;;
+esac
+EOF
+cat >"$HARNESS/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_TIMEOUT_LOG"
+shift
+exec "$@"
+EOF
+cat >"$HARNESS/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s %s\n' "$$" "$*" >> "$FAKE_CARGO_LOG"
+if [[ "${SLEEP_CASPER:-0}" == 1 && "$*" == "test --release -p casper" ]]; then
+    : > "$FAKE_CASPER_STARTED"
+    sleep 300
+fi
+EOF
+chmod +x "$HARNESS/bin/git" "$HARNESS/bin/timeout" "$HARNESS/bin/cargo"
+grep -Fq "trap 'cleanup 130' INT" "$HOOK"
+
+HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD)"
+REMOTE_SHA="0000000000000000000000000000000000000001"
+PUSH_INPUT="refs/heads/test $HEAD_SHA refs/heads/test $REMOTE_SHA"
+COMMON_ENV=(
+  env
+  PATH="$HARNESS/bin:$PATH"
+  TMPDIR="$HARNESS/tmp"
+  FAKE_REMOTE_OID="$REMOTE_SHA"
+  FAKE_TIMEOUT_LOG="$HARNESS/timeouts"
+  FAKE_CARGO_LOG="$HARNESS/cargo"
+  CI=
+  GITLAB_CI=
+  GITHUB_ACTIONS=
+  SKIP_CLIPPY=1
+  SKIP_DENY=1
+  SKIP_CI_TESTS=1
+  TEST_CRATES=casper
+)
+
+printf '%s\n' "$PUSH_INPUT" |
+  "${COMMON_ENV[@]}" bash "$HOOK" origin fake >"$HARNESS/normal.out" 2>&1
+grep -q '^1800 cargo test --release -p casper$' "$HARNESS/timeouts"
+if find "$HARNESS/tmp" -mindepth 1 -print -quit | grep -q .; then
+  echo "normal hook exit left temporary results" >&2
+  exit 1
+fi
+
+: >"$HARNESS/timeouts"
+: >"$HARNESS/cargo"
+printf '%s\n' "$PUSH_INPUT" |
+  "${COMMON_ENV[@]}" SLEEP_CASPER=1 FAKE_CASPER_STARTED="$HARNESS/started" \
+    bash "$HOOK" origin fake >"$HARNESS/cancel.out" 2>&1 &
+HOOK_PID=$!
+for _ in $(seq 1 100); do
+  [[ -f "$HARNESS/started" ]] && break
+  sleep 0.05
+done
+[[ -f "$HARNESS/started" ]]
+kill -TERM "$HOOK_PID"
+set +e
+wait "$HOOK_PID"
+RC=$?
+set -e
+[[ "$RC" -eq 143 ]]
+if grep -q 'No such file or directory' "$HARNESS/cancel.out"; then
+  echo "hook cancellation removed results before workers stopped" >&2
+  exit 1
+fi
+sleep 0.2
+while read -r pid _; do
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "hook cancellation left cargo process $pid" >&2
+    exit 1
+  fi
+done <"$HARNESS/cargo"
+if find "$HARNESS/tmp" -mindepth 1 -print -quit | grep -q .; then
+  echo "hook cancellation left temporary results" >&2
+  exit 1
+fi
+
+printf 'pre-push hook tests passed\n'

--- a/.github/scripts/test-release-train.sh
+++ b/.github/scripts/test-release-train.sh
@@ -8,8 +8,13 @@ trap 'rm -rf "$TMP"' EXIT
 REPOSITORY=example/repository
 
 sha() { printf '%s' "$1" | sha256sum | awk '{print substr($1, 1, 40)}'; }
-S299="$(sha 299)"; S312="$(sha 312)"; S319="$(sha 319)"; S311="$(sha 311)"
-OTHER="$(sha other)"; CONTROL="$(sha control)"; M311="$(sha merge311)"
+S299="$(sha 299)"
+S312="$(sha 312)"
+S319="$(sha 319)"
+S311="$(sha 311)"
+OTHER="$(sha other)"
+CONTROL="$(sha control)"
+M311="$(sha merge311)"
 
 expect_failure() {
 	local label="$1"
@@ -116,7 +121,10 @@ stack_case() { # label, then a shell snippet that mutates a copy of inputs
 	dir="$(mktemp -d "$TMP/case-XXXXXX")"
 	rmdir "$dir"
 	cp -R "$IN" "$dir"
-	( IN="$dir"; eval "$snippet" )
+	(
+		IN="$dir"
+		eval "$snippet"
+	)
 	expect_failure "$label" "$TOOL" validate-stack "$TMP/stack.json" "$dir" "$dir/record.json"
 }
 stack_case 'member base points at the following member (inverted)' \
@@ -160,9 +168,15 @@ stack_case 'integration base ancestry input is missing' \
 MERGED="$TMP/merged"
 cp -R "$IN" "$MERGED"
 M299="$(sha merge299)"
-( IN="$MERGED"; pull 299 closed true dev fix/key-contention-starvation "$S299" "$M299" )
+(
+	IN="$MERGED"
+	pull 299 closed true dev fix/key-contention-starvation "$S299" "$M299"
+)
 jq -n --arg sha "$M299" --arg p "$(sha devtip)" --arg q "$S299" '{sha: $sha, parents: [{sha: $p}, {sha: $q}]}' >"$MERGED/merge-299.json"
-( IN="$MERGED"; reach 299 ahead )
+(
+	IN="$MERGED"
+	reach 299 ahead
+)
 "$TOOL" validate-stack "$TMP/stack.json" "$MERGED" "$MERGED/record.json" 2>/dev/null
 jq -e '.members[0].merged == true and .members[1].base == "fix/key-contention-starvation"' "$MERGED/record.json" >/dev/null
 # After the merged member's branch is deleted, GitHub retargets the next
@@ -170,7 +184,10 @@ jq -e '.members[0].merged == true and .members[1].base == "fix/key-contention-st
 # recorded as observed.
 RETARGET="$TMP/retarget"
 cp -R "$MERGED" "$RETARGET"
-( IN="$RETARGET"; pull 312 open false dev feat/key-contention-phase2 "$S312" )
+(
+	IN="$RETARGET"
+	pull 312 open false dev feat/key-contention-phase2 "$S312"
+)
 "$TOOL" validate-stack "$TMP/stack.json" "$RETARGET" "$RETARGET/record.json" 2>/dev/null
 jq -e '.members[0].merged == true and .members[1].base == "dev" and .members[2].base == "feat/key-contention-phase2"' "$RETARGET/record.json" >/dev/null
 

--- a/.github/scripts/test-release-train.sh
+++ b/.github/scripts/test-release-train.sh
@@ -114,6 +114,21 @@ jq -e --arg top "$S311" --arg s299 "$S299" --arg merge "$M311" --arg base "$B311
 	and .members[0] == {pull_request: 299, head_sha: $s299, base: "dev", merged: false}
 	and .members[3].base == "fix/key-contention-base-bias"' "$TMP/train-record.json" >/dev/null
 "$TOOL" summarize "$TMP/train-record.json" | grep -q 'rehearsal, non-publishing'
+"$TOOL" validate-current-stack "$TMP/train-record.json" "$TMP/train-record.json"
+current_stack_case() {
+	local label="$1" filter="$2" current="$TMP/current-stack.json"
+	jq --arg other "$OTHER" "$filter" "$TMP/train-record.json" >"$current"
+	expect_failure "$label" "$TOOL" validate-current-stack "$TMP/train-record.json" "$current"
+}
+current_stack_case 'top head changed during CI' '.head_sha = $other'
+current_stack_case 'integration base changed during CI' '.integration_base_sha = $other'
+current_stack_case 'logical base changed during CI' '.base_sha = $other'
+current_stack_case 'synthetic base changed during CI' '.merge_base_sha = $other'
+current_stack_case 'synthetic merge changed during CI' '.merge_sha = $other'
+current_stack_case 'middle member head changed during CI' '.members[1].head_sha = $other'
+current_stack_case 'middle member base changed during CI' '.members[1].base = "other"'
+current_stack_case 'middle member merged during CI' '.members[1].merged = true'
+current_stack_case 'member order changed during CI' '.members |= reverse'
 
 # --- Section 15 rejections ------------------------------------------------------
 stack_case() { # label, then a shell snippet that mutates a copy of inputs

--- a/.github/scripts/test-release-train.sh
+++ b/.github/scripts/test-release-train.sh
@@ -9,7 +9,7 @@ REPOSITORY=example/repository
 
 sha() { printf '%s' "$1" | sha256sum | awk '{print substr($1, 1, 40)}'; }
 S299="$(sha 299)"; S312="$(sha 312)"; S319="$(sha 319)"; S311="$(sha 311)"
-OTHER="$(sha other)"
+OTHER="$(sha other)"; CONTROL="$(sha control)"; M311="$(sha merge311)"
 
 expect_failure() {
 	local label="$1"
@@ -77,8 +77,10 @@ expect_failure 'broken yaml' "$TOOL" validate-manifest "$TMP/broken.yml"
 IN="$TMP/inputs"
 mkdir -p "$IN"
 pull() { # number state merged base head_ref head_sha [merge_sha]
-	jq -n --argjson n "$1" --arg state "$2" --argjson merged "$3" --arg base "$4" --arg ref "$5" --arg head "$6" --arg merge "${7:-}" '{
-		number: $n, state: $state, merged: $merged, base: {ref: $base}, head: {ref: $ref, sha: $head},
+	local base_sha
+	base_sha="$(sha "base-$4")"
+	jq -n --argjson n "$1" --arg state "$2" --argjson merged "$3" --arg base "$4" --arg base_sha "$base_sha" --arg ref "$5" --arg head "$6" --arg merge "${7:-}" '{
+		number: $n, state: $state, merged: $merged, base: {ref: $base, sha: $base_sha}, head: {ref: $ref, sha: $head},
 		merge_commit_sha: (if $merge == "" then null else $merge end)}' >"$IN/pull-$1.json"
 }
 compare() { jq -n --arg s "$3" '{status: $s}' >"$IN/compare-$1-$2.json"; }
@@ -86,14 +88,23 @@ reach() { jq -n --arg s "$2" '{status: $s}' >"$IN/reach-$1.json"; }
 pull 299 open false dev fix/key-contention-starvation "$S299"
 pull 312 open false fix/key-contention-starvation feat/key-contention-phase2 "$S312"
 pull 319 open false feat/key-contention-phase2 fix/key-contention-base-bias "$S319"
-pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$S311"
+pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$S311" "$M311"
+B311="$(jq -r '.base.sha' "$IN/pull-311.json")"
+MB311="$(sha synthetic-base)"
+jq -n --arg sha "$M311" --arg base "$MB311" --arg head "$S311" \
+	'{sha: $sha, parents: [{sha: $base}, {sha: $head}]}' >"$IN/top-merge.json"
+jq -n '{status: "ahead"}' >"$IN/top-base.json"
+jq -n '{status: "ahead"}' >"$IN/integration-base.json"
 compare "$S299" "$S312" ahead
 compare "$S312" "$S319" ahead
 compare "$S319" "$S311" identical
 "$TOOL" validate-stack "$TMP/stack.json" "$IN" "$TMP/train-record.json" 2>/dev/null
-jq -e --arg top "$S311" --arg s299 "$S299" '
+IBASE="$(jq -r '.base.sha' "$IN/pull-299.json")"
+jq -e --arg top "$S311" --arg s299 "$S299" --arg merge "$M311" --arg base "$B311" --arg merge_base "$MB311" --arg integration_base "$IBASE" '
 	.schema_version == 1 and .train_id == "key-contention" and .publishing == false
 	and .head_sha == $top and .head_pull_request == 311 and .integration_branch == "dev"
+	and .merge_sha == $merge and .base_sha == $base and .merge_base_sha == $merge_base
+	and .integration_base_sha == $integration_base
 	and (.members | length) == 4
 	and .members[0] == {pull_request: 299, head_sha: $s299, base: "dev", merged: false}
 	and .members[3].base == "fix/key-contention-base-bias"' "$TMP/train-record.json" >/dev/null
@@ -132,6 +143,18 @@ stack_case 'member retargeted to the integration branch while its predecessor is
 	'pull 312 open false dev feat/key-contention-phase2 "$S312"'
 stack_case 'empty pull request document' \
 	': >"$IN/pull-312.json"'
+stack_case 'top synthetic merge changed after observation' \
+	'pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$S311" "$OTHER"'
+stack_case 'top synthetic merge base does not contain the logical base' \
+	'jq -n --arg sha "$M311" --arg base "$OTHER" --arg head "$S311" "{sha: \$sha, parents: [{sha: \$base}, {sha: \$head}]}" >"$IN/top-merge.json"; jq -n "{status: \"diverged\"}" >"$IN/top-base.json"'
+stack_case 'top synthetic merge job input is missing' \
+	'rm "$IN/top-merge.json"'
+stack_case 'top synthetic base ancestry input is missing' \
+	'rm "$IN/top-base.json"'
+stack_case 'integration base is stale' \
+	'jq -n "{status: \"behind\"}" >"$IN/integration-base.json"'
+stack_case 'integration base ancestry input is missing' \
+	'rm "$IN/integration-base.json"'
 
 # A correctly merged bottom member passes.
 MERGED="$TMP/merged"
@@ -190,18 +213,40 @@ sed -i.bak 's/^state: active$/state: promoted/' "$TMP/manifests/other.yml"
 "$TOOL" validate-version "$TMP/stack-publishing.json" "$SRC" "$TMP/manifests" 2>/dev/null
 
 # --- CI planning ----------------------------------------------------------------
-jq -n --arg sha "$S311" --arg repo "$REPOSITORY" '{workflow_runs: [
-	{id: 1, run_number: 10, head_sha: $sha, path: ".github/workflows/ci.yml", status: "completed", conclusion: "success", repository: {full_name: $repo}, head_repository: {full_name: $repo}},
-	{id: 2, run_number: 11, head_sha: $sha, path: ".github/workflows/ci.yml", status: "completed", conclusion: "failure", repository: {full_name: $repo}, head_repository: {full_name: $repo}},
-	{id: 3, run_number: 12, head_sha: $sha, path: ".github/workflows/ci.yml", status: "completed", conclusion: "success", repository: {full_name: $repo}, head_repository: {full_name: $repo}},
-	{id: 4, run_number: 13, head_sha: $sha, path: ".github/workflows/slashing-tests.yml", status: "completed", conclusion: "success", repository: {full_name: $repo}, head_repository: {full_name: $repo}}]}' >"$TMP/runs.json"
-[ "$("$TOOL" plan-ci "$TMP/runs.json" "$S311" "$REPOSITORY")" = 3 ]
-[ "$("$TOOL" plan-ci "$TMP/runs.json" "$OTHER" "$REPOSITORY")" = dispatch ]
-# A pull_request run from a fork lists repository == the base repository;
-# only head_repository reveals the fork.
+TITLE="CI [exact merge $M311]"
+jq -n --arg title "$TITLE" --arg control "$CONTROL" --arg repo "$REPOSITORY" '{workflow_runs: [
+	{id: 1, run_number: 10, head_sha: $control, head_branch: "master", display_title: $title, event: "workflow_dispatch", path: ".github/workflows/ci.yml", status: "completed", conclusion: "success", repository: {full_name: $repo}, head_repository: {full_name: $repo}},
+	{id: 2, run_number: 11, head_sha: $control, head_branch: "master", display_title: $title, event: "workflow_dispatch", path: ".github/workflows/ci.yml", status: "completed", conclusion: "failure", repository: {full_name: $repo}, head_repository: {full_name: $repo}},
+	{id: 3, run_number: 12, head_sha: $control, head_branch: "master", display_title: $title, event: "workflow_dispatch", path: ".github/workflows/ci.yml", status: "completed", conclusion: "success", repository: {full_name: $repo}, head_repository: {full_name: $repo}}]}' >"$TMP/runs.json"
+[ "$("$TOOL" plan-ci "$TMP/runs.json" "$M311" "$REPOSITORY" master "$CONTROL")" = 3 ]
+[ "$("$TOOL" plan-ci "$TMP/runs.json" "$OTHER" "$REPOSITORY" master "$CONTROL")" = dispatch ]
+jq '.workflow_runs |= map(.event = "pull_request")' "$TMP/runs.json" >"$TMP/runs-lightweight.json"
+[ "$("$TOOL" plan-ci "$TMP/runs-lightweight.json" "$M311" "$REPOSITORY" master "$CONTROL")" = dispatch ]
+jq --arg other "$OTHER" '.workflow_runs |= map(.head_sha = $other)' "$TMP/runs.json" >"$TMP/runs-untrusted-control.json"
+[ "$("$TOOL" plan-ci "$TMP/runs-untrusted-control.json" "$M311" "$REPOSITORY" master "$CONTROL")" = dispatch ]
 jq '.workflow_runs |= map(.head_repository.full_name = "fork/repo")' "$TMP/runs.json" >"$TMP/runs-fork.json"
-[ "$("$TOOL" plan-ci "$TMP/runs-fork.json" "$S311" "$REPOSITORY")" = dispatch ]
+[ "$("$TOOL" plan-ci "$TMP/runs-fork.json" "$M311" "$REPOSITORY" master "$CONTROL")" = dispatch ]
 jq '.workflow_runs |= map(del(.head_repository))' "$TMP/runs.json" >"$TMP/runs-nohead.json"
-[ "$("$TOOL" plan-ci "$TMP/runs-nohead.json" "$S311" "$REPOSITORY")" = dispatch ]
+[ "$("$TOOL" plan-ci "$TMP/runs-nohead.json" "$M311" "$REPOSITORY" master "$CONTROL")" = dispatch ]
+jq '.workflow_runs |= map(.status = "in_progress" | .conclusion = null) | .workflow_runs[2].id = 5 | .workflow_runs[2].run_number = 14' "$TMP/runs.json" >"$TMP/runs-active.json"
+[ "$("$TOOL" plan-ci "$TMP/runs-active.json" "$M311" "$REPOSITORY" master "$CONTROL")" = wait:5 ]
+
+jq -n --arg repo "$REPOSITORY" --arg merge "$M311" --arg head "$S311" --arg base "$B311" --arg merge_base "$MB311" '{
+	schema_version: 1, repository: $repo, workflow: ".github/workflows/ci.yml", event: "workflow_dispatch",
+	target_sha: $merge, top_pull_request: 311, head_sha: $head, base_sha: $base, merge_base_sha: $merge_base, run_id: 3, run_attempt: 1
+}' >"$TMP/ci-target.json"
+jq -n '{jobs: [
+	{name: "Integration Tests (amd64)", status: "completed", conclusion: "success"},
+	{name: "Integration Tests (arm64)", status: "completed", conclusion: "success"}
+]}' >"$TMP/ci-jobs.json"
+"$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs.json" "$M311" 311 "$S311" "$B311" "$MB311" 3 1 "$REPOSITORY"
+jq '.jobs[1].conclusion = "skipped"' "$TMP/ci-jobs.json" >"$TMP/ci-jobs-skipped.json"
+expect_failure 'skipped Heavy Pipeline aggregator' "$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs-skipped.json" "$M311" 311 "$S311" "$B311" "$MB311" 3 1 "$REPOSITORY"
+jq '.jobs = [.jobs[0]]' "$TMP/ci-jobs.json" >"$TMP/ci-jobs-missing.json"
+expect_failure 'missing Heavy Pipeline aggregator' "$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs-missing.json" "$M311" 311 "$S311" "$B311" "$MB311" 3 1 "$REPOSITORY"
+jq '.jobs += [.jobs[0]]' "$TMP/ci-jobs.json" >"$TMP/ci-jobs-duplicate.json"
+expect_failure 'duplicate Heavy Pipeline aggregator' "$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs-duplicate.json" "$M311" 311 "$S311" "$B311" "$MB311" 3 1 "$REPOSITORY"
+expect_failure 'CI target binds a stale merge' "$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs.json" "$OTHER" 311 "$S311" "$B311" "$MB311" 3 1 "$REPOSITORY"
+expect_failure 'CI target binds a stale synthetic base' "$TOOL" validate-ci-evidence "$TMP/ci-target.json" "$TMP/ci-jobs.json" "$M311" 311 "$S311" "$B311" "$OTHER" 3 1 "$REPOSITORY"
 
 printf 'release train tests passed\n'

--- a/.github/scripts/test-release-train.sh
+++ b/.github/scripts/test-release-train.sh
@@ -11,6 +11,7 @@ sha() { printf '%s' "$1" | sha256sum | awk '{print substr($1, 1, 40)}'; }
 S299="$(sha 299)"
 S312="$(sha 312)"
 S319="$(sha 319)"
+S331="$(sha 331)"
 S311="$(sha 311)"
 OTHER="$(sha other)"
 CONTROL="$(sha control)"
@@ -54,12 +55,13 @@ stack:
     - pull_request: 299
     - pull_request: 312
     - pull_request: 319
+    - pull_request: 331
     - pull_request: 311
 required_gates: []
 EOF
 "$TOOL" validate-manifest "$TMP/single.yml" | jq -e '.publishing == true and (has("stack") | not)' >/dev/null
 "$TOOL" validate-manifest "$TMP/stack.yml" >"$TMP/stack.json"
-jq -e '.publishing == false and .stack.integration_branch == "dev" and (.stack.members | length) == 4' "$TMP/stack.json" >/dev/null
+jq -e '.publishing == false and .stack.integration_branch == "dev" and (.stack.members | length) == 5' "$TMP/stack.json" >/dev/null
 
 bad_manifest() {
 	local label="$1" filter="$2"
@@ -78,7 +80,7 @@ bad_manifest 'gate without job' '.required_gates = [{id: "x", workflow: "x.yml",
 printf 'not: [valid\n' >"$TMP/broken.yml"
 expect_failure 'broken yaml' "$TOOL" validate-manifest "$TMP/broken.yml"
 
-# --- Stack inputs: a valid chain 299 -> 312 -> 319 -> 311 ---------------------
+# --- Stack inputs: a valid chain 299 -> 312 -> 319 -> 331 -> 311 --------------
 IN="$TMP/inputs"
 mkdir -p "$IN"
 pull() { # number state merged base head_ref head_sha [merge_sha]
@@ -93,7 +95,8 @@ reach() { jq -n --arg s "$2" '{status: $s}' >"$IN/reach-$1.json"; }
 pull 299 open false dev fix/key-contention-starvation "$S299"
 pull 312 open false fix/key-contention-starvation feat/key-contention-phase2 "$S312"
 pull 319 open false feat/key-contention-phase2 fix/key-contention-base-bias "$S319"
-pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$S311" "$M311"
+pull 331 open false fix/key-contention-base-bias fix/fork-choice-missing-history-availability "$S331"
+pull 311 open false fix/fork-choice-missing-history-availability formal/enhance-cbc-design "$S311" "$M311"
 B311="$(jq -r '.base.sha' "$IN/pull-311.json")"
 MB311="$(sha synthetic-base)"
 jq -n --arg sha "$M311" --arg base "$MB311" --arg head "$S311" \
@@ -102,7 +105,8 @@ jq -n '{status: "ahead"}' >"$IN/top-base.json"
 jq -n '{status: "ahead"}' >"$IN/integration-base.json"
 compare "$S299" "$S312" ahead
 compare "$S312" "$S319" ahead
-compare "$S319" "$S311" identical
+compare "$S319" "$S331" ahead
+compare "$S331" "$S311" ahead
 "$TOOL" validate-stack "$TMP/stack.json" "$IN" "$TMP/train-record.json" 2>/dev/null
 IBASE="$(jq -r '.base.sha' "$IN/pull-299.json")"
 jq -e --arg top "$S311" --arg s299 "$S299" --arg merge "$M311" --arg base "$B311" --arg merge_base "$MB311" --arg integration_base "$IBASE" '
@@ -110,9 +114,9 @@ jq -e --arg top "$S311" --arg s299 "$S299" --arg merge "$M311" --arg base "$B311
 	and .head_sha == $top and .head_pull_request == 311 and .integration_branch == "dev"
 	and .merge_sha == $merge and .base_sha == $base and .merge_base_sha == $merge_base
 	and .integration_base_sha == $integration_base
-	and (.members | length) == 4
+	and (.members | length) == 5
 	and .members[0] == {pull_request: 299, head_sha: $s299, base: "dev", merged: false}
-	and .members[3].base == "fix/key-contention-base-bias"' "$TMP/train-record.json" >/dev/null
+	and .members[4].base == "fix/fork-choice-missing-history-availability"' "$TMP/train-record.json" >/dev/null
 "$TOOL" summarize "$TMP/train-record.json" | grep -q 'rehearsal, non-publishing'
 "$TOOL" validate-current-stack "$TMP/train-record.json" "$TMP/train-record.json"
 current_stack_case() {
@@ -151,7 +155,7 @@ stack_case 'member head is not an ancestor of the following head' \
 stack_case 'member closed without merge' \
 	'pull 319 closed false feat/key-contention-phase2 fix/key-contention-base-bias "$S319"'
 stack_case 'manifest head_sha differs from the top member head' \
-	'pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$OTHER"; compare "$S319" "$OTHER" ahead'
+	'pull 311 open false fix/fork-choice-missing-history-availability formal/enhance-cbc-design "$OTHER"; compare "$S331" "$OTHER" ahead'
 stack_case 'merged member without a merge commit' \
 	'pull 299 closed true dev fix/key-contention-starvation "$S299"'
 stack_case 'merged member squashed (single parent)' \
@@ -167,7 +171,7 @@ stack_case 'member retargeted to the integration branch while its predecessor is
 stack_case 'empty pull request document' \
 	': >"$IN/pull-312.json"'
 stack_case 'top synthetic merge changed after observation' \
-	'pull 311 open false fix/key-contention-base-bias formal/enhance-cbc-design "$S311" "$OTHER"'
+	'pull 311 open false fix/fork-choice-missing-history-availability formal/enhance-cbc-design "$S311" "$OTHER"'
 stack_case 'top synthetic merge base does not contain the logical base' \
 	'jq -n --arg sha "$M311" --arg base "$OTHER" --arg head "$S311" "{sha: \$sha, parents: [{sha: \$base}, {sha: \$head}]}" >"$IN/top-merge.json"; jq -n "{status: \"diverged\"}" >"$IN/top-base.json"'
 stack_case 'top synthetic merge job input is missing' \

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -170,7 +170,13 @@ fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "target_sha", "default") !
 fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "top_pull_request", "default") != "", "CI dispatch must accept an optional top pull request")
 build_base = ci.dig("jobs", "build_base")
 fail_if(build_base.dig("outputs", "TARGET_SHA") != "${{ steps.target.outputs.target_sha }}", "Build Base must export the validated target SHA")
+fail_if(build_base.dig("outputs", "MERGE_BASE_SHA") != "${{ steps.target.outputs.merge_base_sha }}", "Build Base must export the synthetic base SHA")
 fail_if(build_base.dig("outputs", "RUN_HEAVY") != "${{ steps.target.outputs.run_heavy }}", "Build Base must export the Heavy Pipeline decision")
+build_steps = build_base.fetch("steps")
+target_step = build_steps.find { |step| step["id"] == "target" }
+fail_if(!target_step&.dig("run")&.include?('compare/${base}...${merge_base}'), "CI must verify synthetic base ancestry")
+target_upload = build_steps.find { |step| step["name"] == "Upload exact target evidence" }
+fail_if(target_upload&.dig("uses").to_s !~ /\Aactions\/upload-artifact@[0-9a-f]{40}\z/, "CI target evidence upload must use a full action SHA")
 pipeline = ci.dig("jobs", "pipeline")
 fail_if(pipeline["if"] != "needs.build_base.outputs.RUN_HEAVY == 'true'", "Heavy Pipeline must use the validated stack decision")
 fail_if(pipeline.dig("with", "checkout_ref") != "${{ needs.build_base.outputs.TARGET_SHA }}", "Heavy Pipeline must check out the validated target SHA")
@@ -179,6 +185,16 @@ fail_if(!ci_text.include?("merge_commit_sha"), "CI must validate the current pul
 fail_if(!ci_text.include?('-f base="$PR_HEAD_REF"'), "CI must detect open pull requests stacked on the current head")
 fail_if(!ci_text.include?('run_heavy=$run_heavy'), "CI must persist the Heavy Pipeline decision")
 fail_if(!ci_text.include?("ci-target-${{ github.run_attempt }}"), "CI must upload attempt-specific target evidence")
+%w[lint deny markdown_link_check test].each do |job_name|
+  checkout = ci.dig("jobs", job_name, "steps").find { |step| step["name"] == "Checkout" }
+  fail_if(checkout&.dig("with", "ref") != "${{ needs.build_base.outputs.TARGET_SHA }}", "#{job_name} must check out the validated target SHA")
+end
+lint_steps = ci.dig("jobs", "lint", "steps")
+fail_if(lint_steps.none? { |step| step["run"].to_s.include?("test-ci-stack-gate.sh") }, "Lint must run CI stack gate tests")
+%w[integration_tests_amd64 integration_tests_arm64].each do |job_name|
+  condition = ci.dig("jobs", job_name, "if").to_s
+  fail_if(!condition.include?("needs.pipeline.result != 'skipped'"), "#{job_name} must fail closed when Heavy Pipeline runs")
+end
 
 # Deployment train setup (Phase 5): manual, default-branch only, one job
 # whose only write permission is actions (the optional ci.yml dispatch), no
@@ -205,6 +221,9 @@ fail_if(!train_text.include?("release-train.sh validate-top-merge"), "deployment
 fail_if(!train_text.include?("release-train.sh validate-version"), "deployment train must verify the source version with release-train.sh")
 fail_if(!train_text.include?("release-train.sh plan-ci"), "deployment train must plan CI evidence with release-train.sh")
 fail_if(!train_text.include?("release-train.sh validate-ci-evidence"), "deployment train must validate exact CI target and Heavy Pipeline evidence")
+fail_if(train_text.scan("release-train.sh validate-stack").length != 2, "deployment train must validate the full stack before and after CI")
+fail_if(!train_text.include?("release-train.sh validate-current-stack"), "deployment train must compare the post-CI stack record")
+fail_if(!train_text.include?(".stack.members[].pull_request"), "deployment train must refresh every stack member after CI")
 fail_if(!train_text.include?('gh workflow run ci.yml --ref "$DEFAULT_BRANCH"'), "deployment train must dispatch the trusted default-branch CI workflow")
 fail_if(!train_text.include?('-f target_sha="$merge_sha" -f top_pull_request="$top"'), "deployment train must dispatch CI for the exact top merge")
 fail_if(!train_text.include?('/attempts/${run_attempt}/jobs'), "deployment train must read jobs from the selected run attempt")

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -9,6 +9,7 @@ ruby -ryaml - \
 	"$ROOT/.github/workflows/canary-publish.yml" \
 	"$ROOT/.github/workflows/oci-validation.yml" \
 	"$ROOT/.github/workflows/merge-recovery-soak.yml" \
+	"$ROOT/.github/workflows/ci.yml" \
 	"$ROOT/.github/workflows/deployment-train.yml" <<'RUBY'
 def trigger(document)
   document["on"] || document[true]
@@ -18,7 +19,7 @@ def fail_if(condition, message)
   abort(message) if condition
 end
 
-release_path, evidence_path, soakin_path, canary_path, oci_path, soak_path, train_path = ARGV
+release_path, evidence_path, soakin_path, canary_path, oci_path, soak_path, ci_path, train_path = ARGV
 release = YAML.load_file(release_path)
 evidence = YAML.load_file(evidence_path)
 soakin = YAML.load_file(soakin_path)
@@ -162,6 +163,23 @@ fail_if(!reusable_text.match?(/Build Docker Image\n\s+if: inputs\.candidate_tag 
 soak_text = File.read(soak_path)
 fail_if(!soak_text.match?(/docker pull --platform [^\n]*@\$\{amd64_digest\}/), "soak candidate mode must pull the image by digest")
 fail_if(!soak_text.match?(/Build node image\n\s+if: needs\.schedule_gate\.outputs\.candidate_tag == ''/m), "soak must skip the source build in candidate mode")
+ci = YAML.load_file(ci_path)
+ci_trigger = trigger(ci)
+fail_if(!ci_trigger.key?("pull_request") || !ci_trigger["pull_request"].nil?, "CI must run lightweight checks for every pull request base")
+fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "target_sha", "default") != "", "CI dispatch must accept an optional exact target SHA")
+fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "top_pull_request", "default") != "", "CI dispatch must accept an optional top pull request")
+build_base = ci.dig("jobs", "build_base")
+fail_if(build_base.dig("outputs", "TARGET_SHA") != "${{ steps.target.outputs.target_sha }}", "Build Base must export the validated target SHA")
+fail_if(build_base.dig("outputs", "RUN_HEAVY") != "${{ steps.target.outputs.run_heavy }}", "Build Base must export the Heavy Pipeline decision")
+pipeline = ci.dig("jobs", "pipeline")
+fail_if(pipeline["if"] != "needs.build_base.outputs.RUN_HEAVY == 'true'", "Heavy Pipeline must use the validated stack decision")
+fail_if(pipeline.dig("with", "checkout_ref") != "${{ needs.build_base.outputs.TARGET_SHA }}", "Heavy Pipeline must check out the validated target SHA")
+ci_text = File.read(ci_path)
+fail_if(!ci_text.include?("merge_commit_sha"), "CI must validate the current pull request synthetic merge")
+fail_if(!ci_text.include?('-f base="$PR_HEAD_REF"'), "CI must detect open pull requests stacked on the current head")
+fail_if(!ci_text.include?('run_heavy=$run_heavy'), "CI must persist the Heavy Pipeline decision")
+fail_if(!ci_text.include?("ci-target-${{ github.run_attempt }}"), "CI must upload attempt-specific target evidence")
+
 # Deployment train setup (Phase 5): manual, default-branch only, one job
 # whose only write permission is actions (the optional ci.yml dispatch), no
 # protected environment, pinned actions, and never a tag, release, image,
@@ -183,8 +201,13 @@ train_text = File.read(train_path)
 fail_if(train_text.match?(/docker\s+(build|push|login)|buildx|gh release|git push|refs\/tags|secrets\.(?!GITHUB_TOKEN)/), "deployment train setup must not publish or use secrets beyond GITHUB_TOKEN")
 fail_if(!train_text.include?("release-train.sh validate-manifest"), "deployment train must validate the manifest with release-train.sh")
 fail_if(!train_text.include?("release-train.sh validate-stack"), "deployment train must verify the stack chain with release-train.sh")
+fail_if(!train_text.include?("release-train.sh validate-top-merge"), "deployment train must verify the top synthetic merge")
 fail_if(!train_text.include?("release-train.sh validate-version"), "deployment train must verify the source version with release-train.sh")
 fail_if(!train_text.include?("release-train.sh plan-ci"), "deployment train must plan CI evidence with release-train.sh")
+fail_if(!train_text.include?("release-train.sh validate-ci-evidence"), "deployment train must validate exact CI target and Heavy Pipeline evidence")
+fail_if(!train_text.include?('gh workflow run ci.yml --ref "$DEFAULT_BRANCH"'), "deployment train must dispatch the trusted default-branch CI workflow")
+fail_if(!train_text.include?('-f target_sha="$merge_sha" -f top_pull_request="$top"'), "deployment train must dispatch CI for the exact top merge")
+fail_if(!train_text.include?('/attempts/${run_attempt}/jobs'), "deployment train must read jobs from the selected run attempt")
 fail_if(!train_text.match?(/\.github\/deployment-trains\/\*\.yml\)/), "deployment train must constrain manifest_path to .github/deployment-trains/")
 puts "release workflow tests passed"
 RUBY

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -10,7 +10,8 @@ ruby -ryaml - \
   "$ROOT/.github/workflows/oci-validation.yml" \
   "$ROOT/.github/workflows/merge-recovery-soak.yml" \
   "$ROOT/.github/workflows/ci.yml" \
-  "$ROOT/.github/workflows/deployment-train.yml" <<'RUBY'
+  "$ROOT/.github/workflows/deployment-train.yml" \
+  "$ROOT/.githooks/pre-push" <<'RUBY'
 def trigger(document)
   document["on"] || document[true]
 end
@@ -19,7 +20,7 @@ def fail_if(condition, message)
   abort(message) if condition
 end
 
-release_path, evidence_path, soakin_path, canary_path, oci_path, soak_path, ci_path, train_path = ARGV
+release_path, evidence_path, soakin_path, canary_path, oci_path, soak_path, ci_path, train_path, pre_push_path = ARGV
 release = YAML.load_file(release_path)
 evidence = YAML.load_file(evidence_path)
 soakin = YAML.load_file(soakin_path)
@@ -228,5 +229,16 @@ fail_if(!train_text.include?('gh workflow run ci.yml --ref "$DEFAULT_BRANCH"'), 
 fail_if(!train_text.include?('-f target_sha="$merge_sha" -f top_pull_request="$top"'), "deployment train must dispatch CI for the exact top merge")
 fail_if(!train_text.include?('/attempts/${run_attempt}/jobs'), "deployment train must read jobs from the selected run attempt")
 fail_if(!train_text.match?(/\.github\/deployment-trains\/\*\.yml\)/), "deployment train must constrain manifest_path to .github/deployment-trains/")
+pre_push_text = File.read(pre_push_path)
+[
+  "check-workflow-invariants.sh",
+  "test-ci-stack-gate.sh",
+  "test-release-train.sh",
+  "test-release-workflows.sh",
+].each do |script|
+  fail_if(!pre_push_text.include?(script), "pre-push must run #{script}")
+end
+fail_if(!pre_push_text.include?('pid_ci'), "pre-push must wait for the CI unit test suite")
+fail_if(!pre_push_text.include?('SKIP_CI_TESTS'), "pre-push must expose the CI unit test skip control")
 puts "release workflow tests passed"
 RUBY

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -194,6 +194,7 @@ fail_if(!ci_text.include?("ci-target-${{ github.run_attempt }}"), "CI must uploa
   fail_if(checkout&.dig("with", "ref") != "${{ needs.build_base.outputs.TARGET_SHA }}", "#{job_name} must check out the validated target SHA")
 end
 lint_steps = ci.dig("jobs", "lint", "steps")
+fail_if(lint_steps.none? { |step| step["run"].to_s.include?("test-pre-push-hook.sh") }, "Lint must test pre-push hook behavior")
 fail_if(lint_steps.none? { |step| step["run"].to_s.include?("test-ci-stack-gate.sh") }, "Lint must run CI stack gate tests")
 %w[integration_tests_amd64 integration_tests_arm64].each do |job_name|
   condition = ci.dig("jobs", job_name, "if").to_s

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -166,7 +166,9 @@ fail_if(!soak_text.match?(/docker pull --platform [^\n]*@\$\{amd64_digest\}/), "
 fail_if(!soak_text.match?(/Build node image\n\s+if: needs\.schedule_gate\.outputs\.candidate_tag == ''/m), "soak must skip the source build in candidate mode")
 ci = YAML.load_file(ci_path)
 ci_trigger = trigger(ci)
-fail_if(!ci_trigger.key?("pull_request") || !ci_trigger["pull_request"].nil?, "CI must run lightweight checks for every pull request base")
+pull_request_trigger = ci_trigger["pull_request"]
+fail_if(!pull_request_trigger.is_a?(Hash) || pull_request_trigger.key?("branches"), "CI must run checks for every pull request base")
+fail_if(!pull_request_trigger.fetch("types", []).include?("edited"), "CI must rerun when a stacked pull request base changes")
 fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "target_sha", "default") != "", "CI dispatch must accept an optional exact target SHA")
 fail_if(ci_trigger.dig("workflow_dispatch", "inputs", "top_pull_request", "default") != "", "CI dispatch must accept an optional top pull request")
 build_base = ci.dig("jobs", "build_base")
@@ -175,7 +177,9 @@ fail_if(build_base.dig("outputs", "MERGE_BASE_SHA") != "${{ steps.target.outputs
 fail_if(build_base.dig("outputs", "RUN_HEAVY") != "${{ steps.target.outputs.run_heavy }}", "Build Base must export the Heavy Pipeline decision")
 build_steps = build_base.fetch("steps")
 target_step = build_steps.find { |step| step["id"] == "target" }
-fail_if(!target_step&.dig("run")&.include?('compare/${base}...${merge_base}'), "CI must verify synthetic base ancestry")
+target_body = target_step&.dig("run").to_s
+fail_if(!target_body.include?('compare/${base}...${merge_base}'), "CI must verify synthetic base ancestry")
+fail_if(target_body.include?("stack-children"), "an open child pull request must not bypass protected-branch Heavy Pipeline")
 target_upload = build_steps.find { |step| step["name"] == "Upload exact target evidence" }
 fail_if(target_upload&.dig("uses").to_s !~ /\Aactions\/upload-artifact@[0-9a-f]{40}\z/, "CI target evidence upload must use a full action SHA")
 pipeline = ci.dig("jobs", "pipeline")
@@ -183,7 +187,6 @@ fail_if(pipeline["if"] != "needs.build_base.outputs.RUN_HEAVY == 'true'", "Heavy
 fail_if(pipeline.dig("with", "checkout_ref") != "${{ needs.build_base.outputs.TARGET_SHA }}", "Heavy Pipeline must check out the validated target SHA")
 ci_text = File.read(ci_path)
 fail_if(!ci_text.include?("merge_commit_sha"), "CI must validate the current pull request synthetic merge")
-fail_if(!ci_text.include?('-f base="$PR_HEAD_REF"'), "CI must detect open pull requests stacked on the current head")
 fail_if(!ci_text.include?('run_heavy=$run_heavy'), "CI must persist the Heavy Pipeline decision")
 fail_if(!ci_text.include?("ci-target-${{ github.run_attempt }}"), "CI must upload attempt-specific target evidence")
 %w[lint deny markdown_link_check test].each do |job_name|
@@ -196,6 +199,9 @@ fail_if(lint_steps.none? { |step| step["run"].to_s.include?("test-ci-stack-gate.
   condition = ci.dig("jobs", job_name, "if").to_s
   fail_if(!condition.include?("needs.pipeline.result != 'skipped'"), "#{job_name} must fail closed when Heavy Pipeline runs")
 end
+link_condition = ci.dig("jobs", "markdown_link_check", "if").to_s
+fail_if(!link_condition.include?("github.event_name != 'pull_request'"), "Markdown link checks must run outside pull requests")
+fail_if(!link_condition.include?("github.base_ref"), "Markdown link checks must limit pull-request bases")
 
 # Deployment train setup (Phase 5): manual, default-branch only, one job
 # whose only write permission is actions (the optional ci.yml dispatch), no
@@ -225,6 +231,10 @@ fail_if(!train_text.include?("release-train.sh validate-ci-evidence"), "deployme
 fail_if(train_text.scan("release-train.sh validate-stack").length != 2, "deployment train must validate the full stack before and after CI")
 fail_if(!train_text.include?("release-train.sh validate-current-stack"), "deployment train must compare the post-CI stack record")
 fail_if(!train_text.include?(".stack.members[].pull_request"), "deployment train must refresh every stack member after CI")
+fail_if(!train_text.include?("--paginate"), "deployment train must read every matching CI run page")
+fail_if(!train_text.include?("--jq '.workflow_runs[]'"), "deployment train must combine paginated CI runs")
+fail_if(!train_text.include?("-f event=workflow_dispatch"), "deployment train must filter CI runs by event")
+fail_if(!train_text.include?('-f branch="$DEFAULT_BRANCH"'), "deployment train must filter CI runs by trusted branch")
 fail_if(!train_text.include?('gh workflow run ci.yml --ref "$DEFAULT_BRANCH"'), "deployment train must dispatch the trusted default-branch CI workflow")
 fail_if(!train_text.include?('-f target_sha="$merge_sha" -f top_pull_request="$top"'), "deployment train must dispatch CI for the exact top merge")
 fail_if(!train_text.include?('/attempts/${run_attempt}/jobs'), "deployment train must read jobs from the selected run attempt")

--- a/.github/scripts/test-release-workflows.sh
+++ b/.github/scripts/test-release-workflows.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ruby -ryaml - \
-	"$ROOT/.github/workflows/release.yml" \
-	"$ROOT/.github/workflows/release-evidence.yml" \
-	"$ROOT/.github/workflows/soak-in.yml" \
-	"$ROOT/.github/workflows/canary-publish.yml" \
-	"$ROOT/.github/workflows/oci-validation.yml" \
-	"$ROOT/.github/workflows/merge-recovery-soak.yml" \
-	"$ROOT/.github/workflows/ci.yml" \
-	"$ROOT/.github/workflows/deployment-train.yml" <<'RUBY'
+  "$ROOT/.github/workflows/release.yml" \
+  "$ROOT/.github/workflows/release-evidence.yml" \
+  "$ROOT/.github/workflows/soak-in.yml" \
+  "$ROOT/.github/workflows/canary-publish.yml" \
+  "$ROOT/.github/workflows/oci-validation.yml" \
+  "$ROOT/.github/workflows/merge-recovery-soak.yml" \
+  "$ROOT/.github/workflows/ci.yml" \
+  "$ROOT/.github/workflows/deployment-train.yml" <<'RUBY'
 def trigger(document)
   document["on"] || document[true]
 end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,10 @@ jobs:
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/check-workflow-invariants.sh
 
+      - name: Verify pre-push hook
+        shell: bash -euo pipefail {0}
+        run: .github/scripts/test-pre-push-hook.sh
+
       - name: Verify stack CI gate
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/test-ci-stack-gate.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 run-name: ${{ inputs.target_sha != '' && format('CI [exact merge {0}]', inputs.target_sha) || github.event.pull_request.title || github.event.head_commit.message || github.ref_name }}
 
+# Exact-merge dispatch metadata names the trusted default branch. The ci-target artifact names the candidate merge that the trusted workflow tests.
+
 on:
   workflow_dispatch:
     inputs:
@@ -23,6 +25,7 @@ on:
     tags:
       - "**"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 # GitHub keeps one running item and one pending item in each concurrency group.
 # Issue #267 showed that one shared push group can discard a pending test run.
@@ -133,10 +136,7 @@ jobs:
             && [ "$PR_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ] \
             && { [ "$PR_BASE_REF" = dev ] || [ "$PR_BASE_REF" = master ]; } \
             && [ "$PR_HEAD_REF" != dev ] && [ "$PR_HEAD_REF" != master ]; then
-            children="$RUNNER_TEMP/stack-children.json"
-            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
-              -f state=open -f base="$PR_HEAD_REF" -f per_page=100 > "$children"
-            [ "$(jq 'length' "$children")" -gt 0 ] || run_heavy=true
+            run_heavy=true
           fi
           {
             echo "target_sha=$target"
@@ -406,6 +406,10 @@ jobs:
   markdown_link_check:
     name: Markdown Link Check
     needs: build_base
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(fromJSON('["dev", "master", "staging", "trying"]'), github.base_ref)
+      || startsWith(github.base_ref, 'feature/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,19 @@
 name: CI
+run-name: ${{ inputs.target_sha != '' && format('CI [exact merge {0}]', inputs.target_sha) || github.event.pull_request.title || github.event.head_commit.message || github.ref_name }}
 
 on:
   workflow_dispatch:
+    inputs:
+      target_sha:
+        description: Exact synthetic merge SHA for a Deployment Train
+        required: false
+        default: ""
+        type: string
+      top_pull_request:
+        description: Top pull request for target_sha
+        required: false
+        default: ""
+        type: string
   push:
     branches:
       - dev
@@ -11,12 +23,6 @@ on:
     tags:
       - "**"
   pull_request:
-    branches:
-      - dev
-      - master
-      - staging
-      - trying
-      - "feature/**"
 
 # GitHub keeps one running item and one pending item in each concurrency group.
 # Issue #267 showed that one shared push group can discard a pending test run.
@@ -24,8 +30,8 @@ on:
 # separate.
 # A newer PR head cancels only the obsolete run for that PR.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha != '' && format('exact-{0}', inputs.target_sha) || (github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.target_sha != '') }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -43,6 +49,9 @@ jobs:
     name: Build Base
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     if: >-
       !startsWith(github.event.head_commit.message, 'chore(release)')
       || startsWith(github.ref, 'refs/tags/')
@@ -50,10 +59,98 @@ jobs:
       VERSION: ${{ steps.env.outputs.VERSION }}
       BRANCH: ${{ steps.env.outputs.BRANCH }}
       SYSTEM_INTEGRATION_REF: ${{ steps.env.outputs.SYSTEM_INTEGRATION_REF }}
+      TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+      TOP_PULL_REQUEST: ${{ steps.target.outputs.top_pull_request }}
+      HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+      BASE_SHA: ${{ steps.target.outputs.base_sha }}
+      MERGE_BASE_SHA: ${{ steps.target.outputs.merge_base_sha }}
+      RUN_HEAVY: ${{ steps.target.outputs.run_heavy }}
     steps:
+      - name: Resolve source target
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_TARGET_SHA: ${{ inputs.target_sha }}
+          REQUESTED_TOP_PULL_REQUEST: ${{ inputs.top_pull_request }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          PR_BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+        shell: bash -euo pipefail {0}
+        run: |
+          target="$REQUESTED_TARGET_SHA"
+          top="$REQUESTED_TOP_PULL_REQUEST"
+          head=""
+          base=""
+          merge_base=""
+          if [ -z "$target" ] && [ -z "$top" ]; then
+            target="$GITHUB_SHA"
+            top=0
+          else
+            [[ "$target" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::target_sha must be a full commit SHA"; exit 1; }
+            [[ "$top" =~ ^[1-9][0-9]*$ ]] || { echo "::error::top_pull_request must be a positive integer"; exit 1; }
+            pull="$RUNNER_TEMP/top-pull.json"
+            commit="$RUNNER_TEMP/target-commit.json"
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${top}" > "$pull"
+            jq -e --arg repo "$GITHUB_REPOSITORY" '
+              .state == "open" and .head.repo.full_name == $repo' "$pull" >/dev/null || {
+              echo "::error::top pull request must be open and its head must be in ${GITHUB_REPOSITORY}"
+              exit 1
+            }
+            observed="$(jq -r '.merge_commit_sha // empty' "$pull")"
+            [ "$observed" = "$target" ] || {
+              echo "::error::pull request #${top} synthetic merge changed from ${target} to ${observed:-unavailable}"
+              exit 1
+            }
+            head="$(jq -r '.head.sha' "$pull")"
+            base="$(jq -r '.base.sha' "$pull")"
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${target}" > "$commit"
+            jq -e --arg merge "$target" --arg head "$head" '
+              .sha == $merge and (.parents | length == 2)
+              and (.parents[0].sha | type == "string" and test("^[0-9a-f]{40}$"))
+              and .parents[1].sha == $head' "$commit" >/dev/null || {
+              echo "::error::target_sha does not join the current top pull request head"
+              exit 1
+            }
+            merge_base="$(jq -r '.parents[0].sha' "$commit")"
+            relationship="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${base}...${merge_base}" --jq '.status')"
+            [ "$relationship" = ahead ] || [ "$relationship" = identical ] || {
+              echo "::error::current pull request base is not an ancestor of the synthetic merge base"
+              exit 1
+            }
+          fi
+          run_heavy=false
+          if [ "$EVENT_NAME" = workflow_dispatch ] && [ "$top" -gt 0 ]; then
+            run_heavy=true
+          elif [ "$EVENT_NAME" = push ] && {
+            [ "$EVENT_REF" = refs/heads/dev ] ||
+            [ "$EVENT_REF" = refs/heads/master ] ||
+            [[ "$EVENT_REF" == refs/tags/v* ]];
+          }; then
+            run_heavy=true
+          elif [ "$EVENT_NAME" = pull_request ] \
+            && [ "$PR_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ] \
+            && { [ "$PR_BASE_REF" = dev ] || [ "$PR_BASE_REF" = master ]; } \
+            && [ "$PR_HEAD_REF" != dev ] && [ "$PR_HEAD_REF" != master ]; then
+            children="$RUNNER_TEMP/stack-children.json"
+            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+              -f state=open -f base="$PR_HEAD_REF" -f per_page=100 > "$children"
+            [ "$(jq 'length' "$children")" -gt 0 ] || run_heavy=true
+          fi
+          {
+            echo "target_sha=$target"
+            echo "top_pull_request=$top"
+            echo "head_sha=$head"
+            echo "base_sha=$base"
+            echo "merge_base_sha=$merge_base"
+            echo "run_heavy=$run_heavy"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ steps.target.outputs.target_sha }}
           fetch-depth: 0
 
       - name: Initialize Environment
@@ -83,6 +180,44 @@ jobs:
           echo "SYSTEM_INTEGRATION_REF=$SYSTEM_INTEGRATION_REF" >> "$GITHUB_OUTPUT"
 
           echo "Version: $VERSION | Branch: $BRANCH"
+
+      - name: Write exact target evidence
+        if: inputs.target_sha != ''
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.target_sha }}
+          TOP_PULL_REQUEST: ${{ steps.target.outputs.top_pull_request }}
+          HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+          BASE_SHA: ${{ steps.target.outputs.base_sha }}
+          MERGE_BASE_SHA: ${{ steps.target.outputs.merge_base_sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        shell: bash -euo pipefail {0}
+        run: |
+          mkdir -p "$RUNNER_TEMP/ci-target"
+          jq -n --arg repo "$GITHUB_REPOSITORY" --arg target "$TARGET_SHA" \
+            --argjson top "$TOP_PULL_REQUEST" --arg head "$HEAD_SHA" --arg base "$BASE_SHA" \
+            --arg merge_base "$MERGE_BASE_SHA" --argjson run "$RUN_ID" --argjson attempt "$RUN_ATTEMPT" '{
+              schema_version: 1,
+              repository: $repo,
+              workflow: ".github/workflows/ci.yml",
+              event: "workflow_dispatch",
+              target_sha: $target,
+              top_pull_request: $top,
+              head_sha: $head,
+              base_sha: $base,
+              merge_base_sha: $merge_base,
+              run_id: $run,
+              run_attempt: $attempt
+            }' > "$RUNNER_TEMP/ci-target/ci-target.json"
+
+      - name: Upload exact target evidence
+        if: inputs.target_sha != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-target-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/ci-target/ci-target.json
+          retention-days: 90
+          if-no-files-found: error
 
       - name: Verify OCI/system-integration pin consistency
         shell: bash -euo pipefail {0}
@@ -138,6 +273,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.build_base.outputs.TARGET_SHA }}
 
       # Deliberately the first step and deliberately in this job. `Lint` is a
       # required status check on devProtect and masterProtect, so a violation
@@ -148,6 +285,10 @@ jobs:
       - name: Verify workflow security invariants
         shell: bash -euo pipefail {0}
         run: bash .github/scripts/check-workflow-invariants.sh
+
+      - name: Verify stack CI gate
+        shell: bash -euo pipefail {0}
+        run: bash .github/scripts/test-ci-stack-gate.sh
 
       - name: Verify soak schedule routing
         shell: bash -euo pipefail {0}
@@ -244,6 +385,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.build_base.outputs.TARGET_SHA }}
 
       - name: cargo-deny check
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -268,6 +411,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.build_base.outputs.TARGET_SHA }}
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8
@@ -302,7 +447,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.crate }})
-    needs: lint
+    needs: [build_base, lint]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -322,6 +467,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.build_base.outputs.TARGET_SHA }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -374,36 +521,15 @@ jobs:
 
   # Heavy pipeline (native Docker build -> ephemeral OCI runner launch ->
   # integration matrix -> smoke) lives in the reusable _integration-pipeline.yml.
-  # This call runs it for INTERNAL events only (pushes + same-repo PRs), which
-  # receive secrets normally and need no approval gate (gated: false). Fork PRs
-  # cannot get secrets on a `pull_request` event, so they skip this job and are
-  # served by ci-fork-pr.yml (pull_request_target, maintainer-gated) instead.
-  #
-  # Promotion PRs whose head is dev or master also skip: the push run on the
-  # identical commit already runs the identical
-  # pipeline, so the PR-event copy would only double OCI VM creations against
-  # the tenancy's daily limit. Required checks are commit-scoped — the push
-  # run's aggregator results land on the same SHA and gate the PR; the
-  # PR-side aggregators skip alongside (skipped = passing, same semantics the
-  # fork path relies on) and finish long before the push run's real results,
-  # so the real results are the latest and win.
   pipeline:
     name: Heavy Pipeline
-    needs: lint
+    needs: [build_base, lint]
     # A newer branch or PR head replaces obsolete heavy work. Version tags use
     # separate groups and run to completion. OCI launch remains globally locked.
     concurrency:
-      group: ci-heavy-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
+      group: ci-heavy-${{ github.event_name == 'workflow_dispatch' && inputs.target_sha != '' && format('exact-{0}', inputs.target_sha) || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref) }}
       cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    if: >-
-      (github.event_name == 'push'
-      && (github.ref == 'refs/heads/dev'
-      || github.ref == 'refs/heads/master'
-      || startsWith(github.ref, 'refs/tags/v')))
-      || (github.event_name == 'pull_request'
-      && contains(fromJSON('["dev", "master"]'), github.base_ref)
-      && github.event.pull_request.head.repo.fork == false
-      && !contains(fromJSON('["dev", "master"]'), github.event.pull_request.head.ref))
+    if: needs.build_base.outputs.RUN_HEAVY == 'true'
     # `secrets: inherit` is required here, not incidental. A called workflow's
     # jobs do not receive `secrets.*` merely by naming an environment — the
     # caller must pass secrets down. Removing this line made the launch job's
@@ -414,6 +540,7 @@ jobs:
     uses: ./.github/workflows/_integration-pipeline.yml
     with:
       gated: false
+      checkout_ref: ${{ needs.build_base.outputs.TARGET_SHA }}
     secrets: inherit
 
   # Per-arch aggregators. The branch ruleset requires status checks named
@@ -421,24 +548,12 @@ jobs:
   # pipeline's per-arch matrix jobs into one ruleset gate per arch. They use
   # `contains(...)` (not `startswith`) because reusable-workflow job names are
   # prefixed with the caller job id ("Heavy Pipeline / Integration Tests (...)").
-  # Internal-only: fork PRs get this check from ci-fork-pr.yml instead, so this
-  # one skips for them (a skipped required check is treated as passing).
-  # PRs from dev/master skip too, mirroring the pipeline job's dedupe condition.
   # Each gate checks only its two architecture slots. A failure in another
   # architecture does not change this gate's result.
   integration_tests_amd64:
     name: Integration Tests (amd64)
     needs: pipeline
-    if: >-
-      always()
-      && ((github.event_name == 'push'
-      && (github.ref == 'refs/heads/dev'
-      || github.ref == 'refs/heads/master'
-      || startsWith(github.ref, 'refs/tags/v')))
-      || (github.event_name == 'pull_request'
-      && contains(fromJSON('["dev", "master"]'), github.base_ref)
-      && github.event.pull_request.head.repo.fork == false
-      && !contains(fromJSON('["dev", "master"]'), github.event.pull_request.head.ref)))
+    if: always() && needs.pipeline.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -470,16 +585,7 @@ jobs:
   integration_tests_arm64:
     name: Integration Tests (arm64)
     needs: pipeline
-    if: >-
-      always()
-      && ((github.event_name == 'push'
-      && (github.ref == 'refs/heads/dev'
-      || github.ref == 'refs/heads/master'
-      || startsWith(github.ref, 'refs/tags/v')))
-      || (github.event_name == 'pull_request'
-      && contains(fromJSON('["dev", "master"]'), github.base_ref)
-      && github.event.pull_request.head.repo.fork == false
-      && !contains(fromJSON('["dev", "master"]'), github.event.pull_request.head.ref)))
+    if: always() && needs.pipeline.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
 
       - name: Upload exact target evidence
         if: inputs.target_sha != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-target-${{ github.run_attempt }}
           path: ${{ runner.temp }}/ci-target/ci-target.json

--- a/.github/workflows/deployment-train.yml
+++ b/.github/workflows/deployment-train.yml
@@ -331,9 +331,8 @@ jobs:
           if [ "$is_stack" = true ]; then
             ci-control/.github/scripts/release-train.sh validate-stack \
               "$manifest" "$current" "$current/train-record.json"
-            jq -e --slurpfile current "$current/train-record.json" '
-              {head_sha, integration_base_sha, base_sha, merge_base_sha, merge_sha, members}
-              == ($current[0] | {head_sha, integration_base_sha, base_sha, merge_base_sha, merge_sha, members})' "$record" >/dev/null
+            ci-control/.github/scripts/release-train.sh validate-current-stack \
+              "$record" "$current/train-record.json"
           else
             jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null
             ci-control/.github/scripts/release-train.sh validate-top-merge \

--- a/.github/workflows/deployment-train.yml
+++ b/.github/workflows/deployment-train.yml
@@ -280,8 +280,39 @@ jobs:
             "$target" "$RUNNER_TEMP/train/ci-jobs.json" "$merge_sha" "$top" "$head_sha" "$base_sha" \
             "$merge_base_sha" "$run_id" "$run_attempt" "$GITHUB_REPOSITORY"
           current="$RUNNER_TEMP/train/current"
+          manifest="$RUNNER_TEMP/train/manifest.json"
           mkdir -p "$current"
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${top}" > "$current/pull-$top.json"
+          is_stack="$(jq -r 'has("stack")' "$manifest")"
+          if [ "$is_stack" = true ]; then
+            members="$(jq -r '.stack.members[].pull_request' "$manifest")"
+            integration="$(jq -r '.stack.integration_branch' "$manifest")"
+          else
+            members="$top"
+            integration=""
+          fi
+          lower=""
+          while IFS= read -r n; do
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${n}" > "$current/pull-$n.json"
+            [ "$(jq -r '.head.repo.full_name // empty' "$current/pull-$n.json")" = "$GITHUB_REPOSITORY" ] || {
+              echo "::error::pull request #${n} head repository changed while exact-merge CI ran"
+              exit 1
+            }
+            upper="$(jq -r '.head.sha' "$current/pull-$n.json")"
+            if [ -n "$lower" ]; then
+              gh api "repos/${GITHUB_REPOSITORY}/compare/${lower}...${upper}" \
+                --jq '{status: .status}' > "$current/compare-$lower-$upper.json"
+            fi
+            if [ "$(jq -r '.merged // false' "$current/pull-$n.json")" = true ]; then
+              member_merge="$(jq -r '.merge_commit_sha' "$current/pull-$n.json")"
+              gh api "repos/${GITHUB_REPOSITORY}/commits/${member_merge}" \
+                --jq '{sha: .sha, parents: [.parents[] | {sha: .sha}]}' > "$current/merge-$n.json"
+              if [ -n "$integration" ]; then
+                gh api "repos/${GITHUB_REPOSITORY}/compare/${member_merge}...${integration}" \
+                  --jq '{status: .status}' > "$current/reach-$n.json"
+              fi
+            fi
+            lower="$upper"
+          done <<<"$members"
           current_merge="$(jq -r '.merge_commit_sha // empty' "$current/pull-$top.json")"
           [[ "$current_merge" =~ ^[0-9a-f]{40}$ ]] || {
             echo "::error::top pull request #${top} no longer has a synthetic merge"
@@ -293,26 +324,28 @@ jobs:
           current_merge_base="$(jq -r '.parents[0].sha' "$current/top-merge.json")"
           gh api "repos/${GITHUB_REPOSITORY}/compare/${current_base}...${current_merge_base}" \
             --jq '{status: .status}' > "$current/top-base.json"
-          root="$(jq -r '.stack.members[0].pull_request // .pull_request' "$RUNNER_TEMP/train/manifest.json")"
-          if [ "$root" != "$top" ]; then
-            gh api "repos/${GITHUB_REPOSITORY}/pulls/${root}" > "$current/pull-$root.json"
-          fi
+          root="$(jq -r '.stack.members[0].pull_request // .pull_request' "$manifest")"
           current_integration_base="$(jq -r '.base.sha' "$current/pull-$root.json")"
           gh api "repos/${GITHUB_REPOSITORY}/compare/${current_integration_base}...${current_merge_base}" \
             --jq '{status: .status}' > "$current/integration-base.json"
-          jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null || {
-            echo "::error::current top synthetic merge does not contain the integration base"
-            exit 1
-          }
-          ci-control/.github/scripts/release-train.sh validate-top-merge \
-            "$RUNNER_TEMP/train/manifest.json" "$current" "$current/top-record.json"
-          jq -e --arg integration_base "$current_integration_base" --slurpfile current "$current/top-record.json" '
-            .head_sha == $current[0].head_sha
-            and .base_sha == $current[0].base_sha
-            and .integration_base_sha == $integration_base
-            and .merge_base_sha == $current[0].merge_base_sha
-            and .merge_sha == $current[0].merge_sha' "$record" >/dev/null || {
-            echo "::error::top pull request changed while exact-merge CI ran"
+          if [ "$is_stack" = true ]; then
+            ci-control/.github/scripts/release-train.sh validate-stack \
+              "$manifest" "$current" "$current/train-record.json"
+            jq -e --slurpfile current "$current/train-record.json" '
+              {head_sha, integration_base_sha, base_sha, merge_base_sha, merge_sha, members}
+              == ($current[0] | {head_sha, integration_base_sha, base_sha, merge_base_sha, merge_sha, members})' "$record" >/dev/null
+          else
+            jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null
+            ci-control/.github/scripts/release-train.sh validate-top-merge \
+              "$manifest" "$current" "$current/top-record.json"
+            jq -e --arg integration_base "$current_integration_base" --slurpfile current "$current/top-record.json" '
+              .head_sha == $current[0].head_sha
+              and .base_sha == $current[0].base_sha
+              and .integration_base_sha == $integration_base
+              and .merge_base_sha == $current[0].merge_base_sha
+              and .merge_sha == $current[0].merge_sha' "$record" >/dev/null
+          fi || {
+            echo "::error::stack changed while exact-merge CI ran"
             exit 1
           }
           jq --arg target "$merge_sha" --argjson run "$(jq '{run_id: .id, run_number: .run_number, run_attempt: .run_attempt, event: .event}' "$RUNNER_TEMP/train/ci-run.json")" \

--- a/.github/workflows/deployment-train.yml
+++ b/.github/workflows/deployment-train.yml
@@ -167,6 +167,13 @@ jobs:
             echo "::error::pull request #${n} is neither open nor merged"
             exit 1
           }
+          # A single train merges its pull request directly into base_branch,
+          # so the observed base ref must be the reviewed base_branch.
+          base_branch="$(jq -r '.base_branch' "$manifest")"
+          jq -e --arg base_branch "$base_branch" '.base.ref == $base_branch' "$pull" >/dev/null || {
+            echo "::error::pull request #${n} targets $(jq -r '.base.ref' "$pull"), not the manifest base_branch ${base_branch}"
+            exit 1
+          }
           ci-control/.github/scripts/release-train.sh validate-top-merge \
             "$manifest" "$RUNNER_TEMP/train/inputs" "$RUNNER_TEMP/train/top-record.json"
           jq --slurpfile top "$RUNNER_TEMP/train/top-record.json" \
@@ -233,6 +240,16 @@ jobs:
               echo "::error::no successful exact-merge ci.yml run exists for ${merge_sha} and wait_for_ci is false"
               exit 1
             }
+            # The dispatched run executes the workflow at the live tip of the
+            # default branch, while the trust predicate binds evidence to the
+            # control SHA this job checked out. When the tip moved, the run
+            # could never match, so fail fast with a retry message instead of
+            # polling for an impossible match.
+            tip="$(gh api "repos/${GITHUB_REPOSITORY}/branches/${DEFAULT_BRANCH}" --jq '.commit.sha')"
+            [ "$tip" = "$control_sha" ] || {
+              echo "::error::${DEFAULT_BRANCH} moved from ${control_sha} to ${tip} after setup checked out its controls; re-run train setup"
+              exit 1
+            }
             before="$(date -u +%s)"
             gh workflow run ci.yml --ref "$DEFAULT_BRANCH" \
               -f target_sha="$merge_sha" -f top_pull_request="$top"
@@ -249,6 +266,17 @@ jobs:
                   and ((.created_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $before))]
                 | sort_by(.run_number) | last | .id // empty' "$RUNNER_TEMP/train/ci-runs.json")"
               [ -n "$run_id" ] && break
+              moved="$(jq -r --arg title "$title" --arg branch "$DEFAULT_BRANCH" --arg control "$control_sha" --argjson before "$before" '
+                [.workflow_runs[] | select(.display_title == $title
+                  and .event == "workflow_dispatch"
+                  and .head_branch == $branch
+                  and .head_sha != $control
+                  and ((.created_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $before))]
+                | length' "$RUNNER_TEMP/train/ci-runs.json")"
+              [ "$moved" = 0 ] || {
+                echo "::error::the dispatched exact-merge run started from a different ${DEFAULT_BRANCH} tip; ${DEFAULT_BRANCH} moved during setup — re-run train setup"
+                exit 1
+              }
             done
             [ -n "$run_id" ] || { echo "::error::exact-merge ci.yml did not start"; exit 1; }
             gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
@@ -332,22 +360,52 @@ jobs:
           current_integration_base="$(jq -r '.base.sha' "$current/pull-$root.json")"
           gh api "repos/${GITHUB_REPOSITORY}/compare/${current_integration_base}...${current_merge_base}" \
             --jq '{status: .status}' > "$current/integration-base.json"
+          # Each validation below carries its own handler. A compound
+          # `if ... fi || { ... }` would suppress `set -e` inside both
+          # branches, so a failed early check could be masked by a later
+          # passing one.
           if [ "$is_stack" = true ]; then
             ci-control/.github/scripts/release-train.sh validate-stack \
-              "$manifest" "$current" "$current/train-record.json"
-            ci-control/.github/scripts/release-train.sh validate-current-stack \
-              "$record" "$current/train-record.json"
+              "$manifest" "$current" "$current/train-record.json" || {
+              echo "::error::stack changed while exact-merge CI ran"
+              exit 1
+            }
           else
-            jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null
+            # Rebuild the complete single-train record from the current
+            # documents — the same construction as setup — so PR state,
+            # base ref, merged flag, and every SHA are compared, not only
+            # the merge chain.
+            jq -e '.state == "open" or .merged == true' "$current/pull-$top.json" >/dev/null || {
+              echo "::error::pull request #${top} is neither open nor merged after exact-merge CI"
+              exit 1
+            }
+            jq -e --arg base_branch "$(jq -r '.base_branch' "$manifest")" \
+              '.base.ref == $base_branch' "$current/pull-$top.json" >/dev/null || {
+              echo "::error::pull request #${top} was retargeted while exact-merge CI ran"
+              exit 1
+            }
+            jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null || {
+              echo "::error::integration base is no longer an ancestor of the synthetic base"
+              exit 1
+            }
             ci-control/.github/scripts/release-train.sh validate-top-merge \
-              "$manifest" "$current" "$current/top-record.json"
-            jq -e --arg integration_base "$current_integration_base" --slurpfile current "$current/top-record.json" '
-              .head_sha == $current[0].head_sha
-              and .base_sha == $current[0].base_sha
-              and .integration_base_sha == $integration_base
-              and .merge_base_sha == $current[0].merge_base_sha
-              and .merge_sha == $current[0].merge_sha' "$record" >/dev/null
-          fi || {
+              "$manifest" "$current" "$current/top-record.json" || {
+              echo "::error::top synthetic merge changed while exact-merge CI ran"
+              exit 1
+            }
+            jq --slurpfile top "$current/top-record.json" \
+              --arg base "$(jq -r '.base.ref' "$current/pull-$top.json")" \
+              --argjson merged "$(jq -r '.merged // false' "$current/pull-$top.json")" '
+              {schema_version: 1, train_id: .id, state: .state, target_version: .target_version,
+               publishing: .publishing, base_branch: .base_branch, integration_branch: null,
+               head_sha: .head_sha, head_pull_request: .pull_request,
+               base_sha: $top[0].base_sha, integration_base_sha: $top[0].base_sha,
+               merge_base_sha: $top[0].merge_base_sha, merge_sha: $top[0].merge_sha,
+               members: [{pull_request: .pull_request, head_sha: .head_sha, base: $base, merged: $merged}],
+               required_gates: .required_gates}' "$manifest" > "$current/train-record.json"
+          fi
+          ci-control/.github/scripts/release-train.sh validate-current-stack \
+            "$record" "$current/train-record.json" || {
             echo "::error::stack changed while exact-merge CI ran"
             exit 1
           }

--- a/.github/workflows/deployment-train.yml
+++ b/.github/workflows/deployment-train.yml
@@ -218,7 +218,11 @@ jobs:
           control_sha="$(git -C ci-control rev-parse HEAD)"
           title="CI [exact merge ${merge_sha}]"
           list_runs() {
-            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?per_page=100" \
+            gh api --method GET --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+              -f event=workflow_dispatch -f branch="$DEFAULT_BRANCH" -f per_page=100 \
+              --jq '.workflow_runs[]' \
+              | jq -s '{workflow_runs: .}' \
               > "$RUNNER_TEMP/train/ci-runs.json"
           }
           list_runs

--- a/.github/workflows/deployment-train.yml
+++ b/.github/workflows/deployment-train.yml
@@ -3,7 +3,7 @@ name: Deployment Train
 # Train setup (docs/release-process.md section 13.2). Validates a reviewed
 # manifest, verifies the member chain of a stack through the GitHub API,
 # verifies the source version, and secures a successful full CI run for the
-# exact head SHA. The train record it produces is the reviewed intent plus
+# exact top synthetic merge SHA. The train record is the reviewed intent plus
 # every member head observed at setup; later re-validation and promotion
 # compare against it.
 #
@@ -23,7 +23,7 @@ on:
         required: true
         type: string
       wait_for_ci:
-        description: When no successful ci.yml run exists for head_sha, dispatch one and wait for it (up to the job timeout)
+        description: When no successful exact-merge ci.yml run exists, dispatch one and wait for it
         required: false
         default: true
         type: boolean
@@ -47,6 +47,7 @@ jobs:
     outputs:
       train_id: ${{ steps.manifest.outputs.train_id }}
       head_sha: ${{ steps.manifest.outputs.head_sha }}
+      merge_sha: ${{ steps.exact.outputs.merge_sha }}
       publishing: ${{ steps.manifest.outputs.publishing }}
       ci_run_id: ${{ steps.ci.outputs.ci_run_id }}
     steps:
@@ -125,6 +126,27 @@ jobs:
             fi
             lower="$upper"
           done <<<"$members"
+          top="$(jq -r '.pull_request' "$manifest")"
+          for _ in $(seq 1 10); do
+            merge_sha="$(jq -r '.merge_commit_sha // empty' "$inputs/pull-$top.json")"
+            [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]] && break
+            sleep 2
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${top}" > "$inputs/pull-$top.json"
+          done
+          [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::top pull request #${top} has no available synthetic merge commit"
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${merge_sha}" \
+            --jq '{sha: .sha, parents: [.parents[] | {sha: .sha}]}' > "$inputs/top-merge.json"
+          base_sha="$(jq -r '.base.sha' "$inputs/pull-$top.json")"
+          merge_base_sha="$(jq -r '.parents[0].sha' "$inputs/top-merge.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/compare/${base_sha}...${merge_base_sha}" \
+            --jq '{status: .status}' > "$inputs/top-base.json"
+          root="$(jq -r '.stack.members[0].pull_request // .pull_request' "$manifest")"
+          integration_base_sha="$(jq -r '.base.sha' "$inputs/pull-$root.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/compare/${integration_base_sha}...${merge_base_sha}" \
+            --jq '{status: .status}' > "$inputs/integration-base.json"
           ls -1 "$inputs"
 
       - name: Verify the stack chain
@@ -140,27 +162,33 @@ jobs:
         run: |
           manifest="$RUNNER_TEMP/train/manifest.json"
           n="$(jq -r '.pull_request' "$manifest")"
-          head="$(jq -r '.head.sha' "$RUNNER_TEMP/train/inputs/pull-$n.json")"
-          [ "$head" = "$(jq -r '.head_sha' "$manifest")" ] || {
-            echo "::error::pull request #${n} head ${head} differs from manifest head_sha"
-            exit 1
-          }
-          jq -e '.state == "open" or .merged == true' "$RUNNER_TEMP/train/inputs/pull-$n.json" >/dev/null || {
+          pull="$RUNNER_TEMP/train/inputs/pull-$n.json"
+          jq -e '.state == "open" or .merged == true' "$pull" >/dev/null || {
             echo "::error::pull request #${n} is neither open nor merged"
             exit 1
           }
-          jq --arg head "$head" --arg base "$(jq -r '.base.ref' "$RUNNER_TEMP/train/inputs/pull-$n.json")" \
-            --argjson merged "$(jq -r '.merged' "$RUNNER_TEMP/train/inputs/pull-$n.json")" '
+          ci-control/.github/scripts/release-train.sh validate-top-merge \
+            "$manifest" "$RUNNER_TEMP/train/inputs" "$RUNNER_TEMP/train/top-record.json"
+          jq --slurpfile top "$RUNNER_TEMP/train/top-record.json" \
+            --arg base "$(jq -r '.base.ref' "$pull")" \
+            --argjson merged "$(jq -r '.merged' "$pull")" '
             {schema_version: 1, train_id: .id, state: .state, target_version: .target_version,
              publishing: .publishing, base_branch: .base_branch, integration_branch: null,
              head_sha: .head_sha, head_pull_request: .pull_request,
-             members: [{pull_request: .pull_request, head_sha: $head, base: $base, merged: $merged}],
+             base_sha: $top[0].base_sha, integration_base_sha: $top[0].base_sha,
+             merge_base_sha: $top[0].merge_base_sha, merge_sha: $top[0].merge_sha,
+             members: [{pull_request: .pull_request, head_sha: .head_sha, base: $base, merged: $merged}],
              required_gates: .required_gates}' "$manifest" > "$RUNNER_TEMP/train/train-record.json"
 
-      - name: Checkout exact head source
+      - name: Read exact merge
+        id: exact
+        shell: bash -euo pipefail {0}
+        run: echo "merge_sha=$(jq -r '.merge_sha' "$RUNNER_TEMP/train/train-record.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact merge source
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
-          ref: ${{ steps.manifest.outputs.head_sha }}
+          ref: ${{ steps.exact.outputs.merge_sha }}
           path: head
           fetch-depth: 0
           persist-credentials: false
@@ -172,48 +200,124 @@ jobs:
           ci-control/.github/scripts/release-train.sh validate-version \
             "$RUNNER_TEMP/train/manifest.json" head ci-control/.github/deployment-trains
 
-      - name: Secure a successful CI run for the head
+      - name: Secure exact-merge CI evidence
         id: ci
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ steps.manifest.outputs.head_sha }}
           WAIT_FOR_CI: ${{ inputs.wait_for_ci }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         shell: bash -euo pipefail {0}
         run: |
+          record="$RUNNER_TEMP/train/train-record.json"
+          merge_sha="$(jq -r '.merge_sha' "$record")"
+          top="$(jq -r '.head_pull_request' "$record")"
+          head_sha="$(jq -r '.head_sha' "$record")"
+          base_sha="$(jq -r '.base_sha' "$record")"
+          integration_base_sha="$(jq -r '.integration_base_sha' "$record")"
+          merge_base_sha="$(jq -r '.merge_base_sha' "$record")"
+          control_sha="$(git -C ci-control rev-parse HEAD)"
+          title="CI [exact merge ${merge_sha}]"
           list_runs() {
-            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${HEAD_SHA}&per_page=50" \
+            gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?per_page=100" \
               > "$RUNNER_TEMP/train/ci-runs.json"
           }
           list_runs
-          run_id="$(ci-control/.github/scripts/release-train.sh plan-ci "$RUNNER_TEMP/train/ci-runs.json" "$HEAD_SHA" "$GITHUB_REPOSITORY")"
-          if [ "$run_id" = dispatch ]; then
-            [ "$WAIT_FOR_CI" = true ] || { echo "::error::no successful ci.yml run exists for ${HEAD_SHA} and wait_for_ci is false"; exit 1; }
-            # workflow_dispatch needs a ref. The top member's branch is the
-            # ref; the run's head_sha is then checked against the manifest so
-            # a branch that moved after setup cannot substitute its tip.
-            top="$(jq -r '.head_pull_request' "$RUNNER_TEMP/train/train-record.json")"
-            ref="$(jq -r '.head.ref' "$RUNNER_TEMP/train/inputs/pull-$top.json")"
+          decision="$(ci-control/.github/scripts/release-train.sh plan-ci \
+            "$RUNNER_TEMP/train/ci-runs.json" "$merge_sha" "$GITHUB_REPOSITORY" "$DEFAULT_BRANCH" "$control_sha")"
+          if [ "$decision" = dispatch ]; then
+            [ "$WAIT_FOR_CI" = true ] || {
+              echo "::error::no successful exact-merge ci.yml run exists for ${merge_sha} and wait_for_ci is false"
+              exit 1
+            }
             before="$(date -u +%s)"
-            gh workflow run ci.yml --ref "$ref"
-            echo "Dispatched ci.yml on ${ref}; waiting for a run at ${HEAD_SHA}."
+            gh workflow run ci.yml --ref "$DEFAULT_BRANCH" \
+              -f target_sha="$merge_sha" -f top_pull_request="$top"
+            echo "Dispatched trusted ci.yml for exact merge ${merge_sha}."
+            run_id=""
             for _ in $(seq 1 30); do
               sleep 20
               list_runs
-              run_id="$(jq -r --arg sha "$HEAD_SHA" --argjson before "$before" '
-                [.workflow_runs[] | select(.head_sha == $sha and .event == "workflow_dispatch"
+              run_id="$(jq -r --arg title "$title" --arg branch "$DEFAULT_BRANCH" --arg control "$control_sha" --argjson before "$before" '
+                [.workflow_runs[] | select(.display_title == $title
+                  and .event == "workflow_dispatch"
+                  and .head_branch == $branch
+                  and .head_sha == $control
                   and ((.created_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $before))]
                 | sort_by(.run_number) | last | .id // empty' "$RUNNER_TEMP/train/ci-runs.json")"
               [ -n "$run_id" ] && break
             done
-            [ -n "$run_id" ] || { echo "::error::ci.yml did not start at ${HEAD_SHA} on ${ref}; the branch may have moved"; exit 1; }
-            gh run watch "$run_id" --exit-status
+            [ -n "$run_id" ] || { echo "::error::exact-merge ci.yml did not start"; exit 1; }
+            gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          elif [[ "$decision" == wait:* ]]; then
+            [ "$WAIT_FOR_CI" = true ] || {
+              echo "::error::exact-merge ci.yml run ${decision#wait:} is still active and wait_for_ci is false"
+              exit 1
+            }
+            run_id="${decision#wait:}"
+            gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
+          else
+            run_id="$decision"
           fi
           gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" > "$RUNNER_TEMP/train/ci-run.json"
-          jq -e --arg sha "$HEAD_SHA" '.head_sha == $sha and .conclusion == "success" and .path == ".github/workflows/ci.yml"' \
-            "$RUNNER_TEMP/train/ci-run.json" >/dev/null || { echo "::error::run ${run_id} is not a successful ci.yml run at ${HEAD_SHA}"; exit 1; }
-          jq --argjson run "$(jq '{run_id: .id, run_number: .run_number, run_attempt: .run_attempt, event: .event}' "$RUNNER_TEMP/train/ci-run.json")" \
-            '. + {ci: $run}' "$RUNNER_TEMP/train/train-record.json" > "$RUNNER_TEMP/train/train-record.with-ci.json"
-          mv "$RUNNER_TEMP/train/train-record.with-ci.json" "$RUNNER_TEMP/train/train-record.json"
+          run_attempt="$(jq -r '.run_attempt' "$RUNNER_TEMP/train/ci-run.json")"
+          jq -e --arg title "$title" --arg branch "$DEFAULT_BRANCH" --arg control "$control_sha" '
+            .display_title == $title
+            and .head_branch == $branch
+            and .head_sha == $control
+            and .event == "workflow_dispatch"
+            and .conclusion == "success"
+            and .path == ".github/workflows/ci.yml"' "$RUNNER_TEMP/train/ci-run.json" >/dev/null || {
+            echo "::error::run ${run_id} is not successful trusted CI evidence for ${merge_sha}"
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/attempts/${run_attempt}/jobs?per_page=100" \
+            > "$RUNNER_TEMP/train/ci-jobs.json"
+          rm -rf "$RUNNER_TEMP/train/ci-target"
+          gh run download "$run_id" --repo "$GITHUB_REPOSITORY" \
+            --name "ci-target-${run_attempt}" --dir "$RUNNER_TEMP/train/ci-target"
+          target="$RUNNER_TEMP/train/ci-target/ci-target.json"
+          ci-control/.github/scripts/release-train.sh validate-ci-evidence \
+            "$target" "$RUNNER_TEMP/train/ci-jobs.json" "$merge_sha" "$top" "$head_sha" "$base_sha" \
+            "$merge_base_sha" "$run_id" "$run_attempt" "$GITHUB_REPOSITORY"
+          current="$RUNNER_TEMP/train/current"
+          mkdir -p "$current"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${top}" > "$current/pull-$top.json"
+          current_merge="$(jq -r '.merge_commit_sha // empty' "$current/pull-$top.json")"
+          [[ "$current_merge" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::top pull request #${top} no longer has a synthetic merge"
+            exit 1
+          }
+          gh api "repos/${GITHUB_REPOSITORY}/commits/${current_merge}" \
+            --jq '{sha: .sha, parents: [.parents[] | {sha: .sha}]}' > "$current/top-merge.json"
+          current_base="$(jq -r '.base.sha' "$current/pull-$top.json")"
+          current_merge_base="$(jq -r '.parents[0].sha' "$current/top-merge.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/compare/${current_base}...${current_merge_base}" \
+            --jq '{status: .status}' > "$current/top-base.json"
+          root="$(jq -r '.stack.members[0].pull_request // .pull_request' "$RUNNER_TEMP/train/manifest.json")"
+          if [ "$root" != "$top" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${root}" > "$current/pull-$root.json"
+          fi
+          current_integration_base="$(jq -r '.base.sha' "$current/pull-$root.json")"
+          gh api "repos/${GITHUB_REPOSITORY}/compare/${current_integration_base}...${current_merge_base}" \
+            --jq '{status: .status}' > "$current/integration-base.json"
+          jq -e '.status == "ahead" or .status == "identical"' "$current/integration-base.json" >/dev/null || {
+            echo "::error::current top synthetic merge does not contain the integration base"
+            exit 1
+          }
+          ci-control/.github/scripts/release-train.sh validate-top-merge \
+            "$RUNNER_TEMP/train/manifest.json" "$current" "$current/top-record.json"
+          jq -e --arg integration_base "$current_integration_base" --slurpfile current "$current/top-record.json" '
+            .head_sha == $current[0].head_sha
+            and .base_sha == $current[0].base_sha
+            and .integration_base_sha == $integration_base
+            and .merge_base_sha == $current[0].merge_base_sha
+            and .merge_sha == $current[0].merge_sha' "$record" >/dev/null || {
+            echo "::error::top pull request changed while exact-merge CI ran"
+            exit 1
+          }
+          jq --arg target "$merge_sha" --argjson run "$(jq '{run_id: .id, run_number: .run_number, run_attempt: .run_attempt, event: .event}' "$RUNNER_TEMP/train/ci-run.json")" \
+            '. + {ci: ($run + {target_sha: $target})}' "$record" > "$RUNNER_TEMP/train/train-record.with-ci.json"
+          mv "$RUNNER_TEMP/train/train-record.with-ci.json" "$record"
           echo "ci_run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Upload train record

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -12,7 +12,7 @@ This repository is built with Cargo, Docker, and system packages only.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source ~/.cargo/env
 
-brew install protobuf openssl pkg-config lmdb just grpcurl
+brew install protobuf openssl pkg-config lmdb just grpcurl ruby jq
 ```
 
 Optional:
@@ -35,7 +35,9 @@ sudo apt-get install -y \
   libssl-dev \
   liblmdb-dev \
   build-essential \
-  gcc
+  gcc \
+  ruby \
+  jq
 
 cargo install just
 ```
@@ -58,7 +60,9 @@ sudo dnf install -y \
   pkg-config \
   openssl-devel \
   lmdb-devel \
-  gcc
+  gcc \
+  ruby \
+  jq
 
 cargo install just
 ```
@@ -73,10 +77,10 @@ Install hooks after cloning:
 
 This sets `core.hooksPath` to `.githooks/`, which provides:
 
-| Hook | Runs | Checks |
-|------|------|--------|
-| `pre-commit` | On every commit | `cargo fmt --check`, `cargo clippy -D warnings` |
-| `pre-push` | On every push | `cargo clippy`, `cargo test --release` |
+| Hook         | Runs            | Checks                                                         |
+|--------------|-----------------|----------------------------------------------------------------|
+| `pre-commit` | On every commit | `cargo fmt --check`, `cargo clippy -D warnings`                 |
+| `pre-push`   | On every push   | CI script tests, `cargo clippy`, `cargo test --release`         |
 
 Both hooks skip automatically in CI environments.
 
@@ -89,7 +93,8 @@ SKIP_CLIPPY=1 git commit -m "wip"
 
 # Push with skips
 QUICK=1 git push                           # Debug-mode tests (faster compile)
-SKIP_TESTS=1 git push                      # Skip tests entirely
+SKIP_TESTS=1 git push                      # Skip Cargo tests
+SKIP_CI_TESTS=1 git push                   # Skip CI script tests
 TEST_CRATES="casper rholang" git push      # Test specific crates only
 TEST_TIMEOUT=300 git push                  # Adjust timeout
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -82,7 +82,7 @@ This sets `core.hooksPath` to `.githooks/`, which provides:
 | `pre-commit` | On every commit | `cargo fmt --check`, `cargo clippy -D warnings`                 |
 | `pre-push`   | On every push   | CI script tests, `cargo clippy`, `cargo test --release`         |
 
-Both hooks skip automatically in CI environments.
+Both hooks skip automatically in CI environments. The pre-push hook gives Casper tests 1800 seconds and gives other commands 600 seconds.
 
 ### Hook Options
 
@@ -96,7 +96,8 @@ QUICK=1 git push                           # Debug-mode tests (faster compile)
 SKIP_TESTS=1 git push                      # Skip Cargo tests
 SKIP_CI_TESTS=1 git push                   # Skip CI script tests
 TEST_CRATES="casper rholang" git push      # Test specific crates only
-TEST_TIMEOUT=300 git push                  # Adjust timeout
+TEST_TIMEOUT=900 git push                  # Adjust the general timeout
+CASPER_TEST_TIMEOUT=2400 git push          # Adjust the Casper timeout
 
 # Bypass entirely (not recommended)
 git commit --no-verify

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Ubuntu or Debian:
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 sudo apt-get update
-sudo apt-get install -y protobuf-compiler libprotobuf-dev pkg-config libssl-dev liblmdb-dev build-essential gcc
+sudo apt-get install -y protobuf-compiler libprotobuf-dev pkg-config libssl-dev liblmdb-dev build-essential gcc ruby jq
 cargo install just
 ```
 
@@ -107,7 +107,7 @@ cargo install cargo-deny --locked   # one-time, required by the pre-commit deny 
 | Hook | When | Checks |
 | --- | --- | --- |
 | `pre-commit` | Every commit | `cargo fmt --check`, `cargo clippy -D warnings`, `cargo deny check` |
-| `pre-push` | Every push | `cargo clippy` (re-check), `cargo test --release` (per-crate) |
+| `pre-push` | Every push | CI script tests, `cargo clippy`, `cargo test --release` (per-crate) |
 
 Both hooks auto-skip in CI environments (the same gates run server-side in `.github/workflows/ci.yml`).
 
@@ -116,7 +116,7 @@ Both hooks auto-skip in CI environments (the same gates run server-side in `.git
 - All three pre-commit checks (fmt, clippy, deny) must pass.
 - The pre-push test suite must pass.
 - Do **not** use `git commit --no-verify` or `git push --no-verify`. The same checks run in CI; bypassing locally only defers the failure.
-- The `SKIP_FMT` / `SKIP_CLIPPY` / `SKIP_DENY` / `SKIP_TESTS` / `QUICK` / `TEST_CRATES` env-var skips are for local in-progress experimentation only. Every commit and push that reaches the remote must pass without skips.
+- The `SKIP_FMT` / `SKIP_CLIPPY` / `SKIP_DENY` / `SKIP_TESTS` / `SKIP_CI_TESTS` / `QUICK` / `TEST_CRATES` env-var skips are for local experiments only. Every remote commit must pass without skips.
 
 See [DEVELOPER.md](DEVELOPER.md#git-hooks) for the full skip-flag reference and `setup-hooks.sh --status` / `--remove` management commands.
 

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -1,7 +1,7 @@
 ---
 doc_type: backlog
 version: "1.1"
-last_updated: 2026-08-13
+last_updated: 2026-08-24
 ---
 
 # Backlog
@@ -66,6 +66,38 @@ depth — either a node-side test under a fixed burst-deploy schedule
 system-integration harness test with a fixed seed/schedule — so the soak
 stops being the only detector. The 45s assertion itself lives in
 system-integration's `test_load.py`; node-side work belongs in `casper`.
+
+---
+
+#### BACKLOG-TD-002: Load-sensitive wall-clock thresholds in local test guards
+
+```yaml
+---
+backlog_id: BACKLOG-TD-002
+title: "Make wall-clock-threshold tests robust to a loaded host"
+category: technical_debt
+priority: p3
+added_at: 2026-08-24
+blocked_by: none
+repo_scope: rspace++ tests and .github/scripts test harnesses
+---
+```
+
+**Evidence:** On 2026-08-24 the pre-push gate failed on
+`concurrent_rspace_test::soft_checkpoint_cost_does_not_scale_with_accumulated_store_size`
+at a 9.4x time ratio against the fixed 8x threshold, while the parallel
+release-mode suite loaded the host. The same test passed in isolation in
+0.04s. The threshold guards the issue-43 O(store-size)
+`HotStore::snapshot()` regression, so the guard itself is load-sensitive,
+not wrong. The 2026-08-24 multi-agent review of PR #334 flagged the same
+class in `test-pre-push-hook.sh` (timing-based assertions on loaded CI
+runners).
+
+**Direction:** Replace fixed wall-clock ratios with a load-robust signal.
+Options: repeat the measurement N times and take the minimum, compare
+against a same-run baseline measured under identical load, raise the
+ratio only under detected contention, or count operations instead of
+time. Keep the regression sensitivity (100x store must not cost ~100x).
 
 ### Feature Ideas
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -410,7 +410,11 @@ Automation records live state outside Git. The manifest records reviewed intent 
 
 #### 13.1.1 Stack manifests
 
-A stack train releases a set of stacked pull requests as one candidate. The candidate is the head of the top pull request. The top branch contains every lower branch, so full CI and every exact-SHA gate on that one SHA test the whole stack.
+A stack train releases a set of stacked pull requests as one candidate. The manifest identifies the head of the top pull request.
+
+Setup derives the current top synthetic merge. This merge contains the complete stack and the current synthetic base chain.
+
+GitHub can use the lower pull request synthetic merge as the first parent. Setup records this parent and the logical base SHA.
 
 A stack manifest uses `schema_version: 2` and adds a `stack` block:
 
@@ -429,6 +433,7 @@ stack:
     - pull_request: 299
     - pull_request: 312
     - pull_request: 319
+    - pull_request: 331
     - pull_request: 311
 required_gates: []
 ```
@@ -449,13 +454,21 @@ The setup workflow performs these actions. Steps marked *stack* apply only to a 
 
 1. Load the manifest from the default branch.
 2. Validate the schema and train identifier.
-3. Verify the pull request and exact head SHA. For a stack, `pull_request` and `head_sha` are the top member.
+3. Verify the top pull request, head SHA, integration base SHA, logical base SHA, synthetic base SHA, and synthetic merge SHA.
 4. *Stack:* verify the member chain. Members are listed bottom to top. The bottom member must target `integration_branch`. Every later member must target the branch of the member immediately before it in the list. When that preceding member has merged, the member may instead target `integration_branch`, because GitHub retargets a pull request when its base branch is deleted. Each member must be open or merged, and every member head must live in this repository. Reject any other base, state, or head repository.
 5. *Stack:* verify the head ancestry. The head of each member must be an ancestor of the head of the member immediately after it in the list, and `head_sha` must equal the head of the top member. Record every member head in the train record. This step proves that the top branch contains the whole stack at setup time.
 6. *Stack:* verify merged members. A member that has already merged must have a true merge commit whose second parent is the recorded member head, and that merge commit must be reachable from `integration_branch`. The setup workflow proves reachability with a compare of the merge commit against the `integration_branch` tip (status `ahead` or `identical`). Setup cannot know how an open member *will* merge. That condition is enforced later: Section 13.3 re-validates the chain after every member merge and the promotion controller verifies every recorded member head at promotion time.
-7. Verify the source version against `target_version`.
+7. Check that the exact synthetic merge source has `target_version`.
 8. Verify that the version has no active reservation. Skip this step when `publishing` is `false`.
-9. Verify a successful full CI run for the exact head SHA. `ci.yml` runs pull-request CI for bases `dev`, `master`, `staging`, `trying`, and `feature/**`. A member whose base is outside that set (for example a `fix/**` or `formal/**` branch) gets no pull-request run. Setup therefore requires one successful `ci.yml` run for `head_sha` from any event. A run whose head commit lives in a fork is not accepted, because the run list reports the base repository for every run and only the head repository reveals the fork. When none exists, setup dispatches `ci.yml` on `head_sha`, waits, and records that run identifier as the train's CI evidence.
+9. Verify one successful trusted CI run for the current top synthetic merge.
+
+Pull-request CI runs lightweight checks for all base branches. A lower stack layer has an open child pull request and skips Heavy Pipeline.
+
+Deployment Train dispatches one Heavy Pipeline from the default branch controls. The dispatch checks out the exact top synthetic merge.
+
+The CI artifact records the top pull request, head SHA, logical base SHA, synthetic base SHA, and merge SHA. Setup rejects missing or skipped architecture aggregators.
+
+Setup checks the top pull request again after CI completes. Setup rejects evidence if the head, base, or synthetic merge changed.
 10. Create the train canary from that CI run.
 11. Start standard gates for the candidate.
 12. Start each mandatory feature-specific gate.
@@ -463,7 +476,11 @@ The setup workflow performs these actions. Steps marked *stack* apply only to a 
 
 Multiple trains can run at the same time. Workflow concurrency keys include the train identifier and target version.
 
-`deployment-train.yml` implements steps 1 to 9 with `release-train.sh`: manifest validation (schema 1 and 2), the member chain, head ancestry, merged-member topology, the source version and reservation, and the CI evidence. The workflow produces a `train-record` artifact (manifest, train record with every member head, and the API documents it verified). A non-publishing train completes at step 9. A publishing train holds at step 9 until the train canary path (steps 10 to 13) lands.
+`deployment-train.yml` implements steps 1 to 9 with `release-train.sh`. The workflow verifies the manifest, stack, exact merge, version, reservation, and CI evidence.
+
+The workflow produces a `train-record` artifact. The artifact contains the manifest, integration base, observed SHAs, member heads, CI run, and API documents.
+
+A non-publishing train completes at step 9. A publishing train holds at step 9 until the train canary path exists.
 
 ### 13.3 Merge requirement
 
@@ -589,7 +606,7 @@ This table defines the target state after the Section 17 workflow changes are co
 
 | Workflow | Trigger | Basis | Typical duration | Role |
 |---|---|---|---|---|
-| `ci.yml` | `push` (dev, master, tags), `pull_request`, `workflow_dispatch` | Event + manual | 25–65 min *measured*; approval gates and runner queues can extend wall time to hours | Full CI |
+| `ci.yml` | `push` (dev, master, tags), all `pull_request` bases, `workflow_dispatch` | Event + manual | 25–65 min *measured*; runner queues can extend wall time | Lightweight PR checks and one exact-merge Heavy Pipeline |
 | `canary-publish.yml` | `workflow_run` (CI completed, master push, success), `workflow_dispatch` (ci_run_id) | Event + manual | 10–20 min *estimated* | Publishes the immutable canary when the source is release-eligible; skips cleanly otherwise |
 | `ci-fork-pr.yml` | `pull_request_target` (dev, master) | Event | Seconds, then the gated pipeline after maintainer approval | Fork lane into the gated pipeline |
 | `_integration-pipeline.yml` | `workflow_call` | Called by ci.yml and ci-fork-pr.yml | 35–50 min *measured* | Heavy pipeline: image build, ephemeral runners, integration matrix, smoke tests |
@@ -603,7 +620,7 @@ This table defines the target state after the Section 17 workflow changes are co
 | `release-evidence.yml` | `workflow_dispatch` (ci_run_id) | Manual | 10–20 min *estimated* (30-min cap) | Exact-run candidate evidence |
 | `release.yml` | `workflow_dispatch` (candidate_tag); `workflow_run` on completion of Full OCI Validation, the slashing suite, and the soak (resume after a missing gate) | Manual start, automatic resume | 5–15 min *estimated* (no builds; copy and verify only) | Exact-candidate stable promotion |
 | `soak-in.yml` | `release` (stable tag published), `workflow_dispatch` | Event (one enrollment per stable release) + manual | Enrollment takes minutes; the soak-in period itself runs in the test net, not in Actions | Shard soak-in enrollment |
-| `deployment-train.yml` | `workflow_dispatch` (`manifest_path`, `wait_for_ci`) | Manual | Minutes for setup; up to the CI duration when it dispatches `ci.yml` for the head | Train validation and setup (Section 13.2 steps 1 to 9) |
+| `deployment-train.yml` | `workflow_dispatch` (`manifest_path`, `wait_for_ci`) | Manual | Minutes for setup; up to the exact-merge CI duration | Train validation and setup (Section 13.2 steps 1 to 9) |
 | `testbed-quality-gate.yml` | `workflow_dispatch`, including dispatch from train manifest gates | Manual + tooling | No measured runs | Feature-specific train gate |
 | `deny-schedule.yml` | `schedule` Mondays 06:00 UTC, `workflow_dispatch` | Time + manual | About 1 min *measured* | Weekly advisory sweep |
 | `ci-runner-reaper.yml` | `schedule` every 30 min, `workflow_dispatch` | Time + manual | 1–2 min *measured* | Ephemeral-runner leak reaper |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -462,13 +462,19 @@ The setup workflow performs these actions. Steps marked *stack* apply only to a 
 8. Verify that the version has no active reservation. Skip this step when `publishing` is `false`.
 9. Verify one successful trusted CI run for the current top synthetic merge.
 
-Pull-request CI runs lightweight checks for all base branches. A lower stack layer has an open child pull request and skips Heavy Pipeline.
+Pull-request CI runs checks for all base branches. Each same-repository pull request into `dev` or `master` must run Heavy Pipeline.
 
-Deployment Train dispatches one Heavy Pipeline from the default branch controls. The dispatch checks out the exact top synthetic merge.
+Intermediate stack layers remain lightweight while they target another feature branch. A base change reruns CI before the layer merges into an integration branch.
+
+Deployment Train dispatches one additional Heavy Pipeline from the default branch controls. The dispatch checks out the exact top synthetic merge.
 
 The CI artifact records the top pull request, head SHA, logical base SHA, synthetic base SHA, and merge SHA. Setup rejects missing or skipped architecture aggregators.
 
-Setup checks the top pull request again after CI completes. Setup rejects evidence if the head, base, or synthetic merge changed.
+Setup accepts a run only when its control SHA equals the current default branch tip. A later default branch change requires a new run.
+
+This strict control binding is intentional. It prevents older workflow controls from supplying evidence, but it can repeat Heavy Pipeline.
+
+Setup checks the complete stack again after CI completes. Setup rejects evidence if a member, base, or synthetic merge changed.
 10. Create the train canary from that CI run.
 11. Start standard gates for the candidate.
 12. Start each mandatory feature-specific gate.
@@ -485,6 +491,8 @@ A non-publishing train completes at step 9. A publishing train holds at step 9 u
 ### 13.3 Merge requirement
 
 The train pull request must merge before stable publication.
+
+Each stack layer must pass the protected integration-branch Heavy Pipeline before it merges. The top exact-merge run does not replace this gate.
 
 The promotion controller verifies that `head_sha` is reachable from `master`. A normal merge preserves this relationship. Train pull requests must therefore use a true merge commit in practice: a squash or rebase costs a full re-candidacy, including a new 60h stability soak.
 
@@ -554,6 +562,10 @@ A maintainer can cancel a candidate or train. Cancellation does not delete tags,
 
 Secret-bearing workflows always use trusted workflow files from the default branch.
 
+Exact-merge run metadata identifies that default branch and a `workflow_dispatch` event. The `ci-target` artifact identifies the candidate synthetic merge.
+
+The trusted workflow checks out candidate code as test input. The resolver rejects fork heads before Heavy Pipeline receives inherited secrets.
+
 A pull-request head cannot change release workflow code for its own privileged run.
 
 Candidate workflows use least-privilege permissions. Release publication uses the protected `release-credentials` environment.
@@ -606,7 +618,7 @@ This table defines the target state after the Section 17 workflow changes are co
 
 | Workflow | Trigger | Basis | Typical duration | Role |
 |---|---|---|---|---|
-| `ci.yml` | `push` (dev, master, tags), all `pull_request` bases, `workflow_dispatch` | Event + manual | 25–65 min *measured*; runner queues can extend wall time | Lightweight PR checks and one exact-merge Heavy Pipeline |
+| `ci.yml` | `push` (dev, master, tags), all `pull_request` bases, `workflow_dispatch` | Event + manual | 25–65 min *measured*; runner queues can extend wall time | PR checks with protected-base and exact-merge Heavy Pipelines |
 | `canary-publish.yml` | `workflow_run` (CI completed, master push, success), `workflow_dispatch` (ci_run_id) | Event + manual | 10–20 min *estimated* | Publishes the immutable canary when the source is release-eligible; skips cleanly otherwise |
 | `ci-fork-pr.yml` | `pull_request_target` (dev, master) | Event | Seconds, then the gated pipeline after maintainer approval | Fork lane into the gated pipeline |
 | `_integration-pipeline.yml` | `workflow_call` | Called by ci.yml and ci-fork-pr.yml | 35–50 min *measured* | Heavy pipeline: image build, ephemeral runners, integration matrix, smoke tests |

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -63,7 +63,7 @@ show_status() {
     echo ""
     echo "Hooks provide:"
     echo "  pre-commit: cargo fmt --check, cargo clippy"
-    echo "  pre-push:   cargo test (full workspace)"
+    echo "  pre-push:   CI script tests and cargo test (full workspace)"
 }
 
 install_via_hookspath() {
@@ -79,7 +79,7 @@ install_via_hookspath() {
     echo ""
     echo "Hooks installed:"
     echo "  pre-commit: cargo fmt --check + cargo clippy"
-    echo "  pre-push:   cargo test (full workspace)"
+    echo "  pre-push:   CI script tests and cargo test (full workspace)"
     echo ""
     echo "To verify: git config --local core.hooksPath"
 }
@@ -132,31 +132,31 @@ remove_hooks() {
 
 # Parse arguments
 case "${1:-}" in
-    --status)
-        show_status
-        ;;
-    --copy)
-        install_via_copy
-        ;;
-    --remove)
-        remove_hooks
-        ;;
-    --help|-h)
-        echo "Usage: $0 [--copy|--status|--remove|--help]"
-        echo ""
-        echo "Options:"
-        echo "  (default)   Install via core.hooksPath (recommended)"
-        echo "  --copy      Copy hooks to .git/hooks/"
-        echo "  --status    Show current hook configuration"
-        echo "  --remove    Remove hook configuration"
-        echo "  --help      Show this help"
-        ;;
-    "")
-        install_via_hookspath
-        ;;
-    *)
-        echo -e "${RED}Unknown option: $1${NC}"
-        echo "Run: $0 --help"
-        exit 1
-        ;;
+--status)
+    show_status
+    ;;
+--copy)
+    install_via_copy
+    ;;
+--remove)
+    remove_hooks
+    ;;
+--help | -h)
+    echo "Usage: $0 [--copy|--status|--remove|--help]"
+    echo ""
+    echo "Options:"
+    echo "  (default)   Install via core.hooksPath (recommended)"
+    echo "  --copy      Copy hooks to .git/hooks/"
+    echo "  --status    Show current hook configuration"
+    echo "  --remove    Remove hook configuration"
+    echo "  --help      Show this help"
+    ;;
+"")
+    install_via_hookspath
+    ;;
+*)
+    echo -e "${RED}Unknown option: $1${NC}"
+    echo "Run: $0 --help"
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
## Summary

Replaces head-SHA CI evidence for deployment trains with an **exact-merge gate**: train setup resolves the top pull request's synthetic merge (`merge_commit_sha`), dispatches `ci.yml` on the default branch with `target_sha`/`top_pull_request` inputs, and the run checks out the merge source while the workflow definitions stay on the default branch. The run self-verifies the merge topology, uploads a `ci-target` artifact that binds the run to the merge, and setup re-validates the whole stack after CI completes.

## Design properties

- CI tests **what will land** (the merge against the current base chain, anchored to the integration branch), not the branch tip.
- **Trusted definitions**: workflow code comes from the default branch; a candidate branch cannot alter the gate that judges it. `plan-ci` only trusts `workflow_dispatch` runs titled `CI [exact merge <sha>]` with `head_branch` = default branch and `head_sha` = the control SHA.
- **Fail-closed races**: the resolve step, the checkout of the ephemeral merge SHA, and the post-CI re-validation each reject a stack that moved.
- `validate-ci-evidence` rejects missing or skipped architecture aggregators, so a skipped Heavy Pipeline can never count as passing train evidence.
- `pull_request` CI now runs lightweight checks on every base, giving stack members (`fix/**`, `formal/**` bases) per-PR coverage; the Heavy Pipeline gating for dev/master PRs is unchanged.
- The pre-push hook understands the new gate; `test-pre-push-hook.sh` and `test-ci-stack-gate.sh` cover the hook and the resolve step with stubbed `gh`.

## Review resolutions (multi-agent review, 2026-08-24)

| Finding | Resolution |
|---|---|
| `if … fi \|\| { }` suppressed `set -e` in the post-CI validation — a failed integration-base check could be masked | Each validation now carries its own handler; the compound `\|\|` form is gone. |
| Single-PR trains never validated `.base.ref` against the manifest `base_branch` | Setup rejects a top pull request whose base ref is not the reviewed `base_branch`. |
| Single-member post-CI validation compared only SHAs — missed closure without merge and retargeting during CI | The single path now rebuilds the complete current train record (state, base ref, merged flag, all SHAs) and compares it through `validate-current-stack`, the same equality the stack path uses. |
| Default-branch movement between checkout and dispatch made the dispatched run undiscoverable (10-minute poll, misleading timeout) | Setup verifies the live default-branch tip equals the control SHA before dispatching, and the poll loop fails fast with a re-run message when a matching run started from a different tip. |

Earlier increments already resolved two design-review findings: `plan-ci` now paginates with `event`/`branch` filters, and the open-child Heavy Pipeline skip was removed (same-repo dev/master PRs always run the pipeline).

## Known open item

`.github/deployment-trains/key-contention.yml` lists #331 between #319 and #311, but #311 still targets `fix/key-contention-base-bias` and its head does not contain #331's head — steps 4 and 5 reject this manifest today. Either retarget #311 onto #331's branch and merge #331's head up, or drop #331 from the stack before the rehearsal.

## Verification

- `test-release-workflows.sh`, `test-release-train.sh`, `test-ci-stack-gate.sh`, `test-pre-push-hook.sh`, and `check-workflow-invariants.sh` pass.
- YAML validates for all touched workflows.

Refs #294
