### PR TITLE
test(rspace): isolate event_log/produce_counter contention cost (#50)

### DIFF
--- a/rspace++/src/rspace/rspace.rs
+++ b/rspace++/src/rspace/rspace.rs
@@ -1374,7 +1374,8 @@ mod tests {
 
     // Disambiguates two candidate explanations for the near-zero wall-clock
     // speedup measured end-to-end at rholang-par scale (bench_par_branches:
-    // 0.88-0.96x at 32 branches, ideal 32x — see issue #50 follow-up):
+    // 0.88-0.96x at 32 branches against a worker-thread-bounded ideal — see
+    // issue #50 follow-up):
     // (a) event_log/produce_counter themselves cost that much, or
     // (b) something else in produce()'s path (HotStore, the striped
     //     per-channel lock, tokio scheduling) is the real cost and these
@@ -1425,13 +1426,24 @@ mod tests {
         }
         let par_ms = t_par.elapsed().as_millis().max(1);
 
+        // log_produce() is synchronous and the branch loops never await, so
+        // each task holds its worker for the whole loop: at most num_workers
+        // (further capped by the host's cores) branches run at once. That, not
+        // PAR_BRANCHES, is the achievable ideal for the efficiency metric.
+        let num_workers = tokio::runtime::Handle::current().metrics().num_workers();
+        let ideal = PAR_BRANCHES.min(num_workers).min(
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(usize::MAX),
+        );
         let speedup = seq_ms as f64 / par_ms as f64;
-        let efficiency = speedup / PAR_BRANCHES as f64 * 100.0;
+        let efficiency = speedup / ideal as f64 * 100.0;
 
         eprintln!(
             "event_log+produce_counter isolated cost: branches={PAR_BRANCHES} \
              ops_per_branch={OPS_PER_BRANCH} total_ops={} sequential={seq_ms}ms \
-             concurrent={par_ms}ms speedup={:.2}x (ideal {PAR_BRANCHES}x) efficiency={:.1}%",
+             concurrent={par_ms}ms speedup={:.2}x (ideal {ideal}x: {PAR_BRANCHES} branches on \
+             {num_workers} workers) efficiency={:.1}%",
             PAR_BRANCHES * OPS_PER_BRANCH,
             speedup,
             efficiency,

--- a/rspace++/src/rspace/rspace.rs
+++ b/rspace++/src/rspace/rspace.rs
@@ -1371,4 +1371,75 @@ mod tests {
             PAR_BRANCHES * OPS_PER_BRANCH,
         );
     }
+
+    // Disambiguates two candidate explanations for the near-zero wall-clock
+    // speedup measured end-to-end at rholang-par scale (bench_par_branches:
+    // 0.88-0.96x at 32 branches, ideal 32x — see issue #50 follow-up):
+    // (a) event_log/produce_counter themselves cost that much, or
+    // (b) something else in produce()'s path (HotStore, the striped
+    //     per-channel lock, tokio scheduling) is the real cost and these
+    //     two locks are not the story despite being std::sync::Mutex.
+    //
+    // Calls log_produce() directly — the exact call log_produce() itself
+    // takes (event_log.push then, for non-persist, produce_counter.insert)
+    // with no produce_lock(), no HotStore, no get_store() RwLock read, no
+    // matcher involved. Isolates these two locks from every other cost
+    // produce() incurs, at the same branch/op counts as bench_par_branches.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn event_log_and_produce_counter_isolated_cost_at_rholang_par_scale() {
+        const PAR_BRANCHES: usize = 32;
+        const OPS_PER_BRANCH: usize = 5000;
+
+        // Sequential baseline: identical total ops, one after another.
+        let seq_rspace = make_rspace().await;
+        let t_seq = Instant::now();
+        for b in 0..PAR_BRANCHES {
+            for i in 0..OPS_PER_BRANCH {
+                let channel = format!("seq_{}_{}", b, i);
+                let data = "datum".to_string();
+                let produce_ref = Produce::create(&channel, &data, false);
+                seq_rspace.log_produce(&produce_ref, &channel, &data, false);
+            }
+        }
+        let seq_ms = t_seq.elapsed().as_millis().max(1);
+
+        // Concurrent: PAR_BRANCHES tokio tasks, each on its own channel set,
+        // all sharing one RSpace and therefore one event_log/produce_counter.
+        let par_rspace = Arc::new(make_rspace().await);
+        let t_par = Instant::now();
+        let handles: Vec<_> = (0..PAR_BRANCHES)
+            .map(|b| {
+                let s = par_rspace.clone();
+                tokio::spawn(async move {
+                    for i in 0..OPS_PER_BRANCH {
+                        let channel = format!("par_{}_{}", b, i);
+                        let data = "datum".to_string();
+                        let produce_ref = Produce::create(&channel, &data, false);
+                        s.log_produce(&produce_ref, &channel, &data, false);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.await.unwrap();
+        }
+        let par_ms = t_par.elapsed().as_millis().max(1);
+
+        let speedup = seq_ms as f64 / par_ms as f64;
+        let efficiency = speedup / PAR_BRANCHES as f64 * 100.0;
+
+        eprintln!(
+            "event_log+produce_counter isolated cost: branches={PAR_BRANCHES} \
+             ops_per_branch={OPS_PER_BRANCH} total_ops={} sequential={seq_ms}ms \
+             concurrent={par_ms}ms speedup={:.2}x (ideal {PAR_BRANCHES}x) efficiency={:.1}%",
+            PAR_BRANCHES * OPS_PER_BRANCH,
+            speedup,
+            efficiency,
+        );
+
+        // No assertion: this test is diagnostic, not a regression gate. It
+        // reports the isolated cost of these two locks so it can be compared
+        // against bench_par_branches' end-to-end number for the same
+        // branch/op counts (see issue #50 investigation).
+    }
 }


### PR DESCRIPTION
## Summary

Adds one diagnostic test that isolates the wall-clock cost of `event_log`/`produce_counter` (`RSpace`'s two remaining `std::sync::Mutex`es) from everything else on the `produce()` path. No production code changes — this test does not fix #50, it pins down which lock the residual serialization from #72's "out of scope" note actually lives in.

## Motivation

#72 fixed six layers of serialization for intra-deploy par-parallelism (#50, #43) and got `rholang-par` from SEQUENTIAL to PARTIALLY PARALLEL (423.7s → 52.9s at forks=32). Its own "out of scope" section names `event_log`/`produce_counter` as the prime suspect for the remaining ~2.5 idle cores, but that was never directly measured — only inferred from the flame graph at the time.

Re-running `bench_par_branches` (the rspace-only rung of #72's own benchmark ladder) against current `dev` HEAD confirmed the residual is still there: **0.88–0.96× speedup at forks=32 against an ideal of 32×**, even with a unique channel per operation — which rules out the striped per-channel lock (#72's fix #4) as the explanation, since it can't contend when every op touches a different channel. That still leaves two candidates open: `event_log`/`produce_counter` themselves, or something else on `produce()`'s path (`HotStore`, `get_store()`'s read lock, tokio scheduling).

## Changes

`rspace++/src/rspace/rspace.rs`: adds `event_log_and_produce_counter_isolated_cost_at_rholang_par_scale`, alongside the two existing `event_log` contention tests. It calls the private `log_produce()` directly — exactly what every `produce()` call does to these two locks (`event_log.push()`, then for non-persistent produces `produce_counter.insert()`) — with no `produce_lock()`, no `HotStore`, no `get_store()` read lock, no matcher. Same scale as `bench_par_branches`: 32 branches × 5,000 ops, sequential baseline vs. concurrent tokio tasks.

## Non-goals

Does not fix `event_log`/`produce_counter`. Follow-up fix direction (sharding `produce_counter` like `HotStore` was sharded, lock-free `event_log`) is scoped as separate work — `event_log` in particular feeds the rig/replay mechanism's event ordering, so its replacement needs its own PR and validation against replay determinism.

## Testing

```
cargo test --release -p rspace_plus_plus --lib rspace::rspace::tests -- --nocapture
```

All 3 tests in the module pass (`test result: ok. 3 passed; 0 failed`).

## Related

#50, #72, #43