### PR TITLE
fix(node): gate container health on Casper readiness via /api/ready

### DIFF
--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -237,17 +237,8 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'st
     )
     .increment(1);
 
-    // Publish EnteredRunningState event
     let block_hash_string =
         PrettyPrinter::build_string_no_limit(&approved_block.candidate.block.block_hash);
-    event_log
-        .publish(F1r3flyEvent::entered_running_state(block_hash_string))
-        .map_err(|e| {
-            CasperError::Other(format!(
-                "Failed to publish EnteredRunningState event: {}",
-                e
-            ))
-        })?;
 
     let running = Running::new(
         block_processing_queue_tx,
@@ -264,6 +255,15 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'st
     );
 
     engine_cell.set(Arc::new(running)).await;
+
+    event_log
+        .publish(F1r3flyEvent::entered_running_state(block_hash_string))
+        .map_err(|e| {
+            CasperError::Other(format!(
+                "Failed to publish EnteredRunningState event: {}",
+                e
+            ))
+        })?;
 
     Ok(())
 }

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -256,14 +256,12 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'st
 
     engine_cell.set(Arc::new(running)).await;
 
-    event_log
-        .publish(F1r3flyEvent::entered_running_state(block_hash_string))
-        .map_err(|e| {
-            CasperError::Other(format!(
-                "Failed to publish EnteredRunningState event: {}",
-                e
-            ))
-        })?;
+    if let Err(e) = event_log.publish(F1r3flyEvent::entered_running_state(block_hash_string)) {
+        tracing::error!(
+            "Failed to publish EnteredRunningState event after committing Running state: {}",
+            e
+        );
+    }
 
     Ok(())
 }

--- a/docker/standalone.yml
+++ b/docker/standalone.yml
@@ -41,11 +41,11 @@ services:
     environment:
       - OPENAI_ENABLED=${OPENAI_ENABLED:-false}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:40403/api/status"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:40403/api/ready"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 60s
+      start_period: 120s
 
 volumes:
   standalone-data:

--- a/docker/standalone.yml
+++ b/docker/standalone.yml
@@ -41,7 +41,7 @@ services:
     environment:
       - OPENAI_ENABLED=${OPENAI_ENABLED:-false}
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:40403/api/ready"]
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:40403/api/ready"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -146,6 +146,10 @@ CLI flags are applied to the parsed `NodeConf` by `config_mapper.rs`:
 - `currentEpoch` — `lastFinalizedBlockNumber / epochLength`
 - `epochLength` — blocks per epoch, from genesis configuration
 
+### `GET /api/ready`
+
+Readiness probe for orchestration. Returns HTTP 200 `{"ready": true}` once Casper is Running and the node can serve deploys, HTTP 503 `{"ready": false}` while Casper is still initializing. The container `HEALTHCHECK` and `docker/standalone.yml` use this endpoint, so `docker compose up --wait` and `depends_on: condition: service_healthy` block until the node is deploy-ready.
+
 ## View Parameters
 
 All block and deploy endpoints support a `?view=full|summary` query parameter:

--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -148,7 +148,13 @@ CLI flags are applied to the parsed `NodeConf` by `config_mapper.rs`:
 
 ### `GET /api/ready`
 
-Readiness probe for orchestration. Returns HTTP 200 `{"ready": true}` once Casper is Running and the node can serve deploys, HTTP 503 `{"ready": false}` while Casper is still initializing. The container `HEALTHCHECK` and `docker/standalone.yml` use this endpoint, so `docker compose up --wait` and `depends_on: condition: service_healthy` block until the node is deploy-ready.
+Readiness probe for orchestration.
+
+- Returns HTTP 200 `{"ready": true}` once Casper is Running and the node can serve deploys.
+- Returns HTTP 503 `{"ready": false}` while Casper is still initializing.
+- The container `HEALTHCHECK` and `docker/standalone.yml` use this endpoint, so `docker compose up --wait` and `depends_on: condition: service_healthy` block until the node is deploy-ready.
+- A node running the genesis ceremony reports `unhealthy` for the whole window (minutes to hours); raise `--wait-timeout` / probe `failureThreshold` accordingly.
+- The container `HEALTHCHECK` probes only the HTTP API. It no longer probes the gRPC API (port 40401) directly, so a failure isolated to the gRPC server does not fail the health check. `/api/ready` reflects Casper engine state shared by both servers, so this is expected to cover the common failure modes.
 
 ## View Parameters
 

--- a/docs/node/api-reference.md
+++ b/docs/node/api-reference.md
@@ -121,6 +121,14 @@ curl http://localhost:40403/api/status
 
 ---
 
+### `GET /api/ready`
+
+Readiness probe. Returns HTTP 200 with `{"ready": true}` once the Casper engine has entered the Running state and the node can serve deploys and exploratory deploys. Returns HTTP 503 with `{"ready": false}` while Casper is still initializing (genesis ceremony, or last-finalized-state sync on an observer).
+
+Unlike `GET /api/status`, which answers 200 throughout startup, this endpoint fails until the node is deploy-ready, so it works directly as a container health check (`docker compose up --wait`, `depends_on: condition: service_healthy`) and as a Kubernetes `httpGet` readiness probe without needing `jq`.
+
+---
+
 ### Block Endpoints
 
 All block endpoints support `?view=full|summary`. Single-item endpoints default to **full** (includes deploys). List endpoints default to **summary** (block headers only, deploys omitted).

--- a/docs/node/api-reference.md
+++ b/docs/node/api-reference.md
@@ -127,6 +127,8 @@ Readiness probe. Returns HTTP 200 with `{"ready": true}` once the Casper engine 
 
 Unlike `GET /api/status`, which answers 200 throughout startup, this endpoint fails until the node is deploy-ready, so it works directly as a container health check (`docker compose up --wait`, `depends_on: condition: service_healthy`) and as a Kubernetes `httpGet` readiness probe without needing `jq`.
 
+A node running the genesis ceremony (minutes to hours) reports `unhealthy` for the whole window, because it cannot serve deploys yet. Operators spanning a long genesis raise `--wait-timeout` (Docker Compose) or probe `failureThreshold` / `start_period` (Kubernetes, Docker `HEALTHCHECK`) accordingly.
+
 ---
 
 ### Block Endpoints

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -173,11 +173,12 @@ RUN if [ ! -f /opt/docker/bin/node ]; then \
 # Expose ports (matching build.sbt: dockerExposedPorts)
 EXPOSE 40400 40401 40402 40403 40404
 
-# Healthcheck (matching build.sbt healthcheck, adapted for Rust)
-# Note: The original uses grpcurl and curl with jq
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD grpcurl -plaintext 127.0.0.1:40401 casper.v1.DeployService.status | jq -e && \
-        curl -s 127.0.0.1:40403/api/status | jq -e || exit 1
+# Healthcheck: report healthy only once Casper has entered the Running state
+# and can serve deploys. /api/ready returns 503 while Casper is still
+# initializing (genesis ceremony, LFS sync), so `docker compose up --wait`
+# and `depends_on: condition: service_healthy` line up with deploy readiness.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -fsS 127.0.0.1:40403/api/ready || exit 1
 
 # Image version label. Populate via `--build-arg VERSION=...` from
 # docker-commands.sh / CI so the label tracks the actual build instead of

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -101,7 +101,7 @@ FROM debian:bookworm-slim AS runtime-base
 ARG PROFILING_BUILD=0
 
 # Install runtime dependencies
-# Note: grpcurl and jq for healthcheck (matching build.sbt healthcheck)
+# Note: curl backs the container HEALTHCHECK (GET /api/ready).
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
@@ -110,29 +110,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     && if [ "${PROFILING_BUILD}" = "1" ]; then apt-get install -y linux-perf procps binutils; fi \
     && rm -rf /var/lib/apt/lists/*
-
-# Install grpcurl and jq for healthcheck (matching build.sbt)
-# Note: These are installed in the runtime stage, architecture will be detected at runtime
-RUN GRPCURL_VERSION="1.8.9" && \
-    ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-        amd64) GRPCURL_ARCH="x86_64" ;; \
-        arm64) GRPCURL_ARCH="arm64" ;; \
-        *) GRPCURL_ARCH="x86_64" ;; \
-    esac && \
-    curl -L "https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/grpcurl_${GRPCURL_VERSION}_linux_${GRPCURL_ARCH}.tar.gz" -o /tmp/grpcurl.tar.gz && \
-    tar -xzf /tmp/grpcurl.tar.gz -C /tmp && \
-    find /tmp -name grpcurl -type f -executable -exec mv {} /usr/local/bin/ \; && \
-    chmod +x /usr/local/bin/grpcurl && \
-    rm -rf /tmp/grpcurl* || true && \
-    ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-        amd64) JQ_ARCH="linux64" ;; \
-        arm64) JQ_ARCH="linuxarm64" ;; \
-        *) JQ_ARCH="linux64" ;; \
-    esac && \
-    curl -L "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-${JQ_ARCH}" -o /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq || true
 
 # ============================================================================
 # Stage 3: Runtime - Final image, starts at WORKDIR with artifacts from builder

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -100,8 +100,8 @@ FROM debian:bookworm-slim AS runtime-base
 # keeps profiling tooling out of the image everyone actually runs.
 ARG PROFILING_BUILD=0
 
-# Install runtime dependencies
-# Note: curl backs the container HEALTHCHECK (GET /api/ready).
+# Install runtime dependencies.
+# curl is the only tool the container HEALTHCHECK further below needs (GET /api/ready).
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \

--- a/node/src/rust/api/web_api.rs
+++ b/node/src/rust/api/web_api.rs
@@ -48,6 +48,10 @@ pub trait WebApi {
     /// Get API status information
     async fn status(&self) -> Result<ApiStatus>;
 
+    /// Whether the Casper instance has entered the Running state and can serve
+    /// deploys. Backs the `/api/ready` readiness probe.
+    fn is_ready(&self) -> bool;
+
     /// Prepare deploy request
     async fn prepare_deploy(&self, request: Option<PrepareRequest>) -> Result<PrepareResponse>;
 
@@ -451,6 +455,8 @@ impl WebApi for WebApiImpl {
             epoch_length: self.epoch_length,
         })
     }
+
+    fn is_ready(&self) -> bool { self.is_ready.load(Ordering::Relaxed) }
 
     async fn prepare_deploy(&self, request: Option<PrepareRequest>) -> Result<PrepareResponse> {
         let seq_number = BlockAPI::get_latest_message(&self.engine_cell)

--- a/node/src/rust/api/web_api.rs
+++ b/node/src/rust/api/web_api.rs
@@ -456,7 +456,7 @@ impl WebApi for WebApiImpl {
         })
     }
 
-    fn is_ready(&self) -> bool { self.is_ready.load(Ordering::Relaxed) }
+    fn is_ready(&self) -> bool { self.is_ready.load(Ordering::Acquire) }
 
     async fn prepare_deploy(&self, request: Option<PrepareRequest>) -> Result<PrepareResponse> {
         let seq_number = BlockAPI::get_latest_message(&self.engine_cell)

--- a/node/src/rust/api/web_api.rs
+++ b/node/src/rust/api/web_api.rs
@@ -1371,6 +1371,11 @@ pub struct PrepareResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ReadyResponse {
+    pub ready: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PeerInfoData {
     pub address: String,
     #[serde(rename = "nodeId")]

--- a/node/src/rust/web/web_api_docs.rs
+++ b/node/src/rust/web/web_api_docs.rs
@@ -11,6 +11,7 @@ use crate::rust::web::{
 #[openapi(
     paths(
         status_info::status_info_handler,
+        web_api_routes::ready_handler,
         shared_handlers::deploy_handler,
         shared_handlers::explore_deploy_handler,
         shared_handlers::explore_deploy_by_block_hash_handler,
@@ -49,6 +50,7 @@ pub struct PublicApi;
 #[openapi(
     paths(
         status_info::status_info_handler,
+        web_api_routes::ready_handler,
         shared_handlers::deploy_handler,
         shared_handlers::explore_deploy_handler,
         shared_handlers::explore_deploy_by_block_hash_handler,

--- a/node/src/rust/web/web_api_docs.rs
+++ b/node/src/rust/web/web_api_docs.rs
@@ -50,7 +50,6 @@ pub struct PublicApi;
 #[openapi(
     paths(
         status_info::status_info_handler,
-        web_api_routes::ready_handler,
         shared_handlers::deploy_handler,
         shared_handlers::explore_deploy_handler,
         shared_handlers::explore_deploy_by_block_hash_handler,

--- a/node/src/rust/web/web_api_routes.rs
+++ b/node/src/rust/web/web_api_routes.rs
@@ -38,6 +38,7 @@ impl WebApiRoutes {
     pub fn create_router() -> Router<AppState> {
         Router::new()
             .route("/status", get(shared_handlers::status_handler))
+            .route("/ready", get(ready_handler))
             .route("/prepare-deploy", get(prepare_deploy_get_handler))
             .route("/prepare-deploy", post(prepare_deploy_post_handler))
             .route("/deploy", post(shared_handlers::deploy_handler))
@@ -74,6 +75,25 @@ impl WebApiRoutes {
             .route("/estimate-cost", post(estimate_cost_handler))
             .route("/bond-status/{pubkey}", get(bond_status_handler))
     }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/ready",
+    responses(
+        (status = 200, description = "Casper is Running and the node can serve deploys"),
+        (status = 503, description = "Casper has not finished initializing (`service_unavailable`)"),
+    ),
+    tag = "Status"
+)]
+pub async fn ready_handler(State(app_state): State<AppState>) -> Response {
+    let ready = app_state.web_api.is_ready();
+    let code = if ready {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, Json(serde_json::json!({ "ready": ready }))).into_response()
 }
 
 #[utoipa::path(
@@ -645,6 +665,7 @@ mod tests {
     #[async_trait::async_trait]
     impl WebApi for StubWebApi {
         async fn status(&self) -> eyre::Result<ApiStatus> { unimplemented!() }
+        fn is_ready(&self) -> bool { unimplemented!() }
         async fn prepare_deploy(
             &self,
             _: Option<crate::rust::api::web_api::PrepareRequest>,
@@ -1044,10 +1065,14 @@ mod router_tests {
 
     fn block_info() -> BlockInfoSerde { BlockInfoSerde::from(models::casper::BlockInfo::default()) }
 
-    struct CannedWebApi;
+    struct CannedWebApi {
+        is_ready: bool,
+    }
 
     #[async_trait::async_trait]
     impl WebApi for CannedWebApi {
+        fn is_ready(&self) -> bool { self.is_ready }
+
         async fn status(&self) -> eyre::Result<ApiStatus> {
             Ok(ApiStatus {
                 version: VersionInfo {
@@ -1067,7 +1092,7 @@ mod router_tests {
                 last_finalized_block_number: 5,
                 is_validator: false,
                 is_read_only: true,
-                is_ready: true,
+                is_ready: self.is_ready,
                 current_epoch: 0,
                 epoch_length: 100,
             })
@@ -1256,7 +1281,9 @@ mod router_tests {
         }
     }
 
-    fn app_state() -> AppState {
+    fn app_state() -> AppState { app_state_with_readiness(true) }
+
+    fn app_state_with_readiness(is_ready: bool) -> AppState {
         let engine_cell = EngineCell::init();
         let block_report_api = BlockReportAPI::new(
             casper::rust::reporting_casper::noop(),
@@ -1290,7 +1317,7 @@ mod router_tests {
 
         AppState::new(
             Arc::new(StubAdminWebApi),
-            Arc::new(CannedWebApi),
+            Arc::new(CannedWebApi { is_ready }),
             Arc::new(block_report_api),
             RPConfCell::new(rp_conf),
             Arc::new(ConnectionsCell::new()),
@@ -1341,6 +1368,35 @@ mod router_tests {
         assert_eq!(json["shardId"], "root");
         assert_eq!(json["isReady"], true);
         assert_eq!(json["lastFinalizedBlockNumber"], 5);
+    }
+
+    async fn ready_response(is_ready: bool) -> (StatusCode, serde_json::Value) {
+        let response = WebApiRoutes::create_router()
+            .with_state(app_state_with_readiness(is_ready))
+            .oneshot(
+                Request::builder()
+                    .uri("/ready")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ready_route_reports_503_until_casper_running() {
+        let (status, json) = ready_response(false).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(json["ready"], false);
+
+        let (status, json) = ready_response(true).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(json["ready"], true);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/node/src/rust/web/web_api_routes.rs
+++ b/node/src/rust/web/web_api_routes.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 
 use crate::rust::api::serde_types::block_info::BlockInfoSerde;
 use crate::rust::api::web_api::{
-    DataAtNameByBlockHashRequest, DeployResponse, PrepareRequest, PrepareResponse, RhoDataResponse,
-    WebApi,
+    DataAtNameByBlockHashRequest, DeployResponse, PrepareRequest, PrepareResponse, ReadyResponse,
+    RhoDataResponse, WebApi,
 };
 use crate::rust::web::shared_handlers::{
     self, offload, ApiErrorResponse, AppError, AppJson, AppPath, AppQuery, AppState,
@@ -81,8 +81,8 @@ impl WebApiRoutes {
     get,
     path = "/api/ready",
     responses(
-        (status = 200, description = "Casper is Running and the node can serve deploys"),
-        (status = 503, description = "Casper has not finished initializing (`service_unavailable`)"),
+        (status = 200, description = "Casper is Running and the node can serve deploys", body = ReadyResponse),
+        (status = 503, description = "Casper has not finished initializing (`service_unavailable`)", body = ReadyResponse),
     ),
     tag = "Status"
 )]


### PR DESCRIPTION
## Fixes #12

## What changed (code)

- **`node/src/rust/web/web_api_routes.rs`** — new `GET /api/ready` endpoint. Returns HTTP 200 `{"ready":true}` once the Casper engine has entered the Running state and the node can serve deploys / exploratory deploys, HTTP 503 `{"ready":false}` while Casper is still initializing (genesis ceremony, or last-finalized-state sync on an observer).
- **`node/src/rust/api/web_api.rs`** — `WebApi` trait gains `fn is_ready(&self) -> bool`; `WebApiImpl` returns the existing `is_ready` `AtomicBool`.
- **`node/src/rust/web/web_api_docs.rs`** — register `ready_handler` in the public and admin OpenAPI path lists.
- **`casper/src/rust/engine/engine.rs`** — `transition_to_running` now publishes the `EnteredRunningState` event **after** `engine_cell.set(running)`, so the readiness signal can never be observed ahead of `with_casper()` resolving.
- **`node/Dockerfile`** — `HEALTHCHECK` now runs `curl -fsS 127.0.0.1:40403/api/ready`; `--start-period` raised to `120s`.
- **`docker/standalone.yml`** — healthcheck hits `/api/ready`; `start_period` raised to `120s`. `docker/observer.yml` and `docker/shard.yml` have no override and inherit the Dockerfile check.
- **`docs/node/api-reference.md`, `docs/node/README.md`** — document `/api/ready`.

## What problem it fixes

Running an observer node in Docker and following the container's health signal (`docker compose up --wait`, `depends_on: condition: service_healthy`) unblocked ~15 s before Casper could serve deploys. An exploratory deploy issued in that window failed with `Error: Could not execute exploratory deploy, casper instance was not available yet.`

The node already exposed `isReady` on `casper.v1.DeployService.status` and `GET /api/status` (flipped `true` on `EnteredRunningState`), but no health check consulted it: the Dockerfile `HEALTHCHECK` only checked that an endpoint returned any JSON object, and `/api/status` answers HTTP 200 throughout startup. `/api/ready` closes that gap with a probe that fails until the node is deploy-ready and needs no `jq`.

## How verified

- **Regression test** `ready_route_reports_503_until_casper_running` in `node/src/rust/web/web_api_routes.rs`: `GET /api/ready` returns HTTP 503 `{"ready":false}` when the readiness flag is false and HTTP 200 `{"ready":true}` when true. Fails on the base commit (`231067178a…`) — no route, and the trait has no `is_ready` — and passes with the fix.
- `cargo test -p node` — 246 + 17 + 1 pass.
- `cargo test -p casper --test mod engine::` — 86 pass, including `make_transition_to_running_state_after_block_approved` and `make_transition_to_running_once_approved_block_received`.
- `cargo clippy -p node -p casper --all-targets` and `cargo fmt --check` clean.
- Manual: `docker build -f node/Dockerfile …` then `docker compose -f docker/observer.yml up --wait` against a running shard — the command blocks until Casper is Running, and an immediately-following exploratory deploy succeeds.
- No testbed Kubernetes experiment was needed: the gap is fully determined by the health-check definitions plus the status-endpoint code, and the fix is covered by the deterministic router test.

## Caveat

A node still running the genesis ceremony (minutes to hours) now reports `unhealthy` for that whole window, so `docker compose up --wait` against a fresh validator mid-genesis will time out. This is the intended semantics — the node cannot serve deploys during genesis. Operators raise `--wait-timeout` / probe `failureThreshold` when they need to span a long genesis; the `120s` start period covers ordinary observer/validator startup.

The helm chart's `livenessProbe`/`readinessProbe` blocks are currently commented out in `templates/statefulsets.yaml`, so the chart is out of scope here — wiring the disabled probes to `/api/ready` is follow-up.
