### PR TITLE
test(casper): lock rejected-deploy re-inclusion window closed before finalization (#42)

### DIFF
--- a/casper/tests/batch2/recovery_cycle_spec.rs
+++ b/casper/tests/batch2/recovery_cycle_spec.rs
@@ -496,6 +496,51 @@ async fn recovery_cycle_rejected_deploy_retries_while_source_is_visible() {
         hex::encode(&surviving_sig)
     );
 
+    // Regression for issue #42: the re-inclusion window between the recovery
+    // proposal and its finalization is closed by the canonical-won selection
+    // filter, NOT by finalization. Before any `record_directly_finalized`
+    // call, validator 0 proposes an interim block on top of `recovery_block`.
+    // `recovery_block` is now in the parent cone and re-includes the recovered
+    // sig cleanly at a height above the rejection, so `prepare_user_deploys`
+    // suppresses it. The recovered sig must be absent from the interim block's
+    // body — a single sig must not appear in every block until the LFB advances.
+    let interim_marker = {
+        tokio::time::sleep(tokio::time::Duration::from_millis(2)).await;
+        construct_deploy::basic_deploy_data(7, None, Some(shard_id.clone()))
+            .expect("build interim_marker")
+    };
+    let interim_block = nodes[0]
+        .add_block_from_deploys(std::slice::from_ref(&interim_marker))
+        .await
+        .expect("validator 0 proposes interim block before finalization");
+    assert!(
+        !interim_block
+            .body
+            .deploys
+            .iter()
+            .any(|pd| pd.deploy.sig == conflict_sig),
+        "issue #42: the recovered sig {} must not be re-included once its clean \
+         recovery inclusion is canonically won over the proposer's parents, even \
+         before the recovery block finalizes; got body.deploys sigs = {:?}",
+        hex::encode(&conflict_sig),
+        interim_block
+            .body
+            .deploys
+            .iter()
+            .map(|pd| hex::encode(&pd.deploy.sig))
+            .collect::<Vec<_>>()
+    );
+    // The buffer entry is still retained (custody holds until finalized-won).
+    {
+        let buffer_guard = nodes[0].rejected_deploy_buffer.lock().expect("buffer lock");
+        assert!(
+            buffer_guard
+                .contains_sig(&conflict_sig)
+                .expect("buffer.contains_sig"),
+            "suppression from re-proposal must not evict the buffer entry"
+        );
+    }
+
     // Buffer custody after the replay wins: the purge keys on floor-state
     // membership of the deploy's effect, and the FLOOR has not covered
     // the replay here — the finality marker written below is not the


### PR DESCRIPTION
## Fixes #42

Test-only. The behavior the issue asks for is already implemented on `dev` — the rejected-deploy re-inclusion window is closed by the canonical-won selection filter in `prepare_user_deploys` (Option 3 from the issue), well before finalization. This PR adds the regression coverage the issue's "Tests" section calls for.

### What changed

`casper/tests/batch2/recovery_cycle_spec.rs` — `recovery_cycle_rejected_deploy_retries_while_source_is_visible` gains an interim propose between the recovery-block sync and the `record_directly_finalized` call:

- validator 0 proposes one interim block on top of `recovery_block`
- assert the recovered sig is **absent** from `interim_block.body.deploys`
- assert the buffer entry is still retained (suppression from re-proposal is not eviction)

### What problem it locks in

Before the recovery re-model, a recovered sig was re-included in **every** block between its recovery proposal and the finalization of its carrier — block-space bloat and redundant execution during the recovery window. The current `canonical_won_over_parents` / `canonical_won_sigs` machinery ([block_creator.rs:611](../blob/dev/casper/src/rust/blocks/proposer/block_creator.rs#L611), [:428](../blob/dev/casper/src/rust/blocks/proposer/block_creator.rs#L428), [interpreter_util.rs:64](../blob/dev/casper/src/rust/util/rholang/interpreter_util.rs#L64)) suppresses the buffered deploy once its clean recovery inclusion is canonically won over the proposer's parents. The new assertion isolates that this happens **before** finalization, not because of it.

### How verified

- `cargo test -p casper --release --test mod recovery_cycle` — green (both tests).
- Full `cargo test -p casper --release` — 936 pass; 5 unrelated genesis-contract Rholang timeout flakes under full-suite parallel load, all green when re-run in isolation.
- Reproduction check: the suppression is defended in depth — the new assertion still holds when `canonical_won_buffer_sigs` and the later `canonical_won` are each neutered, and both together (retry gate, `retry_scope_exempt`/`blocked_by_scope`, and retry-frontier deferral each independently keep the recovered sig out of the block once its recovery inclusion is in the parent cone). The test is a whole-property lock rather than a single-mechanism guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
