### PR TITLE
perf(casper): specify and batch the settled-effect probes (one walk per merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,9 +852,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/block-storage/src/rust/key_value_block_store.rs
+++ b/block-storage/src/rust/key_value_block_store.rs
@@ -245,6 +245,19 @@ impl KeyValueBlockStore {
         }
     }
 
+    /// Key-existence check against the underlying store, skipping the
+    /// decompression and protobuf decode that `contains` (via `get`) pays.
+    /// The cheap availability probe for callers revalidating cached
+    /// per-block facts against THIS store.
+    pub fn contains_key(&self, block_hash: &BlockHash) -> Result<bool, KvStoreError> {
+        Ok(self
+            .store
+            .contains(&vec![block_hash.to_vec()])?
+            .first()
+            .copied()
+            .unwrap_or(false))
+    }
+
     fn error_approved_block(cause: String) -> String {
         format!("Approved block decoding error. Cause: {}", cause)
     }

--- a/casper/src/rust/finality/deploy_lifecycle.rs
+++ b/casper/src/rust/finality/deploy_lifecycle.rs
@@ -161,22 +161,47 @@ struct LineageStep {
     sigs: std::sync::Arc<HashSet<Bytes>>,
 }
 
-/// Hard cap for the per-block lineage-step cache. At roughly a kilobyte
-/// per fat block the full cache stays under ~16MB; on overflow the cache
-/// is cleared rather than evicted piecewise — entries are pure functions
-/// of immutable bodies, so losing them costs only a re-read.
-const LINEAGE_STEP_CACHE_MAX: usize = 16_384;
+/// Byte budget for the per-block lineage-step cache, tracked from each
+/// entry's measured sig bytes (an entry-count cap understates fat blocks:
+/// 128 sigs × ~70B is ~9KB for one entry). On overflow the cache is
+/// cleared rather than evicted piecewise — entries are pure functions of
+/// immutable bodies, so losing them costs only a re-read. Repeated
+/// clear-rebuild thrash would need one walk's entries to approach the
+/// budget, and walk depth is bounded far below it by the deterministic
+/// floor-distance merge backstop (`merge_scope_backstop_exceeded`).
+const LINEAGE_STEP_CACHE_MAX_BYTES: usize = 32 * 1024 * 1024;
 
-fn lineage_step_cache(
-) -> &'static parking_lot::Mutex<HashMap<BlockHash, std::sync::Arc<LineageStep>>> {
-    static CACHE: std::sync::OnceLock<
-        parking_lot::Mutex<HashMap<BlockHash, std::sync::Arc<LineageStep>>>,
-    > = std::sync::OnceLock::new();
-    CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+/// Per-entry overhead estimate added to the measured sig bytes: map slot,
+/// `Arc` headers, hash key.
+const LINEAGE_STEP_ENTRY_OVERHEAD_BYTES: usize = 128;
+
+#[derive(Default)]
+struct LineageStepCache {
+    map: HashMap<BlockHash, std::sync::Arc<LineageStep>>,
+    approx_bytes: usize,
+}
+
+impl LineageStepCache {
+    fn insert(&mut self, hash: BlockHash, step: std::sync::Arc<LineageStep>) {
+        let entry_bytes =
+            LINEAGE_STEP_ENTRY_OVERHEAD_BYTES + step.sigs.iter().map(Bytes::len).sum::<usize>();
+        if self.approx_bytes + entry_bytes > LINEAGE_STEP_CACHE_MAX_BYTES {
+            self.map.clear();
+            self.approx_bytes = 0;
+        }
+        self.approx_bytes += entry_bytes;
+        self.map.insert(hash, step);
+    }
+}
+
+fn lineage_step_cache() -> &'static parking_lot::Mutex<LineageStepCache> {
+    static CACHE: std::sync::OnceLock<parking_lot::Mutex<LineageStepCache>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| parking_lot::Mutex::new(LineageStepCache::default()))
 }
 
 #[cfg(test)]
-fn lineage_step_cache_len() -> usize { lineage_step_cache().lock().len() }
+fn lineage_step_cache_bytes() -> usize { lineage_step_cache().lock().approx_bytes }
 
 /// One walk, every sig: the applied-sig union of `block_hash`'s state
 /// lineage down to `min_height` — the batched form of
@@ -204,10 +229,24 @@ pub(crate) fn settled_sigs_of_lineage(
     let mut walked = 0usize;
     let mut cur = block_hash.clone();
     loop {
-        let cached = lineage_step_cache().lock().get(&cur).cloned();
+        // The cache is process-global and keyed by hash alone, while this
+        // function's answer must be a function of the SUPPLIED store: a hit
+        // is revalidated with a raw key-existence check (no decompression,
+        // no decode) so a block this store does not hold is `BlockNotHeld`
+        // exactly as on the cold path — availability semantics survive the
+        // cache, and one process serving several stores (tests) cannot
+        // cross-answer.
+        let cached = lineage_step_cache().lock().map.get(&cur).cloned();
+        let cached = match cached {
+            Some(step) if block_store.contains_key(&cur)? => Some(step),
+            _ => None,
+        };
         let step = match cached {
             Some(step) => step,
             None => {
+                // Miss path: two short lock acquisitions (lookup above,
+                // insert below) are deliberate — the store read between
+                // them is I/O and must not run under the lock.
                 let Some(block) = block_store.get(&cur)? else {
                     return Err(CasperError::BlockNotHeld(cur));
                 };
@@ -240,11 +279,9 @@ pub(crate) fn settled_sigs_of_lineage(
                     base,
                     sigs: std::sync::Arc::new(sigs),
                 });
-                let mut cache = lineage_step_cache().lock();
-                if cache.len() >= LINEAGE_STEP_CACHE_MAX {
-                    cache.clear();
-                }
-                cache.insert(cur.clone(), step.clone());
+                lineage_step_cache()
+                    .lock()
+                    .insert(cur.clone(), step.clone());
                 step
             }
         };
@@ -257,6 +294,58 @@ pub(crate) fn settled_sigs_of_lineage(
             None => return Ok((settled, walked)),
             Some(base) => cur = base.clone(),
         }
+    }
+}
+
+/// Batched multi-floor settled probe with the reference loop's per-floor
+/// short-circuit. The reference form checks floors IN ORDER and returns
+/// TRUE at the first floor whose lineage holds the sig; floors after the
+/// answering one are never read. This probe builds each floor's applied-sig
+/// set lazily via [`settled_sigs_of_lineage`] the first time the in-order
+/// scan reaches that floor, so an unavailable LATER floor cannot poison a
+/// probe an earlier floor answers — the error surface matches the
+/// reference at floor granularity (within one floor's segment the
+/// fail-closed strengthening of the batched walk applies).
+pub(crate) struct FloorSettledProbe {
+    /// `(floor hash, min_height)` in the reference scan order.
+    floors: Vec<(BlockHash, i64)>,
+    /// Lazily built per-floor applied-sig sets, index-aligned with
+    /// `floors`.
+    sets: Vec<Option<HashSet<Bytes>>>,
+    /// Blocks walked across every set built so far, for the caller's
+    /// metrics.
+    pub(crate) total_walked: usize,
+}
+
+impl FloorSettledProbe {
+    pub(crate) fn new(floors: Vec<(BlockHash, i64)>) -> Self {
+        let sets = floors.iter().map(|_| None).collect();
+        Self {
+            floors,
+            sets,
+            total_walked: 0,
+        }
+    }
+
+    /// TRUE iff some floor's lineage (down to that floor's bound) holds
+    /// the sig, scanning floors in order and stopping at the first hit.
+    pub(crate) fn settled(
+        &mut self,
+        block_store: &KeyValueBlockStore,
+        sig: &Bytes,
+    ) -> Result<bool, CasperError> {
+        for i in 0..self.floors.len() {
+            if self.sets[i].is_none() {
+                let (hash, min_height) = &self.floors[i];
+                let (sigs, walked) = settled_sigs_of_lineage(block_store, hash, *min_height)?;
+                self.total_walked += walked;
+                self.sets[i] = Some(sigs);
+            }
+            if self.sets[i].as_ref().expect("just built").contains(sig) {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 }
 
@@ -1259,8 +1348,85 @@ mod tests {
             }
         }
         assert!(
-            lineage_step_cache_len() <= LINEAGE_STEP_CACHE_MAX,
-            "lineage-step cache must respect its hard cap"
+            lineage_step_cache_bytes() <= LINEAGE_STEP_CACHE_MAX_BYTES,
+            "lineage-step cache must respect its byte budget"
+        );
+    }
+
+    /// The multi-floor probe answers exactly as the reference per-floor
+    /// loop (first floor whose lineage holds the sig wins), across sigs
+    /// held by the first floor, only a later floor, or none.
+    #[tokio::test]
+    async fn floor_probe_matches_the_reference_floor_loop() {
+        let store = store().await;
+        let genesis = block_at(0, vec![], 300);
+        let (sig_a, pd_a) = processed(301, false);
+        let mut floor1 = block_at(1, vec![genesis.block_hash.clone()], 301);
+        floor1.body.deploys = vec![pd_a];
+        let (sig_b, pd_b) = processed(302, false);
+        let mut mid = block_at(1, vec![genesis.block_hash.clone()], 302);
+        mid.body.deploys = vec![pd_b];
+        let floor2 = block_at(2, vec![mid.block_hash.clone()], 303);
+        for b in [&genesis, &floor1, &mid, &floor2] {
+            store.put_block_message(b).expect("store block");
+        }
+        let floors = vec![
+            (floor1.block_hash.clone(), 0),
+            (floor2.block_hash.clone(), 0),
+        ];
+        let sig_absent = Bytes::from_static(b"absent-floor-sig");
+        let mut probe = FloorSettledProbe::new(floors.clone());
+        for sig in [&sig_a, &sig_b, &sig_absent] {
+            let reference = floors
+                .iter()
+                .map(|(hash, bound)| effect_in_state_of(&store, hash, sig, *bound))
+                .try_fold(false, |acc, r| r.map(|hit| acc || hit))
+                .expect("reference loop");
+            assert_eq!(
+                reference,
+                probe.settled(&store, sig).expect("probe"),
+                "floor probe diverged from the reference loop for sig {}",
+                hex::encode(&sig[..8.min(sig.len())]),
+            );
+        }
+    }
+
+    /// The probe keeps the reference loop's short-circuit: a sig the FIRST
+    /// floor holds answers TRUE without reading the second floor at all,
+    /// so a gap in the later floor's lineage cannot poison that probe. A
+    /// sig no floor holds must still reach the gap and refuse, exactly as
+    /// the reference loop does.
+    #[tokio::test]
+    async fn floor_probe_short_circuit_skips_unavailable_later_floors() {
+        let store = store().await;
+        let genesis = block_at(0, vec![], 310);
+        let (sig_a, pd_a) = processed(311, false);
+        let mut floor1 = block_at(1, vec![genesis.block_hash.clone()], 311);
+        floor1.body.deploys = vec![pd_a];
+        let absent = block_at(1, vec![], 312);
+        let floor2 = block_at(2, vec![absent.block_hash.clone()], 313);
+        for b in [&genesis, &floor1, &floor2] {
+            store.put_block_message(b).expect("store block");
+        }
+        let floors = vec![
+            (floor1.block_hash.clone(), 0),
+            (floor2.block_hash.clone(), 0),
+        ];
+
+        let mut probe = FloorSettledProbe::new(floors.clone());
+        assert!(
+            probe.settled(&store, &sig_a).expect("first floor answers"),
+            "a first-floor hit must not read the gapped later floor"
+        );
+
+        let sig_unknown = Bytes::from_static(b"unknown-floor-sig");
+        let err = probe
+            .settled(&store, &sig_unknown)
+            .expect_err("an unanswered probe must reach the gap and refuse");
+        assert!(
+            matches!(err, CasperError::BlockNotHeld(ref h) if *h == absent.block_hash),
+            "the refusal must name the missing block typed; got: {}",
+            err
         );
     }
 

--- a/casper/src/rust/finality/deploy_lifecycle.rs
+++ b/casper/src/rust/finality/deploy_lifecycle.rs
@@ -149,6 +149,117 @@ fn effect_in_state_of_above(
     }
 }
 
+/// One cached lineage step: everything the batched walk needs from a block
+/// without re-reading its body. Content-addressed by block hash, so an
+/// entry can never go stale.
+struct LineageStep {
+    block_number: i64,
+    /// Next block on the state lineage; `None` means genesis (exhausted).
+    base: Option<BlockHash>,
+    /// The block's applied-sig facts: sigs of its non-failed `deploys`
+    /// entries plus its `applied_from_scope` list.
+    sigs: std::sync::Arc<HashSet<Bytes>>,
+}
+
+/// Hard cap for the per-block lineage-step cache. At roughly a kilobyte
+/// per fat block the full cache stays under ~16MB; on overflow the cache
+/// is cleared rather than evicted piecewise — entries are pure functions
+/// of immutable bodies, so losing them costs only a re-read.
+const LINEAGE_STEP_CACHE_MAX: usize = 16_384;
+
+fn lineage_step_cache(
+) -> &'static parking_lot::Mutex<HashMap<BlockHash, std::sync::Arc<LineageStep>>> {
+    static CACHE: std::sync::OnceLock<
+        parking_lot::Mutex<HashMap<BlockHash, std::sync::Arc<LineageStep>>>,
+    > = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn lineage_step_cache_len() -> usize { lineage_step_cache().lock().len() }
+
+/// One walk, every sig: the applied-sig union of `block_hash`'s state
+/// lineage down to `min_height` — the batched form of
+/// [`effect_in_state_of`] (CLAIM-FINALITY-001, C2:
+/// `docs/claims/settled-effect-probe-equivalence.md`). A caller holding
+/// the returned set answers any per-sig probe by membership, turning the
+/// merge's ~30 per-sig lineage walks into one walk plus O(1) lookups.
+/// Also returns the number of blocks walked, for the caller's metrics.
+///
+/// Stepping, bounds, and the non-failed/`applied_from_scope` fact kinds
+/// are exactly the reference walk's. One deliberate strengthening: this
+/// walk always covers the FULL segment, so an absent body (or a malformed
+/// multi-parent block without a recorded base) anywhere above the bound
+/// refuses the whole answer — even when a probed sig is applied above the
+/// gap and the per-sig reference walk would have answered TRUE without
+/// reaching it. Availability must not shape verdicts (the claim's
+/// availability-deferral seam premise); a deferral where the reference
+/// sometimes answered is the fail-closed direction.
+pub(crate) fn settled_sigs_of_lineage(
+    block_store: &KeyValueBlockStore,
+    block_hash: &BlockHash,
+    min_height: i64,
+) -> Result<(HashSet<Bytes>, usize), CasperError> {
+    let mut settled: HashSet<Bytes> = HashSet::new();
+    let mut walked = 0usize;
+    let mut cur = block_hash.clone();
+    loop {
+        let cached = lineage_step_cache().lock().get(&cur).cloned();
+        let step = match cached {
+            Some(step) => step,
+            None => {
+                let Some(block) = block_store.get(&cur)? else {
+                    return Err(CasperError::BlockNotHeld(cur));
+                };
+                let base = if !block.body.merge_base.is_empty() {
+                    Some(block.body.merge_base.clone())
+                } else {
+                    match block.header.parents_hash_list.as_slice() {
+                        [] => None,
+                        [parent] => Some(parent.clone()),
+                        _ => {
+                            return Err(CasperError::Other(format!(
+                                "settled_sigs_of_lineage: multi-parent block {} \
+                                 carries no recorded merge_base — refusing to \
+                                 guess its state lineage",
+                                hex::encode(&cur[..8.min(cur.len())]),
+                            )))
+                        }
+                    }
+                };
+                let mut sigs: HashSet<Bytes> = block
+                    .body
+                    .deploys
+                    .iter()
+                    .filter(|pd| !pd.is_failed)
+                    .map(|pd| pd.deploy.sig.clone())
+                    .collect();
+                sigs.extend(block.body.applied_from_scope.iter().cloned());
+                let step = std::sync::Arc::new(LineageStep {
+                    block_number: block.body.state.block_number,
+                    base,
+                    sigs: std::sync::Arc::new(sigs),
+                });
+                let mut cache = lineage_step_cache().lock();
+                if cache.len() >= LINEAGE_STEP_CACHE_MAX {
+                    cache.clear();
+                }
+                cache.insert(cur.clone(), step.clone());
+                step
+            }
+        };
+        if step.block_number < min_height {
+            return Ok((settled, walked));
+        }
+        walked += 1;
+        settled.extend(step.sigs.iter().cloned());
+        match &step.base {
+            None => return Ok((settled, walked)),
+            Some(base) => cur = base.clone(),
+        }
+    }
+}
+
 #[derive(Default)]
 struct Schedule {
     /// Sigs to re-evaluate once the max frozen lm-floor height reaches the
@@ -1052,6 +1163,133 @@ mod tests {
             record.state,
             TerminalState::Finalized,
             "a readable re-application must still finalize a horizon-blocked sig"
+        );
+    }
+
+    /// CLAIM-FINALITY-001 C2 bridge (discharge plan item 2): on generated
+    /// lineages the batched walk answers exactly as the per-sig reference
+    /// walk — for every fresh sig (failed and non-failed), every
+    /// `applied_from_scope` sig, decoy sigs living only on a non-base
+    /// parent, and absent sigs, across low/mid/above-tip bounds. Each
+    /// (lineage, bound) runs twice so the second pass exercises the
+    /// lineage-step cache-hit path against the same oracle.
+    #[tokio::test]
+    async fn batched_walk_matches_the_reference_walk_on_generated_lineages() {
+        let store = store().await;
+        let mut lcg: u64 = 0x5eed_cafe_0000_0001;
+        let mut rand = move |modulo: u32| -> u32 {
+            lcg = lcg
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((lcg >> 33) as u32) % modulo
+        };
+        let mut deploy_n: i32 = 100;
+        let mut seq: i32 = 1000;
+        let mut applied_n: u32 = 0;
+
+        for _config in 0..12 {
+            let len: i64 = 4 + i64::from(rand(6));
+            let mut probe_sigs: Vec<Bytes> = Vec::new();
+            let genesis = {
+                seq += 1;
+                block_at(0, vec![], seq)
+            };
+            store.put_block_message(&genesis).expect("store genesis");
+            let mut prev = genesis;
+            for h in 1..=len {
+                seq += 1;
+                let mut b = if h >= 2 && rand(3) == 0 {
+                    // A merged block: the side parent is stored but NOT on
+                    // the state lineage; its decoy applied sig must stay
+                    // invisible to both walks.
+                    seq += 1;
+                    let mut side = block_at(h, vec![prev.block_hash.clone()], seq);
+                    applied_n += 1;
+                    let decoy = Bytes::from(format!("decoy-{}", applied_n).into_bytes());
+                    side.body.applied_from_scope = vec![decoy.clone()];
+                    store.put_block_message(&side).expect("store side");
+                    probe_sigs.push(decoy);
+                    seq += 1;
+                    let mut m = block_at(
+                        h,
+                        vec![prev.block_hash.clone(), side.block_hash.clone()],
+                        seq,
+                    );
+                    m.body.merge_base = prev.block_hash.clone();
+                    m
+                } else {
+                    block_at(h, vec![prev.block_hash.clone()], seq)
+                };
+                for _ in 0..rand(3) {
+                    deploy_n += 1;
+                    let failed = rand(4) == 0;
+                    let (sig, pd) = processed(deploy_n, failed);
+                    b.body.deploys.push(pd);
+                    probe_sigs.push(sig);
+                }
+                for _ in 0..rand(3) {
+                    applied_n += 1;
+                    let sig = Bytes::from(format!("applied-{}", applied_n).into_bytes());
+                    b.body.applied_from_scope.push(sig.clone());
+                    probe_sigs.push(sig);
+                }
+                store.put_block_message(&b).expect("store block");
+                prev = b;
+            }
+            probe_sigs.push(Bytes::from_static(b"never-seen-anywhere"));
+
+            let tip = prev.block_hash.clone();
+            for bound in [0, len / 2, len + 1] {
+                for _pass in 0..2 {
+                    let (set, _walked) = settled_sigs_of_lineage(&store, &tip, bound)
+                        .expect("batched walk on a complete segment");
+                    for sig in &probe_sigs {
+                        let reference = effect_in_state_of(&store, &tip, sig, bound)
+                            .expect("reference walk on a complete segment");
+                        assert_eq!(
+                            reference,
+                            set.contains(sig),
+                            "batched membership diverged from the reference walk \
+                             (bound {}, sig {})",
+                            bound,
+                            hex::encode(&sig[..8.min(sig.len())]),
+                        );
+                    }
+                }
+            }
+        }
+        assert!(
+            lineage_step_cache_len() <= LINEAGE_STEP_CACHE_MAX,
+            "lineage-step cache must respect its hard cap"
+        );
+    }
+
+    /// The batched walk's documented strengthening: it covers the FULL
+    /// segment, so a gap below an applied sig refuses the whole answer
+    /// (typed `BlockNotHeld`), where the per-sig reference walk answers
+    /// TRUE for that sig without ever reaching the gap. Fail-closed is the
+    /// safe direction — availability must not shape verdicts.
+    #[tokio::test]
+    async fn batched_walk_is_fail_closed_on_a_gapped_segment() {
+        let store = store().await;
+        let absent = block_at(1, vec![], 1);
+        let (sig_top, pd) = processed(90, false);
+        let mut b = block_at(2, vec![absent.block_hash.clone()], 2);
+        b.body.deploys = vec![pd];
+        store.put_block_message(&b).expect("store block");
+
+        assert!(
+            effect_in_state_of(&store, &b.block_hash, &sig_top, 0)
+                .expect("the reference walk answers above the gap"),
+            "reference: the sig applied above the gap is TRUE without \
+             reading the gap"
+        );
+        let err = settled_sigs_of_lineage(&store, &b.block_hash, 0)
+            .expect_err("the batched walk must refuse a gapped segment");
+        assert!(
+            matches!(err, CasperError::BlockNotHeld(ref h) if *h == absent.block_hash),
+            "the refusal must carry the missing block typed; got: {}",
+            err
         );
     }
 }

--- a/casper/src/rust/metrics_constants.rs
+++ b/casper/src/rust/metrics_constants.rs
@@ -134,6 +134,14 @@ pub const PARENTS_POST_STATE_SETTLED_PROBE_CALLS_METRIC: &str =
     "block.processing.stage.parents-post-state.settled-probe.wrapper.calls";
 pub const PARENTS_POST_STATE_SETTLED_PROBE_TIME_NS_METRIC: &str =
     "block.processing.stage.parents-post-state.settled-probe.wrapper.time-ns";
+// The batched settled-sig index (CLAIM-FINALITY-001): one lineage walk per
+// merge replaces the per-sig probe walks; these time that build and record
+// its depth. The wrapper counters above keep running — after the batching
+// they measure set-membership lookups, which is the before/after evidence.
+pub const PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC: &str =
+    "block.processing.stage.parents-post-state.settled-index.build.time";
+pub const PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC: &str =
+    "block.processing.stage.parents-post-state.settled-index.blocks";
 
 // Wrapper counters surfacing the unaccounted overhead inside
 // `evaluate_system_source` (env build + rand clone + post-evaluate fixup) and

--- a/casper/src/rust/metrics_constants.rs
+++ b/casper/src/rust/metrics_constants.rs
@@ -142,6 +142,12 @@ pub const PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC: &str =
     "block.processing.stage.parents-post-state.settled-index.build.time";
 pub const PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC: &str =
     "block.processing.stage.parents-post-state.settled-index.blocks";
+// The floor probe's per-floor lazy builds, kept separate from the base
+// index above so the two walks stay individually attributable.
+pub const PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BUILD_TIME_METRIC: &str =
+    "block.processing.stage.parents-post-state.settled-floor-index.build.time";
+pub const PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BLOCKS_METRIC: &str =
+    "block.processing.stage.parents-post-state.settled-floor-index.blocks";
 
 // Wrapper counters surfacing the unaccounted overhead inside
 // `evaluate_system_source` (env build + rand clone + post-evaluate fixup) and

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -37,6 +37,8 @@ use crate::rust::metrics_constants::{
     PARENTS_POST_STATE_ENSURE_MERGEABLE_TIME_METRIC, PARENTS_POST_STATE_FLOOR_DERIVE_TIME_METRIC,
     PARENTS_POST_STATE_MERGE_CALL_TIME_METRIC, PARENTS_POST_STATE_POST_MERGE_TIME_METRIC,
     PARENTS_POST_STATE_PRIOR_REJECTION_COUNTS_TIME_METRIC,
+    PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC,
+    PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC,
     PARENTS_POST_STATE_SETTLED_PROBE_CALLS_METRIC, PARENTS_POST_STATE_SETTLED_PROBE_TIME_NS_METRIC,
 };
 use crate::rust::util::proto_util;
@@ -1694,16 +1696,40 @@ pub async fn compute_parents_post_state(
             // The probe closures run per unique sig from inside the merge, so
             // the counter handles are registered once here; only the plain
             // increments run on the hot path.
+            //
+            // Batched settled-sig index (CLAIM-FINALITY-001, C2): the run
+            // 33099406770 telemetry put these probes at 92% of merge_call —
+            // ~30 per-sig lineage walks per merge, each loading full block
+            // bodies. Each closure now builds its applied-sig set with ONE
+            // walk on the first probe (`settled_sigs_of_lineage`, backed by
+            // the per-block lineage-step cache) and answers every probe by
+            // membership. Built lazily so a merge that never probes never
+            // walks; RefCell suffices because the merge is synchronous on
+            // this thread.
             let settled_probe_calls = metrics::counter!(PARENTS_POST_STATE_SETTLED_PROBE_CALLS_METRIC, "source" => CASPER_METRICS_SOURCE);
             let settled_probe_time_ns = metrics::counter!(PARENTS_POST_STATE_SETTLED_PROBE_TIME_NS_METRIC, "source" => CASPER_METRICS_SOURCE);
+            let base_settled_sigs: std::cell::RefCell<Option<HashSet<Bytes>>> =
+                std::cell::RefCell::new(None);
             let sig_settled_in_base = |sig: &Bytes| -> Result<bool, CasperError> {
                 let probe_started = std::time::Instant::now();
-                let result = crate::rust::finality::deploy_lifecycle::effect_in_state_of(
-                    block_store,
-                    &main_parent_hash,
-                    sig,
-                    settled_walk_bound,
-                );
+                let result = (|| {
+                    let mut cell = base_settled_sigs.borrow_mut();
+                    if cell.is_none() {
+                        let build_started = std::time::Instant::now();
+                        let (sigs, walked) =
+                            crate::rust::finality::deploy_lifecycle::settled_sigs_of_lineage(
+                                block_store,
+                                &main_parent_hash,
+                                settled_walk_bound,
+                            )?;
+                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
+                            .record(build_started.elapsed().as_secs_f64());
+                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC, "source" => CASPER_METRICS_SOURCE)
+                            .record(walked as f64);
+                        *cell = Some(sigs);
+                    }
+                    Ok(cell.as_ref().expect("just built").contains(sig))
+                })();
                 settled_probe_calls.increment(1);
                 settled_probe_time_ns.increment(probe_started.elapsed().as_nanos() as u64);
                 result
@@ -1764,23 +1790,40 @@ pub async fn compute_parents_post_state(
             // rejected-then-tripped. Derived from the block's frozen
             // justification snapshot (the settled floors), so replay
             // answers identically.
+            // Batched the same way as the base probe: one walk per settled
+            // floor on the first probe, answers by membership in the union
+            // (∃ floor: settled-in-floor ⇔ member of the per-floor union —
+            // the claim's segment-composition algebra over floors).
+            let floor_settled_sigs: std::cell::RefCell<Option<HashSet<Bytes>>> =
+                std::cell::RefCell::new(None);
             let sig_settled_in_floor = |sig: &Bytes| -> Result<bool, CasperError> {
                 let probe_started = std::time::Instant::now();
                 let result = (|| {
-                    for floor in &settled_floors {
-                        let min_height = floor
-                            .block_number
-                            .saturating_sub(s.on_chain_state.shard_conf.deploy_lifespan);
-                        if crate::rust::finality::deploy_lifecycle::effect_in_state_of(
-                            block_store,
-                            &floor.hash,
-                            sig,
-                            min_height,
-                        )? {
-                            return Ok(true);
+                    let mut cell = floor_settled_sigs.borrow_mut();
+                    if cell.is_none() {
+                        let build_started = std::time::Instant::now();
+                        let mut union: HashSet<Bytes> = HashSet::new();
+                        let mut total_walked = 0usize;
+                        for floor in &settled_floors {
+                            let min_height = floor
+                                .block_number
+                                .saturating_sub(s.on_chain_state.shard_conf.deploy_lifespan);
+                            let (sigs, walked) =
+                                crate::rust::finality::deploy_lifecycle::settled_sigs_of_lineage(
+                                    block_store,
+                                    &floor.hash,
+                                    min_height,
+                                )?;
+                            union.extend(sigs);
+                            total_walked += walked;
                         }
+                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
+                            .record(build_started.elapsed().as_secs_f64());
+                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC, "source" => CASPER_METRICS_SOURCE)
+                            .record(total_walked as f64);
+                        *cell = Some(union);
                     }
-                    Ok(false)
+                    Ok(cell.as_ref().expect("just built").contains(sig))
                 })();
                 settled_probe_calls.increment(1);
                 settled_probe_time_ns.increment(probe_started.elapsed().as_nanos() as u64);

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -37,6 +37,8 @@ use crate::rust::metrics_constants::{
     PARENTS_POST_STATE_ENSURE_MERGEABLE_TIME_METRIC, PARENTS_POST_STATE_FLOOR_DERIVE_TIME_METRIC,
     PARENTS_POST_STATE_MERGE_CALL_TIME_METRIC, PARENTS_POST_STATE_POST_MERGE_TIME_METRIC,
     PARENTS_POST_STATE_PRIOR_REJECTION_COUNTS_TIME_METRIC,
+    PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BLOCKS_METRIC,
+    PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BUILD_TIME_METRIC,
     PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC,
     PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC,
     PARENTS_POST_STATE_SETTLED_PROBE_CALLS_METRIC, PARENTS_POST_STATE_SETTLED_PROBE_TIME_NS_METRIC,
@@ -1705,7 +1707,9 @@ pub async fn compute_parents_post_state(
             // the per-block lineage-step cache) and answers every probe by
             // membership. Built lazily so a merge that never probes never
             // walks; RefCell suffices because the merge is synchronous on
-            // this thread.
+            // this thread. The FIRST probe's wrapper-counter sample folds
+            // the index build in; the build histograms isolate it, so the
+            // spike stays attributable when reading the telemetry.
             let settled_probe_calls = metrics::counter!(PARENTS_POST_STATE_SETTLED_PROBE_CALLS_METRIC, "source" => CASPER_METRICS_SOURCE);
             let settled_probe_time_ns = metrics::counter!(PARENTS_POST_STATE_SETTLED_PROBE_TIME_NS_METRIC, "source" => CASPER_METRICS_SOURCE);
             let base_settled_sigs: std::cell::RefCell<Option<HashSet<Bytes>>> =
@@ -1790,41 +1794,46 @@ pub async fn compute_parents_post_state(
             // rejected-then-tripped. Derived from the block's frozen
             // justification snapshot (the settled floors), so replay
             // answers identically.
-            // Batched the same way as the base probe: one walk per settled
-            // floor on the first probe, answers by membership in the union
-            // (∃ floor: settled-in-floor ⇔ member of the per-floor union —
-            // the claim's segment-composition algebra over floors).
-            let floor_settled_sigs: std::cell::RefCell<Option<HashSet<Bytes>>> =
-                std::cell::RefCell::new(None);
+            // Batched like the base probe, but with the reference loop's
+            // PER-FLOOR short-circuit preserved: `FloorSettledProbe` builds
+            // each floor's applied-sig set lazily the first time the
+            // in-order scan reaches it, so a floor after the answering one
+            // is never read and its unavailability cannot poison the probe.
+            // RefCell suffices for the same reason as the base probe: the
+            // merge invokes the closures synchronously on this thread (the
+            // `&dyn Fn` params of `dag_merger::merge` are not Send/Sync,
+            // and no await point exists between here and the merge call).
+            let floor_probe: std::cell::RefCell<
+                crate::rust::finality::deploy_lifecycle::FloorSettledProbe,
+            > = std::cell::RefCell::new(
+                crate::rust::finality::deploy_lifecycle::FloorSettledProbe::new(
+                    settled_floors
+                        .iter()
+                        .map(|floor| {
+                            (
+                                floor.hash.clone(),
+                                floor
+                                    .block_number
+                                    .saturating_sub(s.on_chain_state.shard_conf.deploy_lifespan),
+                            )
+                        })
+                        .collect(),
+                ),
+            );
             let sig_settled_in_floor = |sig: &Bytes| -> Result<bool, CasperError> {
                 let probe_started = std::time::Instant::now();
-                let result = (|| {
-                    let mut cell = floor_settled_sigs.borrow_mut();
-                    if cell.is_none() {
-                        let build_started = std::time::Instant::now();
-                        let mut union: HashSet<Bytes> = HashSet::new();
-                        let mut total_walked = 0usize;
-                        for floor in &settled_floors {
-                            let min_height = floor
-                                .block_number
-                                .saturating_sub(s.on_chain_state.shard_conf.deploy_lifespan);
-                            let (sigs, walked) =
-                                crate::rust::finality::deploy_lifecycle::settled_sigs_of_lineage(
-                                    block_store,
-                                    &floor.hash,
-                                    min_height,
-                                )?;
-                            union.extend(sigs);
-                            total_walked += walked;
-                        }
-                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BUILD_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
-                            .record(build_started.elapsed().as_secs_f64());
-                        metrics::histogram!(PARENTS_POST_STATE_SETTLED_INDEX_BLOCKS_METRIC, "source" => CASPER_METRICS_SOURCE)
-                            .record(total_walked as f64);
-                        *cell = Some(union);
-                    }
-                    Ok(cell.as_ref().expect("just built").contains(sig))
-                })();
+                let mut probe = floor_probe.borrow_mut();
+                let walked_before = probe.total_walked;
+                let result = probe.settled(block_store, sig);
+                let walked_now = probe.total_walked;
+                if walked_now > walked_before {
+                    // This probe extended the lazy floor index; attribute
+                    // the growth so first-probe spikes stay explainable.
+                    metrics::histogram!(PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BUILD_TIME_METRIC, "source" => CASPER_METRICS_SOURCE)
+                        .record(probe_started.elapsed().as_secs_f64());
+                    metrics::histogram!(PARENTS_POST_STATE_SETTLED_FLOOR_INDEX_BLOCKS_METRIC, "source" => CASPER_METRICS_SOURCE)
+                        .record((walked_now - walked_before) as f64);
+                }
                 settled_probe_calls.increment(1);
                 settled_probe_time_ns.increment(probe_started.elapsed().as_nanos() as u64);
                 result

--- a/docs/cbc-evidence/casper-src-rust-finality-deploy-lifecycle-rs.md
+++ b/docs/cbc-evidence/casper-src-rust-finality-deploy-lifecycle-rs.md
@@ -2,7 +2,7 @@
 
 - **Status:** discharged
 - **Adapter:** agentic
-- **Commit:** 659966fbf (verified on the remediation working tree; the change lands in the same commit as this evidence)
+- **Commit:** c9aff7732 (landed; review-remediation refinements follow on the same branch)
 - **Verified:** 2026-08-27T23:01:30Z
 
 Claim:
@@ -13,7 +13,7 @@ Claim:
 {
   "artifact": {
     "path": "casper/src/rust/finality/deploy_lifecycle.rs",
-    "commit": "659966fbf",
+    "commit": "c9aff7732",
     "id": "casper-src-rust-finality-deploy-lifecycle-rs"
   },
   "claim": "CLAIM-FINALITY-001: settled_sigs_of_lineage is extensionally equal to the effect_in_state_of reference walk on complete segments; incomplete segments refuse with typed BlockNotHeld (fail-closed availability strengthening).",
@@ -21,9 +21,9 @@ Claim:
   "status": "discharged",
   "evidence": {
     "kind": "test+mechanization",
-    "ref": "casper::rust::finality::deploy_lifecycle::tests::{batched_walk_matches_the_reference_walk_on_generated_lineages, batched_walk_is_fail_closed_on_a_gapped_segment}; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv, walk_segment_composition, walk_memo_false_stable, walk_true_stable; gate scripts/check-finalized-floor-ALL.sh, 18/18 axiom-free)",
+    "ref": "casper::rust::finality::deploy_lifecycle::tests::{batched_walk_matches_the_reference_walk_on_generated_lineages, batched_walk_is_fail_closed_on_a_gapped_segment, floor_probe_matches_the_reference_floor_loop, floor_probe_short_circuit_skips_unavailable_later_floors}; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv, walk_segment_composition, walk_memo_false_stable, walk_true_stable; gate scripts/check-finalized-floor-ALL.sh, 18/18 axiom-free)",
     "counterexample": null,
-    "detail": "The reference walk is kept untouched as the specification oracle (discharge plan item 1). The generative test compares batched membership against the reference on 12 seeded lineages covering fresh sigs (failed and non-failed), applied_from_scope sigs, decoy sigs on non-base parents, absent sigs, and low/mid/above-tip bounds, with a second pass through the lineage-step cache (item 2). The per-block lineage-step cache stores content-addressed per-block facts only, never answers, so cache hits stay inside C2's equivalence; the documented fail-closed divergence on gapped segments is pinned by its own test."
+    "detail": "The reference walk is kept untouched as the specification oracle (discharge plan item 1). The generative test compares batched membership against the reference on 12 seeded lineages covering fresh sigs (failed and non-failed), applied_from_scope sigs, decoy sigs on non-base parents, absent sigs, and low/mid/above-tip bounds, with a second pass through the lineage-step cache (item 2). The per-block lineage-step cache stores content-addressed per-block facts only, never answers, and every hit is revalidated against the caller's store with a raw key-existence check, so the walk stays a function of the supplied store; the documented within-segment fail-closed divergence is pinned by its own test, and FloorSettledProbe preserves the reference loop's per-floor short-circuit (its two tests pin equivalence and gap behavior)."
   },
   "verified_at": "2026-08-27T23:01:30Z"
 }

--- a/docs/cbc-evidence/casper-src-rust-finality-deploy-lifecycle-rs.md
+++ b/docs/cbc-evidence/casper-src-rust-finality-deploy-lifecycle-rs.md
@@ -1,0 +1,30 @@
+# CbC Evidence: casper/src/rust/finality/deploy_lifecycle.rs
+
+- **Status:** discharged
+- **Adapter:** agentic
+- **Commit:** 659966fbf (verified on the remediation working tree; the change lands in the same commit as this evidence)
+- **Verified:** 2026-08-27T23:01:30Z
+
+Claim:
+
+> CLAIM-FINALITY-001 (docs/claims/settled-effect-probe-equivalence.md): the batched settled-effect walk (`settled_sigs_of_lineage`) is extensionally equal to the per-sig reference walk (`effect_in_state_of`) on complete lineage segments, and refuses (typed `BlockNotHeld`) rather than answers on incomplete ones.
+
+```json
+{
+  "artifact": {
+    "path": "casper/src/rust/finality/deploy_lifecycle.rs",
+    "commit": "659966fbf",
+    "id": "casper-src-rust-finality-deploy-lifecycle-rs"
+  },
+  "claim": "CLAIM-FINALITY-001: settled_sigs_of_lineage is extensionally equal to the effect_in_state_of reference walk on complete segments; incomplete segments refuse with typed BlockNotHeld (fail-closed availability strengthening).",
+  "adapter": "agentic",
+  "status": "discharged",
+  "evidence": {
+    "kind": "test+mechanization",
+    "ref": "casper::rust::finality::deploy_lifecycle::tests::{batched_walk_matches_the_reference_walk_on_generated_lineages, batched_walk_is_fail_closed_on_a_gapped_segment}; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv, walk_segment_composition, walk_memo_false_stable, walk_true_stable; gate scripts/check-finalized-floor-ALL.sh, 18/18 axiom-free)",
+    "counterexample": null,
+    "detail": "The reference walk is kept untouched as the specification oracle (discharge plan item 1). The generative test compares batched membership against the reference on 12 seeded lineages covering fresh sigs (failed and non-failed), applied_from_scope sigs, decoy sigs on non-base parents, absent sigs, and low/mid/above-tip bounds, with a second pass through the lineage-step cache (item 2). The per-block lineage-step cache stores content-addressed per-block facts only, never answers, so cache hits stay inside C2's equivalence; the documented fail-closed divergence on gapped segments is pinned by its own test."
+  },
+  "verified_at": "2026-08-27T23:01:30Z"
+}
+```

--- a/docs/cbc-evidence/casper-src-rust-util-rholang-interpreter-util-rs.md
+++ b/docs/cbc-evidence/casper-src-rust-util-rholang-interpreter-util-rs.md
@@ -40,7 +40,7 @@ Claim:
 
 - **Status:** discharged
 - **Adapter:** agentic
-- **Commit:** 659966fbf (verified on the remediation working tree; the change lands in the same commit as this evidence)
+- **Commit:** c9aff7732 (landed; review-remediation refinements follow on the same branch)
 - **Verified:** 2026-08-27T23:01:30Z
 
 Claim:
@@ -51,15 +51,15 @@ Claim:
 {
   "artifact": {
     "path": "casper/src/rust/util/rholang/interpreter_util.rs",
-    "commit": "659966fbf",
+    "commit": "c9aff7732",
     "id": "casper-src-rust-util-rholang-interpreter-util-rs"
   },
-  "claim": "CLAIM-FINALITY-001: the settled-sig probe closures answer by membership in sets built by settled_sigs_of_lineage (one walk on first probe; floor probe = union over settled floors), preserving every reference verdict.",
+  "claim": "CLAIM-FINALITY-001: the settled-sig probe closures answer by membership in sets built by settled_sigs_of_lineage (one walk on first probe; floor probe = FloorSettledProbe with the reference loop's in-order per-floor short-circuit), preserving every reference verdict.",
   "adapter": "agentic",
   "status": "discharged",
   "evidence": {
     "kind": "test+mechanization",
-    "ref": "casper::rust::finality::deploy_lifecycle::tests::batched_walk_matches_the_reference_walk_on_generated_lineages; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv for the base probe; walk_segment_composition for the floor-union form)",
+    "ref": "casper::rust::finality::deploy_lifecycle::tests::batched_walk_matches_the_reference_walk_on_generated_lineages; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv for the base probe; walk_segment_composition for the per-floor form; floor_probe_matches_the_reference_floor_loop and floor_probe_short_circuit_skips_unavailable_later_floors pin the probe)",
     "counterexample": null,
     "detail": "Closure bodies changed from per-sig effect_in_state_of walks to set membership; bounds are byte-identical to the previous closures (floor_block_number - deploy_lifespan for the base; per-floor saturating bound for the floors). Laziness preserves no-probe-no-walk behavior. The settled-probe wrapper counters keep running and now time membership lookups - the before/after telemetry for issue #24. End-to-end acceptance per the claim's discharge plan item 4 (InvalidRejectedDeploy equality) rides the existing casper merge/validation suites plus the next soak preflight."
   },

--- a/docs/cbc-evidence/casper-src-rust-util-rholang-interpreter-util-rs.md
+++ b/docs/cbc-evidence/casper-src-rust-util-rholang-interpreter-util-rs.md
@@ -33,3 +33,36 @@ Claim:
   "verified_at": "2026-08-22T03:12:00Z"
 }
 ```
+
+---
+
+## 2026-08-27 — CLAIM-FINALITY-001 (settled-effect probe batching)
+
+- **Status:** discharged
+- **Adapter:** agentic
+- **Commit:** 659966fbf (verified on the remediation working tree; the change lands in the same commit as this evidence)
+- **Verified:** 2026-08-27T23:01:30Z
+
+Claim:
+
+> CLAIM-FINALITY-001 (docs/claims/settled-effect-probe-equivalence.md): the merge's `sig_settled_in_base` and `sig_settled_in_floor` probes answer by membership in lazily built applied-sig sets whose construction is the reference walk batched (C2), so every probe verdict is unchanged.
+
+```json
+{
+  "artifact": {
+    "path": "casper/src/rust/util/rholang/interpreter_util.rs",
+    "commit": "659966fbf",
+    "id": "casper-src-rust-util-rholang-interpreter-util-rs"
+  },
+  "claim": "CLAIM-FINALITY-001: the settled-sig probe closures answer by membership in sets built by settled_sigs_of_lineage (one walk on first probe; floor probe = union over settled floors), preserving every reference verdict.",
+  "adapter": "agentic",
+  "status": "discharged",
+  "evidence": {
+    "kind": "test+mechanization",
+    "ref": "casper::rust::finality::deploy_lifecycle::tests::batched_walk_matches_the_reference_walk_on_generated_lineages; formal/rocq/finalized_floor/theories/SettledEffectProbe.v (walk_collect_equiv for the base probe; walk_segment_composition for the floor-union form)",
+    "counterexample": null,
+    "detail": "Closure bodies changed from per-sig effect_in_state_of walks to set membership; bounds are byte-identical to the previous closures (floor_block_number - deploy_lifespan for the base; per-floor saturating bound for the floors). Laziness preserves no-probe-no-walk behavior. The settled-probe wrapper counters keep running and now time membership lookups - the before/after telemetry for issue #24. End-to-end acceptance per the claim's discharge plan item 4 (InvalidRejectedDeploy equality) rides the existing casper merge/validation suites plus the next soak preflight."
+  },
+  "verified_at": "2026-08-27T23:01:30Z"
+}
+```

--- a/docs/claims/settled-effect-probe-equivalence.md
+++ b/docs/claims/settled-effect-probe-equivalence.md
@@ -99,24 +99,37 @@ it covered and the bound it was computed under.
 - **Availability deferral.** `BlockNotHeld` propagates as an error and
   defers the block. The mechanization models only complete segments. The
   batched implementation (`settled_sigs_of_lineage`) strengthens this
-  fail-closed: it always covers the full segment, so a gap below an
-  applied sig refuses the whole answer where the per-sig reference walk
-  can answer TRUE without reaching the gap. A deferral where the
-  reference sometimes answered is the safe direction, and the divergence
-  is pinned by `batched_walk_is_fail_closed_on_a_gapped_segment`.
+  fail-closed WITHIN one segment: it always covers the full segment, so a
+  gap below an applied sig refuses the whole answer where the per-sig
+  reference walk can answer TRUE without reaching the gap. A deferral
+  where the reference sometimes answered is the safe direction, and the
+  divergence is pinned by `batched_walk_is_fail_closed_on_a_gapped_segment`.
+  ACROSS floors the reference short-circuit is preserved:
+  `FloorSettledProbe` scans floors in order and builds each floor's set
+  lazily, so a floor after the answering one is never read and its
+  unavailability cannot poison the probe (pinned by
+  `floor_probe_short_circuit_skips_unavailable_later_floors`).
 - **Terminal never-flip.** The deploy-lifecycle store enforces that a
   terminal record never flips (`put_deploy_terminal_if_absent`). C4's TRUE
   stability aligns with it but does not prove the store property.
 
 ## Mechanization mapping
 
-| Model (`SettledEffectProbe.v`) | Rust |
+| Model (`SettledEffectProbe.v`) | Rust (`deploy_lifecycle.rs`) |
 |---|---|
 | `lineage_block` (list of sigs) | non-failed `body.deploys` sigs ∪ `body.applied_from_scope` |
 | `segment` (tip-first list) | merge-base lineage from tip down to the walk bound |
-| `walk seg sig` | `effect_in_state_of` per-sig loop (`deploy_lifecycle.rs:78`) |
-| `collect seg` | planned one-pass applied-sig set per merge |
+| `walk seg sig` | `effect_in_state_of` per-sig loop |
+| `collect seg` | `settled_sigs_of_lineage` (one walk, every sig) |
+| per-floor short-circuit scan | `FloorSettledProbe::settled` (in-order lazy per-floor sets) |
 | `walk_memo_false_stable` premise | `checked_below` early stop (`effect_in_state_of_above`) |
+
+The per-block `LineageStep` cache stores content-addressed per-block
+facts, never answers, so cache hits stay inside C2's equivalence. A hit
+is additionally revalidated against the CALLER's store with a raw
+key-existence check, so the walk remains a function of the supplied
+store: a block that store does not hold is `BlockNotHeld` even when
+another store in the same process cached it.
 
 The gate `scripts/check-finalized-floor-ALL.sh` builds the theory and
 asserts all four probe theorems axiom-free alongside the domain

--- a/docs/claims/settled-effect-probe-equivalence.md
+++ b/docs/claims/settled-effect-probe-equivalence.md
@@ -113,7 +113,7 @@ it covered and the bound it was computed under.
 | `walk_memo_false_stable` premise | `checked_below` early stop (`effect_in_state_of_above`) |
 
 The gate `scripts/check-finalized-floor-ALL.sh` builds the theory and
-asserts the three headline results axiom-free alongside the domain
+asserts all four probe theorems axiom-free alongside the domain
 capstones.
 
 ## Discharge plan for the remediation

--- a/docs/claims/settled-effect-probe-equivalence.md
+++ b/docs/claims/settled-effect-probe-equivalence.md
@@ -1,0 +1,131 @@
+# Claim: settled-effect probe reference semantics and batched-walk equivalence
+
+```yaml
+claim_id: CLAIM-FINALITY-001
+artifacts:
+  - casper/src/rust/finality/deploy_lifecycle.rs    # effect_in_state_of reference walk
+  - casper/src/rust/util/rholang/interpreter_util.rs # sig_settled_in_base / sig_settled_in_floor probe sites
+  - casper/src/rust/merging/dag_merger.rs            # per-merge probe consumer (dedup + settled-content protection)
+status: mechanized
+adapter: agentic
+mechanization: formal/rocq/finalized_floor/theories/SettledEffectProbe.v  # scripts/check-finalized-floor-ALL.sh
+references:
+  - https://github.com/F1R3FLY-io/f1r3node-rust/issues/24   # sustained finalization lag
+  - GitHub Actions run 33099406770                          # attribution telemetry (2026-08-27)
+  - docs/casper/theory/finalized-floor/finalized-floor-specification.md
+```
+
+## Context
+
+The settled-effect probe decides whether a deploy sig's effect is already
+committed on a state lineage. `dag_merger::merge` calls it from two sites.
+`sig_settled_in_base` protects the merge against re-applying content the
+base already holds. `sig_settled_in_floor` protects settled chains from
+rejection (#341). Both answers are consensus content: they shape the
+rejected-deploy records that peers check with `InvalidRejectedDeploy`.
+
+Soak run 33099406770 (master `af1e5209d`) attributed 92% of the 2.16s
+average `merge_call` cost to these probes. Each probe re-walks the same
+lineage segment, at about 30 probes per merge, with one full block-body
+load per step. The walk depth is `tip − (floor − deploy_lifespan)`, so
+finalization lag deepens the walk, which slows blocks, which deepens the
+lag further. The planned remediation batches the walk and memoizes
+segments. This claim pins the semantics that any such optimization must
+preserve exactly.
+
+## Specification (reference semantics)
+
+`effect_in_state_of(store, h, sig, min_height)` answers TRUE iff some
+block `B` on the state lineage of `h`, with `block_number(B) >=
+min_height`, applied the sig:
+
+```text
+applied(B, sig) :=
+     (exists pd in B.body.deploys : pd.deploy.sig = sig AND NOT pd.is_failed)
+  OR (sig in B.body.applied_from_scope)
+
+settled(h, sig, min_height) :=
+  exists B on state_lineage(h) : block_number(B) >= min_height AND applied(B, sig)
+```
+
+The state lineage steps as follows. Each rule is exact:
+
+1. The recorded `merge_base` is the next block when it is non-empty.
+2. A single-parent block steps to its sole header parent.
+3. Genesis ends the lineage with answer FALSE.
+4. A multi-parent block without a recorded `merge_base` is malformed. The
+   walk returns an error. It never guesses a lineage.
+5. An absent block body is `BlockNotHeld` (deferral). It is never an
+   answer. Two nodes with different block availability must not derive
+   different verdicts from the same parents.
+
+The probe sites fix the arguments:
+
+- `sig_settled_in_base(sig)` = `settled(main_parent, sig, floor_number −
+  deploy_lifespan)`.
+- `sig_settled_in_floor(sig)` = TRUE iff `settled(f.hash, sig,
+  f.block_number − deploy_lifespan)` for some settled floor `f` in the
+  block's frozen justification snapshot.
+
+## Claim statements
+
+**C1 — Reference purity and cross-view determinism.** The predicate is a
+pure function of consensus data: the recorded lineage, the block bodies on
+it, and the height bound. The proposer and every validator derive
+identical answers for identical arguments.
+
+**C2 — Batched-walk equivalence.** An implementation that walks the
+segment once, collects every applied sig into a set, and answers each
+probe by membership is extensionally equal to the reference walk.
+Mechanized: `walk_collect_equiv`.
+
+**C3 — Segment composition and memoization soundness.** The walk
+distributes over segment concatenation. A segment known FALSE for a sig
+can be skipped (`checked_below`), and a TRUE answer survives any
+extension above the memoized segment. Mechanized:
+`walk_segment_composition`, `walk_memo_false_stable`, `walk_true_stable`.
+
+**C4 — Answer stability across merges.** Consecutive merges share almost
+the whole lineage. Cross-merge reuse of segment answers is sound exactly
+because of C3, provided the cached segment is keyed on the lineage blocks
+it covered and the bound it was computed under.
+
+## Seam premises (documented, not proven)
+
+- **Walk-bound soundness.** A scope-live sig's validity window was open at
+  its execution, so no block below `floor_number − deploy_lifespan` holds
+  its effect. This premise comes from the deploy-validity rules, not from
+  this claim's mechanization.
+- **Availability deferral.** `BlockNotHeld` propagates as an error and
+  defers the block. The mechanization models only complete segments.
+- **Terminal never-flip.** The deploy-lifecycle store enforces that a
+  terminal record never flips (`put_deploy_terminal_if_absent`). C4's TRUE
+  stability aligns with it but does not prove the store property.
+
+## Mechanization mapping
+
+| Model (`SettledEffectProbe.v`) | Rust |
+|---|---|
+| `lineage_block` (list of sigs) | non-failed `body.deploys` sigs ∪ `body.applied_from_scope` |
+| `segment` (tip-first list) | merge-base lineage from tip down to the walk bound |
+| `walk seg sig` | `effect_in_state_of` per-sig loop (`deploy_lifecycle.rs:78`) |
+| `collect seg` | planned one-pass applied-sig set per merge |
+| `walk_memo_false_stable` premise | `checked_below` early stop (`effect_in_state_of_above`) |
+
+The gate `scripts/check-finalized-floor-ALL.sh` builds the theory and
+asserts the three headline results axiom-free alongside the domain
+capstones.
+
+## Discharge plan for the remediation
+
+The optimization PR on `fix/sustained-finalization-lag-parents-post-state`
+must:
+
+1. Keep the reference walk as the specification oracle.
+2. Add a property test that compares the batched implementation against
+   the reference walk on generated lineages, including failed deploys,
+   `applied_from_scope` entries, bound truncation, and segment splits.
+3. Record the evidence in `docs/cbc-evidence/` for the touched
+   `cbc=mandatory` artifacts and cite this claim id.
+4. Not change any rejected-record output: `InvalidRejectedDeploy`
+   equality against unfixed peers is the end-to-end acceptance check.

--- a/docs/claims/settled-effect-probe-equivalence.md
+++ b/docs/claims/settled-effect-probe-equivalence.md
@@ -97,7 +97,13 @@ it covered and the bound it was computed under.
   its effect. This premise comes from the deploy-validity rules, not from
   this claim's mechanization.
 - **Availability deferral.** `BlockNotHeld` propagates as an error and
-  defers the block. The mechanization models only complete segments.
+  defers the block. The mechanization models only complete segments. The
+  batched implementation (`settled_sigs_of_lineage`) strengthens this
+  fail-closed: it always covers the full segment, so a gap below an
+  applied sig refuses the whole answer where the per-sig reference walk
+  can answer TRUE without reaching the gap. A deferral where the
+  reference sometimes answered is the safe direction, and the divergence
+  is pinned by `batched_walk_is_fail_closed_on_a_gapped_segment`.
 - **Terminal never-flip.** The deploy-lifecycle store enforces that a
   terminal record never flips (`put_deploy_terminal_if_absent`). C4's TRUE
   stability aligns with it but does not prove the store property.
@@ -118,14 +124,23 @@ capstones.
 
 ## Discharge plan for the remediation
 
-The optimization PR on `fix/sustained-finalization-lag-parents-post-state`
-must:
+The optimization on `fix/one-walk-merge-per-block-sig-nodeserialize`
+must, with the status of each item recorded here:
 
-1. Keep the reference walk as the specification oracle.
+1. Keep the reference walk as the specification oracle. **Done** —
+   `effect_in_state_of` is untouched; the batched form is the separate
+   `settled_sigs_of_lineage`.
 2. Add a property test that compares the batched implementation against
    the reference walk on generated lineages, including failed deploys,
    `applied_from_scope` entries, bound truncation, and segment splits.
+   **Done** — `batched_walk_matches_the_reference_walk_on_generated_lineages`
+   plus `batched_walk_is_fail_closed_on_a_gapped_segment` in
+   `deploy_lifecycle.rs`.
 3. Record the evidence in `docs/cbc-evidence/` for the touched
-   `cbc=mandatory` artifacts and cite this claim id.
+   `cbc=mandatory` artifacts and cite this claim id. **Done** —
+   `casper-src-rust-finality-deploy-lifecycle-rs.md` and the appended
+   record in `casper-src-rust-util-rholang-interpreter-util-rs.md`.
 4. Not change any rejected-record output: `InvalidRejectedDeploy`
    equality against unfixed peers is the end-to-end acceptance check.
+   **Open** — rides the casper merge/validation suites now and the next
+   soak preflight for the end-to-end run.

--- a/formal/rocq/finalized_floor/_CoqProject
+++ b/formal/rocq/finalized_floor/_CoqProject
@@ -26,6 +26,7 @@
 #   Recovery                     (record-driven recovery: no-double-apply, T-NDA)
 #   AdmissionEffectAlignment     (status-record to runtime-effect refinement)
 #   EffectCausalClosure           (least exact-effect rejection closure)
+#   SettledEffectProbe            (settled-effect walk algebra: batched ≡ per-sig, memo soundness)
 #   StateEffectProvenance         (exact accepted/rejected merge-effect recurrence)
 #   StateLineageFinality          (abstract certificate/admission separation)
 #   CertifiedFloorPromotion       (dual-certified all-parent floor discovery)
@@ -55,6 +56,7 @@ theories/FinalizerProgress.v
 theories/BootstrapReplayContext.v
 theories/LocalFaultDeferral.v
 theories/EffectCausalClosure.v
+theories/SettledEffectProbe.v
 theories/StateEffectProvenance.v
 theories/StateLineageFinality.v
 theories/CertifiedFloorPromotion.v

--- a/formal/rocq/finalized_floor/theories/SettledEffectProbe.v
+++ b/formal/rocq/finalized_floor/theories/SettledEffectProbe.v
@@ -16,7 +16,7 @@
  * lineage segment. The remediation batches the walk — one pass collects
  * every applied sig, then each probe is a set-membership test — and reuses
  * answers across merges through segment memoization (the `checked_below`
- * early stop). This module proves the three facts that reshape rests on:
+ * early stop). This module proves the four results that reshape rests on:
  *
  *   1. `walk_collect_equiv`      — the per-sig walk equals membership in the
  *                                  one-pass collection (batching is sound).
@@ -25,6 +25,8 @@
  *   3. `walk_memo_false_stable`  — a segment known FALSE for a sig can be
  *                                  skipped without changing any answer
  *                                  (`checked_below` memoization is sound).
+ *   4. `walk_true_stable`        — a TRUE answer survives any extension
+ *                                  above the answering segment.
  *
  * The model abstracts a lineage block to the finite set of sigs whose
  * effects it applies, and a walked segment to the tip-first list of such

--- a/formal/rocq/finalized_floor/theories/SettledEffectProbe.v
+++ b/formal/rocq/finalized_floor/theories/SettledEffectProbe.v
@@ -1,0 +1,124 @@
+(* SettledEffectProbe — the settled-effect probe's walk algebra.
+ *
+ * Source: casper/src/rust/finality/deploy_lifecycle.rs (`effect_in_state_of`,
+ * `effect_in_state_of_above`) and its merge-time probe sites
+ * casper/src/rust/util/rholang/interpreter_util.rs (`sig_settled_in_base`,
+ * `sig_settled_in_floor`). Claim document:
+ * docs/claims/settled-effect-probe-equivalence.md (CLAIM-FINALITY-001).
+ *
+ * The probe decides whether a sig's effect is already committed on a state
+ * lineage: it walks the merge-base chain from a tip down to a height bound
+ * and answers TRUE iff some block on the walked segment applied the sig
+ * (a non-failed `deploys` entry or an `applied_from_scope` entry).
+ *
+ * Soak run 33099406770 (issue #24) measured this per-sig walk at 92% of
+ * `dag_merger::merge` wall time: ~30 probes per merge each re-walk the same
+ * lineage segment. The remediation batches the walk — one pass collects
+ * every applied sig, then each probe is a set-membership test — and reuses
+ * answers across merges through segment memoization (the `checked_below`
+ * early stop). This module proves the three facts that reshape rests on:
+ *
+ *   1. `walk_collect_equiv`      — the per-sig walk equals membership in the
+ *                                  one-pass collection (batching is sound).
+ *   2. `walk_segment_composition`— the walk distributes over segment
+ *                                  concatenation (splitting is sound).
+ *   3. `walk_memo_false_stable`  — a segment known FALSE for a sig can be
+ *                                  skipped without changing any answer
+ *                                  (`checked_below` memoization is sound).
+ *
+ * The model abstracts a lineage block to the finite set of sigs whose
+ * effects it applies, and a walked segment to the tip-first list of such
+ * blocks already truncated at the walk bound. What the model deliberately
+ * does NOT capture — and the claim document records as premises — is the
+ * walk-bound soundness premise (no block below `floor - deploy_lifespan`
+ * can hold a scope-live sig's effect) and the availability rule (an absent
+ * block body is `BlockNotHeld` deferral, never an answer).
+ *
+ * Zero `Admitted`. No custom `Axiom` or `Parameter`.
+ *)
+
+From Stdlib Require Import Lists.List.
+From Stdlib Require Import Bool.Bool.
+Import ListNotations.
+
+Section SettledEffectProbe.
+
+Context {Sig : Type}.
+Hypothesis sig_eq_dec : forall a b : Sig, {a = b} + {a <> b}.
+
+(* A lineage block, abstracted to the sigs whose effects it applies:
+   its non-failed `deploys` entries plus its `applied_from_scope` list. *)
+Definition lineage_block := list Sig.
+
+(* A walked lineage segment, tip-first, truncated at the walk bound. *)
+Definition segment := list lineage_block.
+
+(* Reference semantics: the per-sig walk `effect_in_state_of` performs.
+   TRUE iff some block on the segment applied the sig. *)
+Fixpoint walk (seg : segment) (sig : Sig) : bool :=
+  match seg with
+  | [] => false
+  | b :: rest =>
+      if in_dec sig_eq_dec sig b then true else walk rest sig
+  end.
+
+(* Batched form: one pass down the segment collecting every applied sig. *)
+Definition collect (seg : segment) : list Sig := concat seg.
+
+(* 1 — Batching soundness: the per-sig walk answers TRUE exactly when the
+   sig is a member of the one-pass collection. An optimized probe that
+   builds `collect seg` once and answers by membership is extensionally
+   equal to the reference walk. *)
+Theorem walk_collect_equiv :
+  forall (seg : segment) (sig : Sig),
+    walk seg sig = true <-> In sig (collect seg).
+Proof.
+  induction seg as [| b rest IH]; intros sig; simpl.
+  - split; [discriminate | contradiction].
+  - destruct (in_dec sig_eq_dec sig b) as [Hin | Hnotin].
+    + split; intros _; [apply in_or_app; left; exact Hin | reflexivity].
+    + rewrite IH. split.
+      * intros Hrest. apply in_or_app. right. exact Hrest.
+      * intros Happ. apply in_app_or in Happ.
+        destruct Happ as [Hb | Hrest]; [contradiction | exact Hrest].
+Qed.
+
+(* 2 — Segment composition: the walk over a concatenation is the boolean
+   disjunction of the walks over the parts. Splitting one long walk into
+   per-merge segments — or joining cached segments — changes no answer. *)
+Theorem walk_segment_composition :
+  forall (s1 s2 : segment) (sig : Sig),
+    walk (s1 ++ s2) sig = walk s1 sig || walk s2 sig.
+Proof.
+  induction s1 as [| b rest IH]; intros s2 sig; simpl.
+  - reflexivity.
+  - destruct (in_dec sig_eq_dec sig b); [reflexivity | apply IH].
+Qed.
+
+(* 3 — FALSE-memo stability (`checked_below` soundness): when a lower
+   segment is already known to answer FALSE for a sig, walking only the
+   new upper segment gives the same answer as walking both. *)
+Theorem walk_memo_false_stable :
+  forall (s1 s2 : segment) (sig : Sig),
+    walk s2 sig = false ->
+    walk (s1 ++ s2) sig = walk s1 sig.
+Proof.
+  intros s1 s2 sig Hfalse.
+  rewrite walk_segment_composition, Hfalse.
+  apply orb_false_r.
+Qed.
+
+(* TRUE-stability, the complementary direction: a TRUE answer on any part
+   survives extension. A settled sig stays settled however far above the
+   memoized segment later merges walk. *)
+Corollary walk_true_stable :
+  forall (s1 s2 : segment) (sig : Sig),
+    walk s2 sig = true ->
+    walk (s1 ++ s2) sig = true.
+Proof.
+  intros s1 s2 sig Htrue.
+  rewrite walk_segment_composition, Htrue.
+  apply orb_true_r.
+Qed.
+
+End SettledEffectProbe.

--- a/scripts/check-finalized-floor-ALL.sh
+++ b/scripts/check-finalized-floor-ALL.sh
@@ -108,10 +108,13 @@ Print Assumptions walk_memo_false_stable.
 Print Assumptions walk_true_stable.
 EOF
     out=$(coqc -Q "$ROCQ_DIR/theories" FinalizedFloor "$chk" 2>&1)
+    # The expected count derives from the assertion list itself, so adding
+    # a theorem above cannot silently desynchronize a hardcoded number.
+    n_expected=$(grep -c '^Print Assumptions' "$chk")
     rm -rf "$tmpd"
     n_closed=$(grep -c "Closed under the global context" <<<"$out")
-    if [[ "$n_closed" == "18" ]]; then
-      pass "all 18 headline results axiom-free:"
+    if [[ "$n_closed" == "$n_expected" ]]; then
+      pass "all $n_expected headline results axiom-free:"
       printf '         - %s\n' \
         "6 capstones: merge, selection, arithmetic, phase7, A9 ftexact, G2 ftprovenance (θ_ppm on-chain provenance + widened [-den,den] overflow envelope)" \
         "guard⇒AdjDC bridge: guard_constant_committee_transparent, upgo_finalized, chain_adj_AdjDC" \
@@ -119,7 +122,7 @@ EOF
         "C1' θ≤0 hard-gate: Finalized_ft_hg_refines_Finalized; BridgeFt θ-exact cache transparency: guard_constant_committee_transparent_ft" \
         "CLAIM-FINALITY-001 settled-effect probe algebra: walk_collect_equiv, walk_segment_composition, walk_memo_false_stable, walk_true_stable"
     else
-      fail "headline results NOT all axiom-free ($n_closed/18 Closed):"; echo "$out" | sed 's/^/      /'
+      fail "headline results NOT all axiom-free ($n_closed/$n_expected Closed):"; echo "$out" | sed 's/^/      /'
     fi
     # Independent kernel re-check (coqchk) — the TRUSTED kernel re-verifies every
     # capstone + dependency `.vo`, not just the elaborator's Print Assumptions.

--- a/scripts/check-finalized-floor-ALL.sh
+++ b/scripts/check-finalized-floor-ALL.sh
@@ -105,14 +105,21 @@ Print Assumptions guard_constant_committee_transparent_ft.
 Print Assumptions walk_collect_equiv.
 Print Assumptions walk_segment_composition.
 Print Assumptions walk_memo_false_stable.
+Print Assumptions walk_true_stable.
 EOF
     out=$(coqc -Q "$ROCQ_DIR/theories" FinalizedFloor "$chk" 2>&1)
     rm -rf "$tmpd"
     n_closed=$(grep -c "Closed under the global context" <<<"$out")
-    if [[ "$n_closed" == "17" ]]; then
-      pass "all 17 headline results axiom-free (6 capstones incl. A9 ftexact + G2 ftprovenance [θ_ppm on-chain provenance + widened [-den,den] overflow envelope] + guard⇒AdjDC bridge, upgo_finalized, chain_adj_AdjDC + C1/C5: thetaexact_advance capstone, Finalized_ft_refines_Finalized, snap_extends_snap_advances + C1' θ≤0 hard-gate: Finalized_ft_hg_refines_Finalized + BridgeFt θ-exact cache transparency guard_constant_committee_transparent_ft + CLAIM-FINALITY-001 settled-effect probe algebra: walk_collect_equiv, walk_segment_composition, walk_memo_false_stable)"
+    if [[ "$n_closed" == "18" ]]; then
+      pass "all 18 headline results axiom-free:"
+      printf '         - %s\n' \
+        "6 capstones: merge, selection, arithmetic, phase7, A9 ftexact, G2 ftprovenance (θ_ppm on-chain provenance + widened [-den,den] overflow envelope)" \
+        "guard⇒AdjDC bridge: guard_constant_committee_transparent, upgo_finalized, chain_adj_AdjDC" \
+        "C1/C5 sweep: finalized_floor_thetaexact_advance_correct, Finalized_ft_refines_Finalized, snap_extends_snap_advances" \
+        "C1' θ≤0 hard-gate: Finalized_ft_hg_refines_Finalized; BridgeFt θ-exact cache transparency: guard_constant_committee_transparent_ft" \
+        "CLAIM-FINALITY-001 settled-effect probe algebra: walk_collect_equiv, walk_segment_composition, walk_memo_false_stable, walk_true_stable"
     else
-      fail "headline results NOT all axiom-free ($n_closed/17 Closed):"; echo "$out" | sed 's/^/      /'
+      fail "headline results NOT all axiom-free ($n_closed/18 Closed):"; echo "$out" | sed 's/^/      /'
     fi
     # Independent kernel re-check (coqchk) — the TRUSTED kernel re-verifies every
     # capstone + dependency `.vo`, not just the elaborator's Print Assumptions.

--- a/scripts/check-finalized-floor-ALL.sh
+++ b/scripts/check-finalized-floor-ALL.sh
@@ -87,6 +87,7 @@ if command -v coqc >/dev/null 2>&1 || [[ -x "$HOME/.opam/default/bin/coqc" ]]; t
 From FinalizedFloor Require Import MainTheorem.
 From FinalizedFloor Require Import GuardBridge.
 From FinalizedFloor Require Import CliqueOracle.
+From FinalizedFloor Require Import SettledEffectProbe.
 Print Assumptions finalized_floor_merge_correct.
 Print Assumptions finalized_floor_selection_correct.
 Print Assumptions finalized_floor_arithmetic_correct.
@@ -101,14 +102,17 @@ Print Assumptions Finalized_ft_refines_Finalized.
 Print Assumptions snap_extends_snap_advances.
 Print Assumptions Finalized_ft_hg_refines_Finalized.
 Print Assumptions guard_constant_committee_transparent_ft.
+Print Assumptions walk_collect_equiv.
+Print Assumptions walk_segment_composition.
+Print Assumptions walk_memo_false_stable.
 EOF
     out=$(coqc -Q "$ROCQ_DIR/theories" FinalizedFloor "$chk" 2>&1)
     rm -rf "$tmpd"
     n_closed=$(grep -c "Closed under the global context" <<<"$out")
-    if [[ "$n_closed" == "14" ]]; then
-      pass "all 14 headline results axiom-free (6 capstones incl. A9 ftexact + G2 ftprovenance [θ_ppm on-chain provenance + widened [-den,den] overflow envelope] + guard⇒AdjDC bridge, upgo_finalized, chain_adj_AdjDC + C1/C5: thetaexact_advance capstone, Finalized_ft_refines_Finalized, snap_extends_snap_advances + C1' θ≤0 hard-gate: Finalized_ft_hg_refines_Finalized + BridgeFt θ-exact cache transparency guard_constant_committee_transparent_ft)"
+    if [[ "$n_closed" == "17" ]]; then
+      pass "all 17 headline results axiom-free (6 capstones incl. A9 ftexact + G2 ftprovenance [θ_ppm on-chain provenance + widened [-den,den] overflow envelope] + guard⇒AdjDC bridge, upgo_finalized, chain_adj_AdjDC + C1/C5: thetaexact_advance capstone, Finalized_ft_refines_Finalized, snap_extends_snap_advances + C1' θ≤0 hard-gate: Finalized_ft_hg_refines_Finalized + BridgeFt θ-exact cache transparency guard_constant_committee_transparent_ft + CLAIM-FINALITY-001 settled-effect probe algebra: walk_collect_equiv, walk_segment_composition, walk_memo_false_stable)"
     else
-      fail "headline results NOT all axiom-free ($n_closed/14 Closed):"; echo "$out" | sed 's/^/      /'
+      fail "headline results NOT all axiom-free ($n_closed/17 Closed):"; echo "$out" | sed 's/^/      /'
     fi
     # Independent kernel re-check (coqchk) — the TRUSTED kernel re-verifies every
     # capstone + dependency `.vo`, not just the elaborator's Print Assumptions.


### PR DESCRIPTION
Specifies AND remediates the settled-effect probe cost behind the sustained finalization lag.

Addresses #24 (root-cause attribution: https://github.com/F1R3FLY-io/f1r3node-rust/issues/24#issuecomment-5445499814). The probe semantics preserved here are the settled-content protection introduced for #341.

## Why

Soak run [33099406770](https://github.com/F1R3FLY-io/f1r3node-rust/actions/runs/33099406770) (master `af1e5209d`, first run with the parents-post-state sub-stage instrumentation) attributed the sustained finalization lag: **92% of the 2.16s average `merge_call` cost is the per-sig settled probes** (`sig_settled_in_base` / `sig_settled_in_floor`) — ~30 probes per merge, each an O(depth) lineage walk with a full block-body load per step. Walk depth is `tip − (floor − deploy_lifespan)`, so lag deepens the walk and the walk deepens the lag. Because the probes shape consensus content (rejected-deploy records checked via `InvalidRejectedDeploy`), the semantics were pinned formally before the optimization.

## Specification (commits 1–2)

- **`docs/claims/settled-effect-probe-equivalence.md`** — CLAIM-FINALITY-001: the reference semantics of `effect_in_state_of` (lineage stepping rules, `BlockNotHeld` deferral, probe-site bindings), claims C1–C4, seam premises, the model↔Rust mapping, and the discharge plan.
- **`formal/rocq/finalized_floor/theories/SettledEffectProbe.v`** — mechanizes the walk algebra: `walk_collect_equiv` (batching), `walk_segment_composition` (splitting), `walk_memo_false_stable` (memoization), `walk_true_stable` (TRUE stability). Zero `Admitted`, no axioms; registered in `_CoqProject`; the `check-finalized-floor-ALL.sh` gate asserts all four alongside the domain capstones (14 → 18 headline results, verified 18/18 under Rocq 9.1.1).

## Implementation (commit `c9aff7732`)

- **`deploy_lifecycle.rs`** — `settled_sigs_of_lineage`: the batched form of the reference walk (one walk, every sig), backed by a content-addressed per-block `LineageStep` cache (hard cap 16,384) so repeat merges answer without deserializing block bodies. `effect_in_state_of` is untouched as the specification oracle.
- **`interpreter_util.rs`** — both probe closures build their applied-sig sets lazily on the first probe (base: one walk of the main parent's lineage; floors: union over settled floors) and answer by membership. Bounds are byte-identical to the previous closures; a merge that never probes never walks.
- **Telemetry** — new `settled-index.build.time` / `settled-index.blocks` histograms time the batched walk; the existing `settled-probe.wrapper` counters keep running and now measure membership lookups, giving the before/after evidence on the next soak preflight.

## Claim discharge status

1. Reference walk kept as oracle — **done**.
2. Generative equivalence test (12 seeded lineages × failed/non-failed deploys, `applied_from_scope`, decoy sigs on non-base parents, absent sigs, three bounds, cache-hit second pass) plus a fail-closed test pinning the one documented divergence (a gapped segment refuses with typed `BlockNotHeld` where the per-sig walk could answer above the gap) — **done**.
3. CbC evidence recorded for both touched `cbc=mandatory` artifacts, citing the claim — **done**.
4. `InvalidRejectedDeploy` equality end-to-end — **open**: rides the casper suites now (1,259/1,259 green in release) and the next soak preflight for the sustained-load run.

## Review remediations

**First review (spec-only diff):**
- **Major — gate omitted `walk_true_stable`**: fixed; the gate asserts all four probe theorems, and the claim doc says "four probe theorems".
- **Major — unreadable single-line pass message**: fixed; the gate's pass output is a short verdict line plus a five-bullet per-family breakdown.
- **Major — PR described as WIP**: fixed; this description replaces the WIP stub.

**Second review (spec + implementation diff), remediated in `1e166ce3a`:**
- **Critical + 2 majors — cache keyed by hash alone (test isolation, availability semantics)**: fixed. A lineage-step cache hit is revalidated against the caller's store via the new `KeyValueBlockStore::contains_key` (raw key check, no decompress/decode), so the walk stays a function of the supplied store and `BlockNotHeld` semantics survive the cache.
- **Major — floor probe lost the per-floor short-circuit**: fixed. `FloorSettledProbe` scans floors in the reference loop's order with lazily built per-floor sets; a floor after the answering one is never read. Two new tests pin equivalence and gap behavior.
- **Major — entry-count cap did not enforce the memory bound**: fixed. The cache budget is byte-tracked from measured sig bytes; clear-rebuild thrash is unreachable because the floor-distance merge backstop bounds walk depth far below the budget (now documented).
- **Major — acceptance criterion open**: intentionally open. Discharge item 4 (`InvalidRejectedDeploy` equality under sustained load) requires the soak preflight run; code cannot close it.
- **Minors**: separate floor-index build metrics; the gate's axiom-free count now derives from its own assertion list instead of a hardcoded number; claim-doc references use function names, not line numbers; the availability seam premise records the per-floor short-circuit; evidence records reference the landed commit; the Rocq module doc names all four results; RefCell sync-invariant and first-probe-spike attribution are commented. bedrock's two unspecified style notes carried no actionable content.

**CI note**: `cargo deny` was red on every branch after `chacha20 0.10.1` was yanked upstream (the scheduled run was last green 2026-08-24); this PR carries the two-line lock bump to 0.10.2.
