### PR TITLE
Chore/consolidate override stanzas

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -29,13 +29,7 @@
 # suite load; the same build passed twice in isolation moments later. Same
 # remedy as pos_spec above. It runs in well under a second, so the island
 # costs the run nothing.
-[[profile.default.overrides]]
-filter = '''
-  test(/genesis::contracts::pos_spec::pos_spec/)
-  | test(/soft_checkpoint_cost_does_not_scale_with_accumulated_store_size/)
-'''
-threads-required = "num-cpus"
-
+#
 # The rspace event-log sentinels measure lock contention and concurrent-vs-
 # sequential cost with spin-probe observers and wall-clock timers, so they
 # are the same scheduling-artifact class as the two islands above. PR #392
@@ -48,5 +42,9 @@ threads-required = "num-cpus"
 # process on a shared runner, so the two contention sentinels also carry a
 # 50% threshold with the measured margins recorded beside each constant.
 [[profile.default.overrides]]
-filter = 'test(/rspace::rspace::tests::(event_log_mutex_does_not_contend_under_concurrent_produces|par_branch_event_log_does_not_contend_at_rholang_par_scale|event_log_and_produce_counter_isolated_cost_at_rholang_par_scale|get_store_read_lock_isolated_cost_at_rholang_par_scale)$/)'
+filter = '''
+  test(/genesis::contracts::pos_spec::pos_spec/)
+  | test(/soft_checkpoint_cost_does_not_scale_with_accumulated_store_size/)
+  | test(/rspace::rspace::tests::(event_log_mutex_does_not_contend_under_concurrent_produces|par_branch_event_log_does_not_contend_at_rholang_par_scale|event_log_and_produce_counter_isolated_cost_at_rholang_par_scale|get_store_read_lock_isolated_cost_at_rholang_par_scale)$/)
+'''
 threads-required = "num-cpus"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,12 @@
 # nextest configuration.
 #
+# One override gives a small set of scheduling-sensitive tests the whole machine.
+# `threads-required = "num-cpus"` makes nextest run each matched test with no
+# co-tenant tests. Each test keeps its full-parallelism speed everywhere else in
+# the run. Add a test to the filter below only when it fails from CPU or lock
+# starvation in a full parallel run and passes deterministically in isolation.
+# Record the evidence for each entry in the notes that follow.
+#
 # `pos_spec` is by far the heaviest genesis-contract RhoSpec test: it runs the full
 # 16-test PoSTest.rho suite through the interpreter over a CUSTOM-parameter genesis
 # (minimum_bond=2 / maximum_bond=100000 => a GENESIS_CACHE miss => a full genesis
@@ -9,14 +16,9 @@
 # tests) it is starved for CPU + the shared LMDB environment badly enough to exceed its
 # RhoSpec execution timeout — a scheduling artifact, not a hang or a correctness issue
 # (it passes deterministically in isolation and alongside the 22 genesis siblings).
+# Islanded, it runs at its isolated ~50s speed. Every other genesis spec is light
+# enough to pass at full parallelism.
 #
-# `threads-required = "num-cpus"` makes nextest schedule it with the whole machine to
-# itself (no co-tenant tests), so it runs at its isolated ~50s speed. It is one short
-# island in the run; every other genesis spec is light enough to pass at full parallelism.
-[[profile.default.overrides]]
-filter = 'test(/genesis::contracts::pos_spec::pos_spec/)'
-threads-required = "num-cpus"
-
 # `soft_checkpoint_cost_does_not_scale_with_accumulated_store_size` is a
 # timing-invariant regression guard (issue-43: O(store-size) HotStore
 # snapshots) that compares microsecond-scale cost at two store sizes. Its 8x
@@ -25,8 +27,11 @@ threads-required = "num-cpus"
 # a fully parallel run skew the two measurement windows unevenly — the
 # issue-283 flake class. A 2026-08-31 pre-push run measured 15.7x under full
 # suite load; the same build passed twice in isolation moments later. Same
-# remedy as pos_spec above: schedule it with the machine to itself. It runs
-# in well under a second, so the island costs the run nothing.
+# remedy as pos_spec above. It runs in well under a second, so the island
+# costs the run nothing.
 [[profile.default.overrides]]
-filter = 'test(/soft_checkpoint_cost_does_not_scale_with_accumulated_store_size/)'
+filter = '''
+  test(/genesis::contracts::pos_spec::pos_spec/)
+  | test(/soft_checkpoint_cost_does_not_scale_with_accumulated_store_size/)
+'''
 threads-required = "num-cpus"


### PR DESCRIPTION
## Summary

This PR merges the three nextest override tables in `.config/nextest.toml` into one table. Each table set `threads-required = "num-cpus"` for a different filter. The single table now uses one filterset that joins the three filters with the `|` operator.

The change does not alter test scheduling. Every test that had the machine to itself before still has the machine to itself. No other file changes.

PR #394 left this consolidation out of its fix and named it as follow-up housekeeping. This PR completes that follow-up.

## Changes

- Replace three `[[profile.default.overrides]]` tables with one table.
- Write the filter as a multi-line TOML literal string, one predicate per line, so a future island is a one-line addition.
- Add a header note that states when a test qualifies for the island and asks for recorded evidence.
- Keep the three existing evidence notes for `pos_spec`, the soft-checkpoint guard, and the rspace event-log sentinels.

## Verification

`cargo nextest list` with the merged filter returns the same test set that the three old tables covered:

- `casper::mod genesis::contracts::pos_spec::pos_spec`
- `rspace_plus_plus rspace::rspace::tests::event_log_mutex_does_not_contend_under_concurrent_produces`
- `rspace_plus_plus rspace::rspace::tests::par_branch_event_log_does_not_contend_at_rholang_par_scale`
- `rspace_plus_plus rspace::rspace::tests::event_log_and_produce_counter_isolated_cost_at_rholang_par_scale`
- `rspace_plus_plus rspace::rspace::tests::get_store_read_lock_isolated_cost_at_rholang_par_scale`
- `soft_checkpoint_cost_does_not_scale_with_accumulated_store_size` in both rspace++ test binaries that build it

The soft-checkpoint guard appears in two binaries because rspace++ compiles it as a standalone integration test and again inside the `tests/mod.rs` harness. The old table used the same regex, so both copies were islanded before this change.

The pre-commit hook passed fmt, clippy, test, and deny on both commits. The multi-agent review on this PR returned five approvals with no findings above suggestion level.

## Branch notes

The branch started from `master` and merged `dev` twice, once after PR #387 landed and once after PR #394 landed. The tip of `master` is already contained in `dev`, so this PR carries no release commits and only the configuration change reaches `dev`.
