### PR TITLE
fix(casper): read paths abstain history below the LFS restore horizon

### DIFF
--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -16,4 +16,4 @@
 # Bump both in the same commit: `just repin-system-integration <sha>`
 # (scripts/repin-system-integration.sh) rewrites every pin site together and
 # runs the invariants checker.
-SYSTEM_INTEGRATION_REF=8b4da0f9395fc951b68af1be8ae023fb1aeb9d09
+SYSTEM_INTEGRATION_REF=ce5a825b2c090c8680ced81327e03f83c9bfa38f

--- a/.github/oci-validation.env
+++ b/.github/oci-validation.env
@@ -16,4 +16,4 @@
 # Bump both in the same commit: `just repin-system-integration <sha>`
 # (scripts/repin-system-integration.sh) rewrites every pin site together and
 # runs the invariants checker.
-SYSTEM_INTEGRATION_REF=ce5a825b2c090c8680ced81327e03f83c9bfa38f
+SYSTEM_INTEGRATION_REF=e4a26eb69fcfc611d56d8473f4de2b09960bc173

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -45,7 +45,7 @@ env:
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit,
   # via `just repin-system-integration <sha>`.
-  SYSTEM_INTEGRATION_REF: 8b4da0f9395fc951b68af1be8ae023fb1aeb9d09
+  SYSTEM_INTEGRATION_REF: ce5a825b2c090c8680ced81327e03f83c9bfa38f
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/_integration-pipeline.yml
+++ b/.github/workflows/_integration-pipeline.yml
@@ -45,7 +45,7 @@ env:
   # MUST be kept identical to .github/oci-validation.env (the Full OCI
   # Validation workflow sources that file) — bump both in the same commit,
   # via `just repin-system-integration <sha>`.
-  SYSTEM_INTEGRATION_REF: ce5a825b2c090c8680ced81327e03f83c9bfa38f
+  SYSTEM_INTEGRATION_REF: e4a26eb69fcfc611d56d8473f4de2b09960bc173
   # Pinned OCI CLI installer (release tag + sha256) and CLI version. The
   # install.sh checksum fails closed if the tag is ever moved; OCI_CLI_VERSION
   # pins what the installer pulls from PyPI (without it the installer floats to

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -179,7 +179,14 @@ env:
   # full green x3 on the d94fffd content (run 32691266446 attempts 1+2, run
   # 32759382579), and 8b4da0f is d94fffd merged to main with no further
   # changes.
-  SYSTEM_INTEGRATION_REF: 8b4da0f9395fc951b68af1be8ae023fb1aeb9d09
+  # 2026-08-31: 8b4da0f -> ce5a825 (SI PR #132 branch): retires ftt=-1 from
+  # the joiner-boundary/trim_state/synchrony shards (a negative FTT legally
+  # permits divergent floors that the suite's forbidden-log check treats as
+  # fatal — run 33220782199's arm64-docker failure), makes the joiner test
+  # round-driven, and routes hardcoded timeouts through the hierarchy.
+  # Verified: the three migrated tests green locally at the production FTT.
+  # Re-pin to the merged main SHA once #132 lands.
+  SYSTEM_INTEGRATION_REF: ce5a825b2c090c8680ced81327e03f83c9bfa38f
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/.github/workflows/merge-recovery-soak.yml
+++ b/.github/workflows/merge-recovery-soak.yml
@@ -213,7 +213,11 @@ env:
   # Verified: the three migrated tests green locally at the production FTT;
   # SI CI full green on ce5a825. Re-pin to the merged main SHA once #132
   # lands.
-  SYSTEM_INTEGRATION_REF: ce5a825b2c090c8680ced81327e03f83c9bfa38f
+  # 2026-08-31: ce5a825 -> e4a26eb (system-integration MAIN — the #132 merge
+  # commit; the branch pin's content, now immutable on main). Verified:
+  # descends from ce5a825 (merge-base --is-ancestor), and full node CI green
+  # on the ce5a825 content (this PR's heavy pipeline, all six legs).
+  SYSTEM_INTEGRATION_REF: e4a26eb69fcfc611d56d8473f4de2b09960bc173
   # Pinned OCI CLI installer (release tag + sha256). The checksum fails closed
   # if the tag is ever moved. Bump both together when upgrading.
   OCI_CLI_INSTALLER_URL: "https://raw.githubusercontent.com/oracle/oci-cli/v3.89.1/scripts/install/install.sh"

--- a/block-storage/src/rust/dag/block_dag_key_value_storage.rs
+++ b/block-storage/src/rust/dag/block_dag_key_value_storage.rs
@@ -393,12 +393,15 @@ impl KeyValueDagRepresentation {
         }
     }
 
+    // A latest-message slot can name a block this node does not hold (a
+    // stale slot below an LFS restore horizon); both readers treat it as
+    // absent rather than erroring.
     pub fn latest_message(
         &self,
         validator: &Validator,
     ) -> Result<Option<BlockMetadata>, KvStoreError> {
         match self.latest_message_hash(validator) {
-            Some(hash) => self.lookup_unsafe(&hash).map(Some),
+            Some(hash) => self.lookup(&hash),
             None => Ok(None),
         }
     }
@@ -408,8 +411,9 @@ impl KeyValueDagRepresentation {
 
         let mut result = HashMap::new();
         for (validator, hash) in latest_messages.iter() {
-            let metadata = self.lookup_unsafe(hash)?;
-            result.insert(validator.clone(), metadata);
+            if let Some(metadata) = self.lookup(hash)? {
+                result.insert(validator.clone(), metadata);
+            }
         }
 
         Ok(result)

--- a/casper/src/rust/api/block_api.rs
+++ b/casper/src/rust/api/block_api.rs
@@ -26,6 +26,7 @@ use prost::Message;
 use rspace_plus_plus::rspace::hashing::stable_hash_provider;
 use rspace_plus_plus::rspace::history::Either;
 use rspace_plus_plus::rspace::trace::event::{Event as RspaceEvent, IOEvent};
+use shared::rust::store::key_value_store::KvStoreError;
 use shared::rust::ByteString;
 
 use crate::rust::blocks::proposer::propose_result::{
@@ -37,7 +38,7 @@ use crate::rust::engine::engine_cell::EngineCell;
 use crate::rust::errors::CasperError;
 use crate::rust::genesis::contracts::standard_deploys;
 use crate::rust::reporting_proto_transformer::ReportingProtoTransformer;
-use crate::rust::safety_oracle::{CliqueOracleImpl, SafetyOracle};
+use crate::rust::safety_oracle::{CliqueOracleImpl, SafetyOracle, MIN_FAULT_TOLERANCE};
 use crate::rust::state::instances::proposer_state::ProposerState;
 use crate::rust::util::rholang::runtime_manager::RuntimeManager;
 use crate::rust::util::rholang::tools::Tools;
@@ -462,8 +463,14 @@ impl BlockAPI {
                         return Ok(Some(light_block_info));
                     }
                     Ok(false) => {}
+                    // A block the scan window names but this node does not
+                    // hold (an LFS restore horizon) is skipped, not an error.
                     Err(err) => {
-                        return Err(err);
+                        tracing::debug!(
+                            "fallback deploy scan skipping unreadable block {}: {}",
+                            PrettyPrinter::build_string_bytes(&hash),
+                            err
+                        );
                     }
                 }
             }
@@ -1148,10 +1155,19 @@ impl BlockAPI {
 
             let mut block_infos_at_height_acc = Vec::new();
             for block_hashes_at_height in topo_sort_dag {
-                let blocks_at_height: Vec<_> = block_hashes_at_height
-                    .iter()
-                    .map(|block_hash| casper.block_store().get_unsafe(block_hash))
-                    .collect();
+                // A height window can name blocks this node does not hold
+                // (an LFS restore horizon); serve the held ones.
+                let mut blocks_at_height: Vec<BlockMessage> =
+                    Vec::with_capacity(block_hashes_at_height.len());
+                for block_hash in block_hashes_at_height.iter() {
+                    match casper.block_store().get(block_hash)? {
+                        Some(block) => blocks_at_height.push(block),
+                        None => tracing::debug!(
+                            "get-blocks-by-heights skipping unheld block {}",
+                            PrettyPrinter::build_string_bytes(block_hash)
+                        ),
+                    }
+                }
 
                 for block in blocks_at_height {
                     let block_info =
@@ -1250,9 +1266,12 @@ impl BlockAPI {
     ) -> ApiErr<String> {
         let do_it = |(_casper, topo_sort): (&dyn MultiParentCasper, Vec<Vec<BlockHash>>)| -> ApiErr<String> {
             // case (_, topoSort) => ...
+            // An unheld block (an LFS restore horizon) renders without edges.
             let fetch_parents = |block_hash: &BlockHash| -> Vec<BlockHash> {
-                let block = _casper.block_store().get_unsafe(block_hash);
-                block.header.parents_hash_list.clone()
+                match _casper.block_store().get(block_hash) {
+                    Ok(Some(block)) => block.header.parents_hash_list.clone(),
+                    _ => Vec::new(),
+                }
             };
 
             //string will be converted to an ApiErr<String>
@@ -1295,7 +1314,15 @@ impl BlockAPI {
         let mut block_infos_acc = Vec::new();
         for block_hashes_at_height in topo_sort {
             for block_hash in block_hashes_at_height {
-                let block = casper.block_store().get_unsafe(&block_hash);
+                // A height window can name blocks this node does not hold
+                // (an LFS restore horizon); serve the held ones.
+                let Some(block) = casper.block_store().get(&block_hash)? else {
+                    tracing::debug!(
+                        "get-blocks skipping unheld block {}",
+                        PrettyPrinter::build_string_bytes(&block_hash)
+                    );
+                    continue;
+                };
                 let block_info = BlockAPI::get_block_info_with_dag(
                     casper.as_ref(),
                     &dag,
@@ -1333,7 +1360,15 @@ impl BlockAPI {
         let mut block_infos_acc = Vec::new();
         for block_hashes_at_height in topo_sort {
             for block_hash in block_hashes_at_height {
-                let block = casper.block_store().get_unsafe(&block_hash);
+                // A height window can name blocks this node does not hold
+                // (an LFS restore horizon); serve the held ones.
+                let Some(block) = casper.block_store().get(&block_hash)? else {
+                    tracing::debug!(
+                        "get-blocks-full skipping unheld block {}",
+                        PrettyPrinter::build_string_bytes(&block_hash)
+                    );
+                    continue;
+                };
                 let block_info = BlockAPI::get_block_info_with_dag(
                     casper.as_ref(),
                     &dag,
@@ -1425,9 +1460,12 @@ impl BlockAPI {
             // of node-local insertion order.
             let maybe_block_hash = dag.deploy_canonical_appearance(deploy_id)?;
 
-            match maybe_block_hash {
-                Some(block_hash) => {
-                    let block = casper.block_store().get_unsafe(&block_hash);
+            // The canonical carrier can sit below an LFS restore horizon;
+            // fall through to the recent-blocks scan instead of erroring.
+            match maybe_block_hash
+                .and_then(|block_hash| casper.block_store().get(&block_hash).ok().flatten())
+            {
+                Some(block) => {
                     let light_block_info =
                         BlockAPI::get_light_block_info(casper.as_ref(), &block).await?;
                     Ok(light_block_info)
@@ -1539,16 +1577,10 @@ impl BlockAPI {
             if let Ok(Some(meta)) = dag.lookup(&block.block_hash) {
                 meta.fault_tolerance_value
             } else {
-                let safety_oracle = CliqueOracleImpl;
-                safety_oracle
-                    .normalized_fault_tolerance(dag, &block.block_hash)
-                    .await?
+                Self::fault_tolerance_or_unknown(dag, &block.block_hash).await?
             }
         } else {
-            let safety_oracle = CliqueOracleImpl;
-            safety_oracle
-                .normalized_fault_tolerance(dag, &block.block_hash)
-                .await?
+            Self::fault_tolerance_or_unknown(dag, &block.block_hash).await?
         };
 
         let weights_map = proto_util::weight_map(block);
@@ -1562,6 +1594,32 @@ impl BlockAPI {
 
         let block_info = constructor(block, fault_tolerance, is_finalized);
         Ok(block_info)
+    }
+
+    /// An oracle walk that reaches history this node does not hold (an LFS
+    /// restore horizon) reads as unknown fault tolerance, never as an API
+    /// failure.
+    async fn fault_tolerance_or_unknown(
+        dag: &KeyValueDagRepresentation,
+        block_hash: &BlockHash,
+    ) -> ApiErr<f32> {
+        let safety_oracle = CliqueOracleImpl;
+        match safety_oracle
+            .normalized_fault_tolerance(dag, block_hash)
+            .await
+        {
+            Ok(ft) => Ok(ft),
+            Err(KvStoreError::MissingBlock { hash, .. }) => {
+                tracing::debug!(
+                    "fault tolerance unknown for {}: history below the restore \
+                     horizon ({})",
+                    PrettyPrinter::build_string_bytes(block_hash),
+                    PrettyPrinter::build_string_bytes(&hash)
+                );
+                Ok(MIN_FAULT_TOLERANCE)
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 
     async fn get_block_info<M: MultiParentCasper + ?Sized, A: Sized + Send>(

--- a/casper/src/rust/engine/multi_parent_casper/snapshot.rs
+++ b/casper/src/rust/engine/multi_parent_casper/snapshot.rs
@@ -142,9 +142,28 @@ pub(crate) async fn compute_snapshot<T: TransportLayer + Send + Sync>(
     // storage I/O.
     let mut valid_latest_metas: HashMap<Validator, models::rust::block_metadata::BlockMetadata> =
         HashMap::with_capacity(valid_latest_msgs.len());
+    // A latest message this node does not hold (a stale slot below an LFS
+    // restore horizon) cannot be cited as a parent; abstain the validator
+    // instead of failing every snapshot. Parent and LCA reads below inherit
+    // held provenance from this filter.
+    let mut unheld_validators: Vec<Validator> = Vec::new();
     for (validator, hash) in valid_latest_msgs.iter() {
-        let meta = dag.lookup_unsafe(hash)?;
-        valid_latest_metas.insert(validator.clone(), meta);
+        match dag.lookup(hash)? {
+            Some(meta) => {
+                valid_latest_metas.insert(validator.clone(), meta);
+            }
+            None => {
+                tracing::debug!(
+                    target: "f1r3fly.casper.snapshot",
+                    "abstaining validator with unheld latest message {:?}",
+                    hash
+                );
+                unheld_validators.push(validator.clone());
+            }
+        }
+    }
+    for validator in unheld_validators {
+        valid_latest_msgs.remove(&validator);
     }
     let mut unique_parent_hashes: HashSet<BlockHash> =
         HashSet::with_capacity(valid_latest_msgs.len());

--- a/casper/src/rust/estimator.rs
+++ b/casper/src/rust/estimator.rs
@@ -94,6 +94,24 @@ impl Estimator {
         filtered_latest_messages_hashes
             .retain(|validator, _| !invalid_latest_messages.contains_key(validator));
 
+        // A latest message this node does not hold (a stale slot below an
+        // LFS restore horizon) cannot be cited or scored; abstain the
+        // validator instead of failing every fork-choice run.
+        let mut unheld: Vec<Validator> = Vec::new();
+        for (validator, hash) in filtered_latest_messages_hashes.iter() {
+            if dag.lookup(hash)?.is_none() {
+                tracing::debug!(
+                    target: "f1r3fly.casper.estimator",
+                    "abstaining validator with unheld latest message {:?}",
+                    hash
+                );
+                unheld.push(validator.clone());
+            }
+        }
+        for validator in unheld {
+            filtered_latest_messages_hashes.remove(&validator);
+        }
+
         let genesis_metadata = BlockMetadata::from_block(genesis, false, None, None);
 
         tracing::debug!(target: "f1r3fly.casper.estimator.tips_fallback", "lca");

--- a/casper/src/rust/finality/floor.rs
+++ b/casper/src/rust/finality/floor.rs
@@ -365,14 +365,27 @@ pub async fn floor_of_view(
     // A latest-message slot whose held target the validator never signed
     // is a seed — the newly-bonded genesis placeholder — not testimony,
     // and it must not drag a height-0 tip into this derivation. A slot
-    // whose target has no local metadata stays in: if a walk needs the
-    // block, the absence hold below covers it. Node-local filtering is
-    // sound here because this is the finalizer's own LFB clock, not a
-    // consensus-visible derivation.
+    // whose target is not held is abstained too: it names a block below
+    // the restore horizon, which catch-up can never deliver. Node-local
+    // filtering is sound here because this is the finalizer's own LFB
+    // clock, not a consensus-visible derivation.
     let mut testimony: Vec<(Validator, BlockHash)> = Vec::new();
     for (validator, hash) in dag.latest_message_hashes() {
-        if let Some(metadata) = dag.lookup(&hash).map_err(CasperError::from)? {
-            if metadata.sender != validator {
+        match dag.lookup(&hash).map_err(CasperError::from)? {
+            Some(metadata) if metadata.sender != validator => continue,
+            Some(_) => {}
+            // An unheld slot names a block below the restore horizon —
+            // catch-up can never deliver it, so keeping the slot turns
+            // the absence hold below into a permanent, silent LFB freeze.
+            // Skipping it abstains the validator from this node's clock,
+            // sound by the same node-local argument as the seed filter.
+            None => {
+                tracing::debug!(
+                    target: "f1r3fly.finalizer",
+                    validator = %PrettyPrinter::build_string_bytes(&validator),
+                    lm = %PrettyPrinter::build_string_bytes(&hash),
+                    "abstaining unheld latest-message slot from the floor derivation"
+                );
                 continue;
             }
         }

--- a/casper/src/rust/safety/clique_oracle.rs
+++ b/casper/src/rust/safety/clique_oracle.rs
@@ -677,6 +677,24 @@ impl CliqueOracle {
             if full_weight_map.values().sum::<i64>() <= 0 {
                 return Ok(MIN_FAULT_TOLERANCE);
             }
+            // A latest message this node does not hold (a stale slot below an
+            // LFS restore horizon) abstains its validator: it can neither
+            // agree nor witness, and erroring here would fail every
+            // fault-tolerance read on the node. Abstention only ever
+            // understates the clique.
+            let mut held_latest_messages = BTreeMap::new();
+            for (validator, hash) in latest_messages.iter() {
+                if dag.lookup(hash)?.is_some() {
+                    held_latest_messages.insert(validator.clone(), hash.clone());
+                } else {
+                    tracing::debug!(
+                        target: "f1r3fly.casper.safety.clique_oracle",
+                        "abstaining validator with unheld latest message {:?}",
+                        hash
+                    );
+                }
+            }
+            let latest_messages = &held_latest_messages;
             let agreeing_weight_map =
                 Self::agreeing_weight_map(&full_weight_map, target_msg, dag, latest_messages)
                     .await?;

--- a/casper/src/rust/safety/clique_oracle.rs
+++ b/casper/src/rust/safety/clique_oracle.rs
@@ -551,9 +551,22 @@ impl CliqueOracle {
             // at one height and every join derivation refuses forever (the
             // ucc 00e6a2e3 consensus halt). Matches the Scala reference
             // (CliqueOracle.scala `dag.isInMainChain(targetMsg, ...)`).
-            latest_messages
-                .get(validator)
-                .map_or(Ok(false), |hash| dag.is_in_main_chain(message, hash))
+            //
+            // An unheld hash in the walk resolves to false DETERMINISTICALLY,
+            // not node-locally: any unheld hash reachable from held
+            // references sits below the restore horizon (above-horizon
+            // dependencies are fetched before admission; the LFS restore
+            // inserts the anchor and above), hence below every held
+            // candidate — a fully-held node's walk returns false at the
+            // same point by height comparison alone. The verdict is
+            // bit-identical with or without the block.
+            let Some(hash) = latest_messages.get(validator) else {
+                return Ok(false);
+            };
+            match dag.is_in_main_chain(message, hash) {
+                Err(KvStoreError::MissingBlock { .. }) => Ok(false),
+                other => other,
+            }
         }
 
         let mut agreeing_map = HashMap::new();

--- a/casper/tests/finalized_floor/horizon_read_abstention_spec.rs
+++ b/casper/tests/finalized_floor/horizon_read_abstention_spec.rs
@@ -4,13 +4,15 @@
 // one stale slot otherwise fails every fault-tolerance read (the #306
 // `lookup_unsafe` storm) and every fork-choice run on the node.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
 use block_storage::rust::dag::block_metadata_store::BlockMetadataStore;
+use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use casper::rust::estimator::Estimator;
-use casper::rust::safety::clique_oracle::CliqueOracle;
+use casper::rust::finality::floor::{floor_of_view, Floor, FloorOfView};
+use casper::rust::safety::clique_oracle::{CliqueOracle, FtThreshold};
 use models::rust::block_hash::BlockHash;
 use models::rust::block_implicits::get_random_block_default;
 use models::rust::block_metadata::BlockMetadata;
@@ -108,6 +110,160 @@ fn restored_dag_with_stale_lm() -> (KeyValueDagRepresentation, BlockMessage, Blo
         )),
     };
     (dag, genesis, target)
+}
+
+fn stale_validator(dag: &KeyValueDagRepresentation, target: &BlockMessage) -> Validator {
+    dag.latest_messages_map
+        .iter()
+        .find(|(_, hash)| **hash != target.block_hash)
+        .map(|(validator, _)| validator.clone())
+        .expect("stale validator")
+}
+
+fn in_mem_block_store() -> KeyValueBlockStore {
+    KeyValueBlockStore::new(
+        Arc::new(InMemoryKeyValueStore::new()),
+        Arc::new(InMemoryKeyValueStore::new()),
+    )
+}
+
+/// The finalizer's own derivation must not hold its cycle forever on a stale
+/// slot: catch-up can never deliver a block below the restore horizon, so an
+/// `AbsenceHold` naming it recurs every cycle and freezes the LFB silently.
+#[tokio::test]
+async fn a_stale_latest_message_does_not_hold_the_finalizer_forever() {
+    let (dag, genesis, _target) = restored_dag_with_stale_lm();
+    let current = Floor {
+        hash: genesis.block_hash.clone(),
+        block_number: 0,
+    };
+
+    let outcome = floor_of_view(
+        &dag,
+        &in_mem_block_store(),
+        &current,
+        FtThreshold::from_f32_lossy(0.1),
+    )
+    .await
+    .expect("floor_of_view must not error on a restored view");
+
+    assert!(
+        !matches!(outcome, FloorOfView::AbsenceHold { .. }),
+        "one unheld latest-message slot must abstain from the finalizer's \
+         own clock, not hold every cycle on a block catch-up can never \
+         deliver: {outcome:?}"
+    );
+}
+
+/// The finality DECISION must stay bit-identical across honest nodes: a node
+/// that holds the stale validator's old block and a restored node that does
+/// not must return the same verdict. An unheld hash reachable from held
+/// references is always below the restore horizon, hence below every held
+/// candidate — non-descent is decidable without the block.
+#[tokio::test]
+async fn the_finality_decision_is_identical_with_and_without_the_stale_block() {
+    let (mut restored_dag, _genesis, target) = restored_dag_with_stale_lm();
+
+    // One logical old block, referenced by both views: the restored view has
+    // its hash only, the held view holds it. The held clone shares the
+    // metadata index (Arc) — harmless here, since the decision path reads
+    // heights from the per-clone block_number_map, not metadata.
+    let v_stale = stale_validator(&restored_dag, &target);
+    let old = bonded_block(0, vec![], v_stale.clone(), &[]);
+    restored_dag
+        .latest_messages_map
+        .insert(v_stale.clone(), old.block_hash.clone());
+
+    let mut held_dag = restored_dag.clone();
+    held_dag.dag_set.insert(old.block_hash.clone());
+    held_dag.block_number_map.insert(old.block_hash.clone(), 0);
+    held_dag
+        .height_map
+        .entry(0)
+        .or_insert_with(imbl::HashSet::new)
+        .insert(old.block_hash.clone());
+    held_dag
+        .block_metadata_index
+        .write()
+        .add(BlockMetadata::from_block(&old, false, None, None))
+        .expect("seed old-block metadata");
+
+    let ftt = FtThreshold::from_f32_lossy(0.1);
+    let held_snapshot: BTreeMap<Validator, BlockHash> =
+        held_dag.latest_messages_map.clone().into_iter().collect();
+    let restored_snapshot: BTreeMap<Validator, BlockHash> = restored_dag
+        .latest_messages_map
+        .clone()
+        .into_iter()
+        .collect();
+
+    let held_verdict =
+        CliqueOracle::ft_witnessed_exact(&target.block_hash, &held_dag, &held_snapshot, ftt, false)
+            .await
+            .expect("fully-held decision");
+    let restored_verdict = CliqueOracle::ft_witnessed_exact(
+        &target.block_hash,
+        &restored_dag,
+        &restored_snapshot,
+        ftt,
+        false,
+    )
+    .await
+    .expect(
+        "the decision path must compute the sub-horizon slot's non-agreement \
+         without holding the block, not error",
+    );
+
+    assert_eq!(
+        held_verdict, restored_verdict,
+        "restored and fully-held nodes must agree on the finality verdict"
+    );
+}
+
+/// A held side-branch block at the restore boundary can name a sub-horizon
+/// main parent. The agreement walk that crosses it must resolve exactly as a
+/// fully-held node would (the parent sits below the candidate, so descent
+/// fails), not error mid-walk.
+#[tokio::test]
+async fn a_sub_horizon_main_parent_crossing_resolves_deterministically() {
+    let (mut dag, _genesis, target) = restored_dag_with_stale_lm();
+
+    let v_live = dag
+        .latest_messages_map
+        .iter()
+        .find(|(_, hash)| **hash == target.block_hash)
+        .map(|(validator, _)| validator.clone())
+        .expect("live validator");
+    let below_horizon_parent = BlockHash::from(b"below-restore-horizon-mp".to_vec());
+    let side = bonded_block(2, vec![below_horizon_parent.clone()], v_live.clone(), &[]);
+    dag.dag_set.insert(side.block_hash.clone());
+    dag.block_number_map.insert(side.block_hash.clone(), 2);
+    dag.main_parent_map
+        .insert(side.block_hash.clone(), below_horizon_parent);
+    dag.block_metadata_index
+        .write()
+        .add(BlockMetadata::from_block(&side, false, None, None))
+        .expect("seed side metadata");
+    dag.latest_messages_map
+        .insert(v_live, side.block_hash.clone());
+
+    let snapshot: BTreeMap<Validator, BlockHash> =
+        dag.latest_messages_map.clone().into_iter().collect();
+
+    let verdict = CliqueOracle::ft_witnessed_exact(
+        &target.block_hash,
+        &dag,
+        &snapshot,
+        FtThreshold::from_f32_lossy(0.1),
+        false,
+    )
+    .await
+    .expect(
+        "a walk crossing into sub-horizon history must resolve as non-descent, \
+         not error",
+    );
+
+    assert!(!verdict, "nothing descends from the target on this shape");
 }
 
 #[tokio::test]

--- a/casper/tests/finalized_floor/horizon_read_abstention_spec.rs
+++ b/casper/tests/finalized_floor/horizon_read_abstention_spec.rs
@@ -1,0 +1,151 @@
+// On an LFS-restored node a validator's latest-message slot can name a block
+// below the restore horizon — held as a hash only, never indexed. Read paths
+// that materialize latest messages must abstain that validator, not error:
+// one stale slot otherwise fails every fault-tolerance read (the #306
+// `lookup_unsafe` storm) and every fork-choice run on the node.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use block_storage::rust::dag::block_dag_key_value_storage::KeyValueDagRepresentation;
+use block_storage::rust::dag::block_metadata_store::BlockMetadataStore;
+use casper::rust::estimator::Estimator;
+use casper::rust::safety::clique_oracle::CliqueOracle;
+use models::rust::block_hash::BlockHash;
+use models::rust::block_implicits::get_random_block_default;
+use models::rust::block_metadata::BlockMetadata;
+use models::rust::casper::protocol::casper_message::{BlockMessage, Bond};
+use models::rust::validator::Validator;
+use parking_lot::RwLock as PlRwLock;
+use rspace_plus_plus::rspace::shared::in_mem_key_value_store::InMemoryKeyValueStore;
+use shared::rust::store::key_value_typed_store_impl::KeyValueTypedStoreImpl;
+
+use crate::helper::block_util::generate_validator;
+
+fn bonded_block(
+    number: i64,
+    parents: Vec<BlockHash>,
+    sender: Validator,
+    bonds: &[(Validator, i64)],
+) -> BlockMessage {
+    let mut block = get_random_block_default();
+    block.body.state.block_number = number;
+    block.header.parents_hash_list = parents;
+    block.sender = sender;
+    block.body.state.bonds = bonds
+        .iter()
+        .map(|(validator, stake)| Bond {
+            validator: validator.clone(),
+            stake: *stake,
+        })
+        .collect();
+    block
+}
+
+/// Two bonded validators; a two-block held chain (genesis -> target); one
+/// validator's latest message poisoned to an unheld hash — the restored
+/// node's shape.
+fn restored_dag_with_stale_lm() -> (KeyValueDagRepresentation, BlockMessage, BlockMessage) {
+    let v_live = generate_validator(Some("live"));
+    let v_stale = generate_validator(Some("stale"));
+    let bonds = [(v_live.clone(), 100i64), (v_stale.clone(), 100i64)];
+
+    let genesis = bonded_block(0, vec![], Validator::new(), &bonds);
+    let target = bonded_block(1, vec![genesis.block_hash.clone()], v_live.clone(), &bonds);
+    let below_horizon = BlockHash::from(b"below-restore-horizon-lm".to_vec());
+
+    let metadata_store = KeyValueTypedStoreImpl::new(Arc::new(InMemoryKeyValueStore::new()));
+    let mut metadata_index = BlockMetadataStore::new(metadata_store);
+    metadata_index
+        .add(BlockMetadata::from_block(&genesis, false, None, None))
+        .expect("seed genesis metadata");
+    metadata_index
+        .add(BlockMetadata::from_block(&target, false, None, None))
+        .expect("seed target metadata");
+
+    let mut dag_set = imbl::HashSet::new();
+    let mut block_number_map = imbl::HashMap::new();
+    let mut height_map = imbl::OrdMap::new();
+    for (hash, number) in [(&genesis.block_hash, 0i64), (&target.block_hash, 1)] {
+        dag_set.insert(hash.clone());
+        block_number_map.insert(hash.clone(), number);
+        height_map
+            .entry(number)
+            .or_insert_with(imbl::HashSet::new)
+            .insert(hash.clone());
+    }
+    let mut main_parent_map = imbl::HashMap::new();
+    main_parent_map.insert(target.block_hash.clone(), genesis.block_hash.clone());
+    let mut child_map = imbl::HashMap::new();
+    child_map.insert(
+        genesis.block_hash.clone(),
+        imbl::HashSet::unit(target.block_hash.clone()),
+    );
+
+    let mut latest_messages_map = imbl::HashMap::new();
+    latest_messages_map.insert(v_live, target.block_hash.clone());
+    latest_messages_map.insert(v_stale, below_horizon);
+
+    let mut finalized_blocks_set = imbl::HashSet::new();
+    finalized_blocks_set.insert(genesis.block_hash.clone());
+
+    let dag = KeyValueDagRepresentation {
+        dag_set,
+        latest_messages_map,
+        child_map,
+        height_map,
+        block_number_map,
+        main_parent_map,
+        self_justification_map: imbl::HashMap::new(),
+        invalid_blocks_set: imbl::HashSet::new(),
+        last_finalized_block_hash: genesis.block_hash.clone(),
+        finalized_blocks_set,
+        block_metadata_index: Arc::new(PlRwLock::new(metadata_index)),
+        floor_index: KeyValueTypedStoreImpl::new(Arc::new(InMemoryKeyValueStore::new())),
+        frontier_index: KeyValueTypedStoreImpl::new(Arc::new(InMemoryKeyValueStore::new())),
+        lifecycle: Arc::new(PlRwLock::new(
+            block_storage::rust::dag::deploy_lifecycle_types::DeployLifecycleTables::in_memory(),
+        )),
+    };
+    (dag, genesis, target)
+}
+
+#[tokio::test]
+async fn a_stale_latest_message_does_not_fail_fault_tolerance() {
+    let (dag, _genesis, target) = restored_dag_with_stale_lm();
+
+    let result = CliqueOracle::normalized_fault_tolerance(&target.block_hash, &dag).await;
+
+    assert!(
+        result.is_ok(),
+        "one unheld latest-message slot must abstain, not fail every \
+         fault-tolerance read on the node: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn a_stale_latest_message_does_not_fail_fork_choice() {
+    let (mut dag, genesis, target) = restored_dag_with_stale_lm();
+    let latest_messages: HashMap<Validator, BlockHash> =
+        dag.latest_messages_map.clone().into_iter().collect();
+
+    let estimator = Estimator::apply(1, None);
+    let result = estimator
+        .tips_with_latest_messages(&mut dag, &genesis, latest_messages)
+        .await;
+
+    match result {
+        Ok(fork_choice) => {
+            assert!(
+                fork_choice.tips.contains(&target.block_hash),
+                "fork choice must still rank the held chain, got {:?}",
+                fork_choice.tips
+            );
+        }
+        Err(err) => panic!(
+            "one unheld latest-message slot must abstain, not fail every \
+             fork-choice run on the node: {err:?}"
+        ),
+    }
+}

--- a/casper/tests/finalized_floor/mod.rs
+++ b/casper/tests/finalized_floor/mod.rs
@@ -12,6 +12,7 @@
 //     and i5 from committed sub-DAG fixtures: logged-verdict fidelity pins,
 //     plus the below-target ancestor-prefix red the walk refinement answers.
 
+mod horizon_read_abstention_spec;
 mod oracle_stall_replay_spec;
 mod prop_bonds_from_floor;
 mod prop_ft_ppm_provenance;


### PR DESCRIPTION
Completes #306's residual: after an LFS restore, a validator's latest-message slot can name a block below the restore horizon — held as a hash only, never indexed. Every read path that materialized latest messages `lookup_unsafe`'d that slot, so ONE stale entry from one inactive validator failed every fault-tolerance read (the one-hash-repeated-300x storm in #306's logs), every fork-choice run, and every propose attempt on the node. #318's typed `MissingBlock` only helps paths with a deferral consumer — block processing has one; the API, the estimator, and propose have none. Not consensus-affecting in live operation: on a fully-held DAG every filter is a no-op, and abstention can only understate the clique (the safe direction, same philosophy as AbsenceHold).

Independent of the #368/#369 stack — based on `dev`, disjoint files.

### Diff anatomy

| Bucket | Files | Δ | Notes |
|---|---:|---|---|
| Production | 5 | +143 −26 | Held-LM filters at the three materialization boundaries, unheld-as-absent in storage, lookup-and-skip across the API's windowed walks |
| Tests | 2 | +152 −0 | One red-first spec (both reds died in the oracle/estimator weight walks on untouched code) |

### What changed

- **The three latest-message materialization boundaries abstain unheld validators.** The oracle's `ft_witnessed`, the estimator's `tips_with_latest_messages`, and the propose snapshot each filter latest messages to held blocks before any walk; every parent/LCA read below inherits held provenance from that filter. An abstained validator simply contributes no agreement weight — exactly how an equivocator or invalid-block sender is already treated.
- **Storage treats an unheld latest message as absent.** `latest_message`/`latest_messages` return `None`/skip instead of erroring, so no future caller can reintroduce the storm through the accessor.
- **The API's windowed walks lookup-and-skip.** `get_blocks`, `get_blocks_full`, by-height ranges, and machine-verifiable-DAG parent fetches skip unheld blocks; find-deploy falls through to its scan; a fault-tolerance read that still reaches unheld history degrades to `ft = -1` instead of failing the call.
- **41-site `lookup_unsafe` provenance audit closed.** Beyond the fix surface: `validate.rs`'s parent reads were already horizon-tolerant, the equivocation detector's totality claim holds over safe provenance, and finalizer/lifecycle sites read only the held LFB. No other site can see an unheld hash.

### Suggested reading order

1. `casper/tests/finalized_floor/horizon_read_abstention_spec.rs` — the restored node's shape and both reds
2. `clique_oracle.rs::ft_witnessed` + `estimator.rs::tips_with_latest_messages` + `snapshot.rs` (the three boundaries)
3. `block_dag_key_value_storage.rs` (unheld-as-absent at the accessor)
4. `block_api.rs` (the windowed walks and `fault_tolerance_or_unknown`)

Co-Authored-By: Claude <noreply@anthropic.com>
