### PR TITLE
fix(rspace): try_lock_owned() fast path in striped_locks::acquire_locks

### DIFF
--- a/rspace++/src/rspace/striped_locks.rs
+++ b/rspace++/src/rspace/striped_locks.rs
@@ -48,7 +48,21 @@ pub(crate) async fn acquire_locks(
 
     let mut held: Vec<HeldLock> = Vec::with_capacity(indices.len());
     for idx in indices {
-        let guard = stripes[idx].clone().lock_owned().await;
+        // Fast path: try_lock_owned() first. Measured under `rholang-par`
+        // (many concurrent par-branches, each mostly on its own private
+        // stripe) the stripe is free the overwhelming majority of the time —
+        // going through lock_owned().await unconditionally, even when
+        // uncontended, was adding real wall-clock cost around the .await
+        // point itself (not genuine mutex contention — confirmed by direct
+        // measurement) that dominated `phase_a wait` at high fork counts.
+        // Only the genuinely-contended case falls through to the slow
+        // .await path. See issues/02-intra-deploy-par-mutex-rspace.md
+        // items 16-19 (F1R3FLY-io/f1r3node-rust#50) for the measurements
+        // behind this change.
+        let guard = match stripes[idx].clone().try_lock_owned() {
+            Ok(guard) => guard,
+            Err(_) => stripes[idx].clone().lock_owned().await,
+        };
         held.push(HeldLock { _guard: guard });
     }
 


### PR DESCRIPTION
## Summary

Closes the remaining part of #50 (intra-deploy par-operator parallelism does not deliver speedup). #72/#346/#355/#356 fixed the `event_log`/`produce_counter`/`get_store()` contention and the testbed's own thread-count default; this PR fixes the last identified bottleneck: `phase_a wait` staying huge (hundreds of thousands of ms at `FORKS=32`) even after those fixes.

## Root cause

`striped_locks::acquire_locks` always called `tokio::sync::Mutex::lock_owned().await` unconditionally, even when the target stripe was free. Direct measurement (diagnostic instrumentation, not included in this PR) showed real per-stripe contention was negligible — only ~130-180 of 4096 stripes were ever touched during a `FORKS=32` propose, with near-zero expected collisions among them. Despite that, the `.await` path itself carried real wall-clock cost on a heavily-loaded runtime, independent of actual contention — most likely tokio scheduling/cooperative-task-budget overhead around the await point.

## Fix

Try `try_lock_owned()` first; only fall back to the async `.await` path when the stripe is genuinely held by another task.

## Measurements

Three consecutive `rholang-par` testbed runs (`mid` profile, 8 CPU), forks=1→32:

| FORKS | PROPOSE ms (pre-fix) | PROPOSE ms (post-fix) | PhaseA wait ms (pre-fix) | PhaseA wait ms (post-fix) |
|---|---|---|---|---|
| 1 | ~4,600 | 3,302 | ~1,300 | 25 |
| 8 | ~9,000 | 5,784 | ~26,000 | 48 |
| 16 | ~17,500 | 10,052 | ~120,000 | 77 |
| 32 | ~33,000–40,700 | 19,161 | ~430,000–595,000 | 118 |

`FORKS=32`: ~2x faster propose wall-clock, with *lower* CPU peak — the CPU usage in prior runs was largely tokio async-machinery churn around an always-uncontended mutex, not real work.