### PR TITLE
docs: remove AI watermarks identifiers from work-log frontmatter

### DIFF
--- a/docs/plans/where-clauses-and-match-guards-2026-04-29.md
+++ b/docs/plans/where-clauses-and-match-guards-2026-04-29.md
@@ -1,7 +1,6 @@
 ---
 title: Rholang `where` clauses on receives and `where` guards on match cases
 status: draft
-author: claude-session
 date: 2026-04-29
 related-docs:
   - docs/rholang/rholangtut.md

--- a/docs/work-logs/casper-test-node-congruence-baseline-2026-08-19.md
+++ b/docs/work-logs/casper-test-node-congruence-baseline-2026-08-19.md
@@ -2,7 +2,6 @@
 doc_type: work_log
 task_id: TASK-015-1
 epic_id: EPIC-015
-created_by: claude-session-b0c4ed4f
 created_at: 2026-08-19
 handoff_status: ready
 next_steps:

--- a/docs/work-logs/coordination-archive-2026-08-01T03Z.md
+++ b/docs/work-logs/coordination-archive-2026-08-01T03Z.md
@@ -2,7 +2,6 @@
 doc_type: work-log
 title: "Coordination archive — narrative entries moved out of docs/ToDos.md"
 created_at: 2026-08-01T03:50:00Z
-author: claude-session-68b96ecd
 provenance: docs/ToDos.md
 reason: >
   Format normalization: docs/ToDos.md is the canonical epic/task file per

--- a/docs/work-logs/task-004-1-2026-04-17T19-19-55Z.md
+++ b/docs/work-logs/task-004-1-2026-04-17T19-19-55Z.md
@@ -2,7 +2,6 @@
 doc_type: work_log
 task_id: TASK-004-1
 epic_id: EPIC-004
-claimed_by: claude-session-epic004
 claimed_at: 2026-04-17T19:19:55Z
 handoff_status: ready
 source_repo: F1R3FLY-io/f1r3node

--- a/docs/work-logs/task-004-1-resync-fb59611f-2026-04-29T18-50-45Z.md
+++ b/docs/work-logs/task-004-1-resync-fb59611f-2026-04-29T18-50-45Z.md
@@ -2,7 +2,6 @@
 doc_type: work_log
 task_id: TASK-004-1
 epic_id: EPIC-004
-claimed_by: claude-session-resync-fb59611f
 claimed_at: 2026-04-29T18:50:45Z
 handoff_status: ready
 source_repo: F1R3FLY-io/f1r3node

--- a/docs/work-logs/task-EPIC-010-2026-07-15T20-57Z.md
+++ b/docs/work-logs/task-EPIC-010-2026-07-15T20-57Z.md
@@ -3,9 +3,7 @@ doc_type: work-log
 epic: EPIC-010
 user_story: US-004
 branch: hotfix/72-soak-benchmark
-created_by: claude-session-07b4ccc6
 created_at: 2026-07-15T20:57:00Z
-claimed_by: claude-session-810424d7
 claimed_at: 2026-07-15T21:35:00Z
 handoff_status: in_progress
 next_steps:

--- a/docs/work-logs/task-consolidate-casper-docs-2026-08-20T16-32-37Z.md
+++ b/docs/work-logs/task-consolidate-casper-docs-2026-08-20T16-32-37Z.md
@@ -2,7 +2,6 @@
 task: consolidate-casper-design
 branch: docs/consolidate-casper-design
 stacked_on: fix/key-contention-starvation (PR #299)
-claimed_by: claude-session-consolidate-casper
 claimed_at: 2026-08-20T16:32:37Z
 handoff_status: in_progress
 checkpoints:

--- a/docs/work-logs/task-merge-recovery-port-2026-07-13T21-30Z.md
+++ b/docs/work-logs/task-merge-recovery-port-2026-07-13T21-30Z.md
@@ -1,7 +1,6 @@
 ---
 task: merge-recovery-validation-port
 branch: fix/dev-merge-recovery-validation
-claimed_by: claude-session-07b4ccc6
 started: 2026-07-13T20:00:00Z
 handoff_status: in_progress
 ---

--- a/docs/work-logs/task-sync-2026-04-29T20-27Z.md
+++ b/docs/work-logs/task-sync-2026-04-29T20-27Z.md
@@ -1,7 +1,6 @@
 ---
 doc_type: work_log
 task_id: TASK-sync-2026-04-29
-claimed_by: claude-session-sync94451
 claimed_at: 2026-04-29T20:27:31Z
 handoff_status: ready
 source_repo: F1R3FLY-io/f1r3node


### PR DESCRIPTION
- Drop claude-session-* values from claimed_by, created_by, and author keys in 8 work logs and 1 plan document
- Keep all other frontmatter, including the provenance pointer in the coordination archive
- Source tree and remaining docs audited clean (no invisible Unicode, no C2PA)