### PR TITLE
ci(soak): report a completed-but-failed preflight accurately

### DIFF
--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -2180,6 +2180,8 @@ jobs:
           if [ "$PREFLIGHT_RESULT" = "passed" ]; then
             state=success
             description="Full integration preflight passed"
+          elif [ "$PREFLIGHT_RESULT" = "failed" ]; then
+            description="Full integration preflight completed with test failures"
           elif [ "$PENDING_RESULT" != "success" ]; then
             description="Preflight status initialization failed"
           elif [ "$LAUNCH_RESULT" != "success" ]; then


### PR DESCRIPTION
## Summary

The `Finalize Integration Preflight Status` job in `merge-recovery-soak.yml` had no branch for a preflight that ran to completion and failed tests: `PREFLIGHT_RESULT=failed` fell through to the generic **"Full integration preflight did not complete"** description. That misreports runs like [32877942498](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/32877942498) (visible on PR #311), where all three suites executed and exactly one test failed (the known issue #24 throughput ceiling).

Two-line fix: an explicit `failed` branch sets the description to **"Full integration preflight completed with test failures"**; the old fallback now applies only when the preflight step never ran (infra death). The failure *state* is unchanged — only the description is corrected.

## Verification

- YAML parses; `check-workflow-invariants.sh` green
- No behavior change to gating: the status state logic is untouched