### PR TITLE
docs(casper): align the protocol overview with the finalized-floor design

### DIFF
--- a/docs/casper/CONSENSUS_PHILOSOPHY.md
+++ b/docs/casper/CONSENSUS_PHILOSOPHY.md
@@ -86,7 +86,7 @@ The fork-choice tie-break is the stake score, then the ascending block hash. The
 
 ### Option B1 — merged-frontier retry packaging (recommended next step)
 
-The owner packages a gated retry only when its own tip already merges every same-key contender that the owner can see. The retry then executes fresh and sequentially on top of the settled contention. It does not race as a sibling. When an unseen contender still races in, loss-aware adjudication covers the adjudicable subset.
+The owner packages a gated retry only when one selected parent covers all valid latest messages (the canonical predicate — see the glossary entry [Merged-frontier retry packaging](./GLOSSARY.md#merged-frontier-retry-packaging), which matches the implemented gate in `block_creator.rs`). The retry then executes fresh and sequentially on top of the settled contention. It does not race as a sibling. When an unseen contender still races in, loss-aware adjudication covers the adjudicable subset.
 
 - **Pros:** The policy is node-local. It needs no consensus change, no wire change, and no upgrade coordination. The diff in `prepare_user_deploys_with_policy` is small. Ground Truth 2 makes the deferral safe from peer rejection.
 - **Cons:** The policy is a heuristic, not a guarantee. Under saturated contention, a merged frontier without contenders never occurs. Each deferral spends validity window to increase the success probability. The policy does not influence merges that other validators build.

--- a/docs/casper/CONSENSUS_PROTOCOL.md
+++ b/docs/casper/CONSENSUS_PROTOCOL.md
@@ -101,7 +101,7 @@ Proposals are triggered by the [heartbeat proposer](#8-liveness-heartbeat-propos
 3. **Select parents** via [fork choice](#5-fork-choice-lmd-ghost) (LMD GHOST)
    - One parent per validator, deduplicated
    - Limited by `max_number_of_parents` and `max_parent_depth`
-4. **Compute LCA** (Lowest Common Ancestor) of selected parents — bounds the [merge scope](#6-state-merging-multi-parent)
+4. **Compute LCA** (Lowest Common Ancestor) of selected parents — an input to [fork-choice scoring](#5-fork-choice-lmd-ghost); the [merge scope](#6-state-merging-multi-parent) is bounded by the finalized floor, not the LCA
 5. **Build justifications**: Each bonded validator's latest message hash
 6. **Compute deploy scope**: BFS traversal within `deploy_lifespan` window to find all deploys already included in ancestor blocks
 
@@ -265,7 +265,7 @@ In a multi-parent DAG, different validators may have included different deploys 
 
 ### Algorithm (`dag_merger.rs` + `conflict_set_merger.rs`)
 
-1. **Identify visible blocks**: All blocks between the LCA and the parents (exclusive of LCA, inclusive of parents)
+1. **Identify visible blocks**: `closure(parents) \ closure(floor)` — every block above the finalized floor that a parent can reach (exclusive of the floor closure, inclusive of parents). See [finalized-floor-specification.md](./theory/finalized-floor/finalized-floor-specification.md) R-SCOPE.
 2. **Collect deploys**: Extract user deploys from all visible blocks
 3. **Detect conflicts**: Branches conflict if they contain the **same user deploy ID** (not content — just the deploy signature)
 4. **Resolve**: `ConflictSetMerger` selects the highest-value subset
@@ -278,13 +278,14 @@ In a multi-parent DAG, different validators may have included different deploys 
 
 ### Determinism Constraint
 
-The merge scope is derived entirely from DAG structure (parent pointers and block heights), not from local finalization state. Two validators with different finalization views must compute the same merge result for identical parent sets. This is why the LCA (not the LFB) bounds the scope.
+The merge scope is bounded by the finalized floor of the block. The floor is a pure function of the block's frozen justifications, so every node derives the same floor for the same block. Two validators with different local finalization views therefore compute the same merge result for identical parent sets. The node-local last finalized block (LFB) never bounds the scope — only the block-derived floor does.
 
 ### Performance Bounds
 
 - Merge cost: O(visible_blocks^2 x deploys^2) for conflict resolution
-- LCA scoping keeps visible_blocks bounded
-- **Fallback**: If visible_blocks > 512 or LCA distance > 256, falls back to latest parent's post-state (discards non-selected parent deploys — they land in the rejected-deploy buffer and a subsequent proposer re-includes them via `prepare_user_deploys`)
+- Floor scoping keeps visible_blocks bounded
+- **Δ-backstop**: When the floor distance `Δ = num(maxParent) − num(floor)` exceeds the cap (`MAX_FLOOR_DISTANCE_BLOCKS` = 256), `compute_parents_post_state` refuses the merge with a deterministic error keyed on Δ alone. On propose the round parks and retries after finality advances. On validate an over-Δ block is deterministically invalid. The merge never substitutes a lossy single-parent post-state (R-BACKSTOP — the former fallback dropped co-parent writes, the ~400-block bug).
+- The visible-scope size (`MAX_PARENT_MERGE_SCOPE_BLOCKS` = 512) is an advisory metric only. Branch width is not node-deterministic, so scope size never gates admission.
 
 ### System Deploys
 

--- a/docs/casper/GLOSSARY.md
+++ b/docs/casper/GLOSSARY.md
@@ -309,11 +309,96 @@ blocks; rejected deploys are block-body records of a particular merge result.
 *Avoid*: "rejection cache" because persistence and retry eligibility are
 load-bearing properties.
 
+### Latest message
+
+A latest message is the most recent block a bonded validator has produced,
+as recorded in a view or in a block's frozen justifications. Fork choice
+scores from the latest messages, and the
+[merged-frontier retry packaging](#merged-frontier-retry-packaging) gate
+tests whether one selected parent covers all valid latest messages.
+
+**Preferred usage.** Use for the per-validator tip a view or a
+justification set records.
+*Distinguish from* a justification: a justification is the recorded
+reference to a latest message inside a block.
+*Avoid*: "tip" unqualified, because the DAG has many tips and only one
+latest message per validator.
+
+### Finalized floor
+
+The finalized floor of a block is the finalized ancestor that the block's
+own frozen justifications witness. Both floor sources are block-structural
+facts, so every node derives the same floor for the same block. The floor
+bounds the [merge scope](#merge-scope), anchors the
+[merge base](#merge-base) fallback, supplies the validation committee,
+and paces the [retry gate](#retry-gate). The normative rules live in
+[finalized-floor-specification.md](./theory/finalized-floor/finalized-floor-specification.md).
+
+**Preferred usage.** Use for the block-derived finalization bound that
+consensus rules read.
+*Distinguish from* [Last finalized block (LFB)](#last-finalized-block-lfb):
+the floor is a pure function of the block; the LFB is a node-local
+observation.
+*Avoid*: "floor" unqualified in a document that also discusses numeric
+floors or limits.
+
+### Last finalized block (LFB)
+
+The last finalized block is the highest block a node's finalization
+oracle has finalized in its own view. The LFB is node-local: two healthy
+nodes can briefly hold different LFBs. No consensus rule may read the
+LFB, because a node-local input would fork the network.
+
+**Preferred usage.** Use for the node's own finalization progress marker,
+such as metrics, pruning, and API output.
+*Distinguish from* [Finalized floor](#finalized-floor): the merge scope
+and the validation committee read the block-derived floor, never the LFB.
+*Avoid*: "finalized block" unqualified when the node-local marker is
+intended.
+
+### Lowest common ancestor (LCA)
+
+The lowest common ancestor is the deepest block that is an ancestor of
+every latest message in a fork-choice computation. Fork choice scores
+stake weight from each latest message down to the LCA and then ranks
+greedily downward from it. The many-input variant is LUCA (lowest
+universal common ancestor). The fork-choice dossier holds the algorithm
+and the T-LCA obligation
+([fork-choice-glossary.md](./theory/fork-choice/fork-choice-glossary.md)).
+
+**Preferred usage.** Use only for the fork-choice scoring base.
+*Distinguish from* [Merge scope](#merge-scope): the merge scope is
+bounded by the [finalized floor](#finalized-floor) of the block, never
+by the LCA. The
+protocol overview carried this confusion before the finalized-floor
+migration.
+*Avoid*: "common ancestor" without the lowest qualifier, and any use of
+LCA to describe a merge bound.
+
+### Merge base
+
+The merge base is the state a multi-parent merge starts from. The base is
+the main parent's post-state when that state holds the
+[settled content](#settled-content) of the
+[finalized floor](#finalized-floor). Otherwise the base falls back to the
+floor's post-state (`compute_parents_post_state`). Validators recompute
+the choice from the block's recorded justifications, so the base is
+node-identical.
+
+**Preferred usage.** Use for the starting state of a merge and its
+deterministic fallback rule.
+*Distinguish from* [Merge scope](#merge-scope): the base is one state;
+the scope is the set of blocks whose effects merge onto it.
+*Avoid*: "parent state" unqualified, because only the main parent can
+supply the base.
+
 ### Merge scope
 
 Merge scope is the bounded ancestry whose state effects participate in
-multi-parent merging for a [consensus snapshot](#consensus-snapshot). A merge
-can place eligible work in the [rejected deploy buffer](#rejected-deploy-buffer)
+multi-parent merging for a [consensus snapshot](#consensus-snapshot),
+bounded by the [finalized floor](#finalized-floor) of the block:
+`closure(parents) \ closure(floor)`. A merge can place eligible work in
+the [rejected deploy buffer](#rejected-deploy-buffer)
 when competing effects cannot all be retained.
 
 **Preferred usage.** Use for the bounded ancestry whose state effects
@@ -324,6 +409,24 @@ selected for state merging; an ancestor set may be an unconstrained graph
 traversal.
 *Avoid*: "merge window" unless referring specifically to a numeric depth or
 time parameter.
+
+### Floor distance (Δ)
+
+The floor distance is `Δ = num(maxParent) − num(floor)`: the height span
+between the highest parent and the [finalized floor](#finalized-floor).
+Δ is a pure function of the block's frozen justifications, so every node
+computes the same value. When Δ exceeds `MAX_FLOOR_DISTANCE_BLOCKS`
+(256), the merge fails with a deterministic error keyed on Δ alone: the
+proposer parks the round, and a validator rejects the block (R-BACKSTOP).
+The visible-scope size (`MAX_PARENT_MERGE_SCOPE_BLOCKS` = 512) is an
+advisory metric and never gates admission, because branch width is not
+node-deterministic.
+
+**Preferred usage.** Use for the deterministic merge-span bound and its
+backstop.
+*Distinguish from* the scope-size metric: Δ gates, scope size only warns.
+*Avoid*: "merge depth", and any phrasing that revives the removed lossy
+single-parent fallback.
 
 ### Content ordering
 
@@ -392,11 +495,60 @@ owner-scoped: only the sender of the carrier buffers the retry of that copy.
 holds the rejection record.
 *Avoid*: "source block" without qualification.
 
+### Deploy lifespan
+
+The deploy lifespan is the validity window of a deploy, measured in
+blocks. A deploy is eligible from its `valid_after_block_number` until
+the window closes, and it terminates `Expired` if it never lands. The
+same window bounds the repeat-deploy ancestor scan
+(`expiration_threshold`) and the record view of the
+[prior-rejection count](#prior-rejection-count): records older than
+`deploy_lifespan` do not count.
+
+**Preferred usage.** Use for the block-height validity window and the
+scan bounds derived from it.
+*Distinguish from* the [retry frontier lease](#retry-frontier-lease),
+which bounds proposer deferral, not deploy validity.
+*Avoid*: "timeout" and "TTL", because the window uses block height, not
+wall-clock time.
+
+### Deploy lifecycle
+
+The deploy lifecycle is the per-signature progression a node records for
+each deploy: open event rows (inclusions and rejections projected from
+block bodies) and a WRITE-ONCE terminal record (`Finalized`, `Expired`,
+or `Failed`). Event rows are pruned at the terminal write, so the events
+table holds open signatures only. The status API reads these tables as
+lookups.
+
+**Preferred usage.** Use for the recorded progression and its storage
+tables (`deploy-lifecycle-events`, `deploy-lifecycle-terminal`).
+*Distinguish from* finalization: a terminal record is a node's durable
+verdict about one deploy; finalization is a property of blocks.
+*Avoid*: "deploy status" for the storage internals — status is the API
+view over the lifecycle tables.
+
+### Settled content
+
+Settled content is what the [finalized floor](#finalized-floor) closure
+commits: effects and records contained in the state the floor stands
+for. A state "holds the settled content of the floor" when everything
+the floor commits is present in that state. The
+[merge base](#merge-base) rule and the [retry gate](#retry-gate) both
+key on settlement, so both stay pure functions of the block.
+
+**Preferred usage.** Use for floor-committed effects and records that a
+rule tests for containment.
+*Distinguish from* finalized: settled is containment in the block-derived
+floor closure; finalized is the oracle's property of a block.
+*Avoid*: "confirmed", "committed" unqualified.
+
 ### Retry gate
 
 The retry gate is the rule that makes a retry legal only after the latest
 [kept rejection record](#kept-rejection-record) of the signature settles
-inside the frozen floor closure. The gate is a pure function of the block, so
+inside the frozen [finalized floor](#finalized-floor) closure. The gate is a
+pure function of the block, so
 every validator computes the same verdict (`PrematureDeployRetry`).
 
 **Preferred usage.** Use for the floor-paced legality rule on re-proposal.


### PR DESCRIPTION
Docs-only alignment. The CbC design review for PR #382 flagged these passages as pre-existing drift, out of scope there: the protocol overview predated the finalized-floor migration. Every corrected claim is anchored to the normative spec and verified against the current code.

## Fixes

| Passage | Was | Now | Anchor |
|---|---|---|---|
| CONSENSUS_PROTOCOL Step 1.4 | "Compute LCA ... bounds the merge scope" | LCA is a fork-choice scoring input; the merge scope is floor-bounded | `finalized-floor-specification.md` R-SCOPE |
| §6 "Identify visible blocks" | "All blocks between the LCA and the parents" | `closure(parents) \ closure(floor)` | R-SCOPE |
| §6 "Determinism Constraint" | "LCA (not the LFB) bounds the scope" | The floor is a pure function of the block's frozen justifications, so the scope is node-identical; the node-local LFB never bounds it | R-FLOOR / S1 |
| §6 "Performance Bounds" | ">512 visible blocks or LCA distance >256 falls back to latest parent's post-state" | The deterministic Δ-backstop: refuse when Δ > `MAX_FLOOR_DISTANCE_BLOCKS` (256); the 512 scope figure (`MAX_PARENT_MERGE_SCOPE_BLOCKS`) is an advisory metric that never gates admission | R-BACKSTOP; `interpreter_util.rs` (`merge_scope_backstop_exceeded`) |
| CONSENSUS_PHILOSOPHY Option B1 | "its own tip already merges every same-key contender" | The canonical glossary predicate: "one selected parent covers all valid latest messages", citing the glossary anchor | Implemented gate in `block_creator.rs` (every non-invalid justification latest message must be an ancestor of one selected parent) |

## Notes

- The former lossy single-parent fallback that §6 documented is the behavior R-BACKSTOP forbids (it dropped co-parent writes — the ~400-block bug). The code refuses deterministically today; the docs now say so.
- The B1 drift was settled by reading the implementation: the glossary phrasing matches `block_creator.rs`, so the philosophy text was the drifted side and now cites the glossary as canonical.
- No overlap with PR #382's doc deltas (Step 8, §4.4, glossary entries) — the branches merge cleanly in either order.

## Glossary gap closure (second commit)

The load-bearing `docs/casper/GLOSSARY.md` leaned on undefined terms — its own entries cited "the frozen floor closure" and "the finalized floor" with no anchor. Nine entries close the gaps:

- **Floor family** (the definitional backbone of the drift this PR fixes): `Finalized floor`, `Last finalized block (LFB)` (with the load-bearing distinguo: block-derived fact vs node-local observation — no consensus rule may read the LFB), `Floor distance (Δ)` (the R-BACKSTOP semantics), `Merge base` (the deterministic fallback rule), and `Lowest common ancestor (LCA)` (fork-choice scoring base only, never a merge bound).
- **Settlement and lifecycle**: `Settled content`, `Deploy lifespan`, `Deploy lifecycle`, `Latest message`.
- Dangling references in `Retry gate` and the tightened `Merge scope` now link to the new anchors. All internal anchors verified resolving.

Deliberately NOT added here: a lifecycle consensus-role entry — PR #382 adds `Repeat-deploy signature index` in the same region, and this branch avoids touching any line #382 edits.
