### PR TITLE
fix(deps): drop unused TLS and OpenTelemetry crates flagged by Dependabot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,13 +1089,12 @@ dependencies = [
  "rand 0.9.5",
  "regex",
  "reqwest 0.12.28",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pemfile 2.2.0",
- "rustls-webpki 0.102.8",
  "shared",
  "thiserror 2.0.19",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tonic 0.14.6",
  "tonic-prost",
@@ -1104,7 +1103,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "webpki",
  "x509-parser",
 ]
 
@@ -2461,7 +2459,6 @@ dependencies = [
  "linked-hash-map",
  "memchr",
  "nom 4.2.3",
- "reqwest 0.11.27",
  "serde",
  "serde_path_to_error",
  "thiserror 1.0.69",
@@ -2607,20 +2604,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -2629,10 +2612,10 @@ dependencies = [
  "hyper 1.11.0",
  "hyper-util",
  "log",
- "rustls 0.23.43",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.9",
 ]
@@ -3314,7 +3297,7 @@ dependencies = [
  "base64 0.22.1",
  "http-body-util",
  "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "indexmap 2.14.0",
  "ipnet",
@@ -3484,10 +3467,10 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3597,9 +3580,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "models",
  "num-bigint",
- "opentelemetry 0.20.0",
- "opentelemetry-zipkin",
- "opentelemetry_sdk 0.20.0",
  "parking_lot",
  "proptest",
  "prost 0.14.4",
@@ -3626,8 +3606,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-log 0.2.0",
- "tracing-opentelemetry",
+ "tracing-log",
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
@@ -3838,12 +3817,6 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
@@ -3858,132 +3831,6 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk 0.20.0",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
-dependencies = [
- "futures-core",
- "futures-sink",
- "indexmap 2.14.0",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
-dependencies = [
- "async-trait",
- "bytes",
- "http 0.2.12",
- "opentelemetry 0.21.0",
- "reqwest 0.11.27",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
-dependencies = [
- "opentelemetry 0.21.0",
-]
-
-[[package]]
-name = "opentelemetry-zipkin"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2bee3ec1be4d0088378e0eb1dd54c113cbd7ec5622cc4f26181debf1d4d7b5"
-dependencies = [
- "async-trait",
- "futures-core",
- "http 0.2.12",
- "once_cell",
- "opentelemetry 0.21.0",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.21.2",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "typed-builder",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float 3.9.2",
- "percent-encoding",
- "rand 0.8.7",
- "regex",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry 0.21.0",
- "ordered-float 4.6.0",
- "percent-encoding",
- "rand 0.8.7",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4654,7 +4501,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.43",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
@@ -4675,7 +4522,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -4994,7 +4841,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
@@ -5004,8 +4850,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -5014,7 +4858,6 @@ dependencies = [
  "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5039,7 +4882,7 @@ dependencies = [
  "http-body 1.1.0",
  "http-body-util",
  "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
@@ -5050,7 +4893,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5058,7 +4901,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -5477,18 +5320,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -5498,21 +5329,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -5521,10 +5340,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5553,27 +5372,6 @@ checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -5696,16 +5494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5723,19 +5511,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -5941,7 +5716,7 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "tracing-appender",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -6469,21 +6244,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.43",
+ "rustls",
  "tokio",
 ]
 
@@ -6632,7 +6397,7 @@ dependencies = [
  "socket2 0.6.5",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.3",
  "tower-layer",
@@ -6845,17 +6610,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -6863,22 +6617,6 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75327c6b667828ddc28f5e3f169036cb793c3f588d83bf0f262a7f062ffed3c8"
-dependencies = [
- "once_cell",
- "opentelemetry 0.20.0",
- "opentelemetry_sdk 0.20.0",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6908,7 +6646,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -6995,17 +6733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
-name = "typed-builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7081,7 +6808,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7100,12 +6827,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -7365,16 +7086,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/comm/Cargo.toml
+++ b/comm/Cargo.toml
@@ -27,8 +27,6 @@ rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2.1"
 tokio-rustls = "0.26" 
 x509-parser = "0.16"
-webpki = "0.22"
-rustls-webpki = "0.102"
 thiserror = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa"] }
 futures = { workspace = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,7 +36,7 @@ hex = { workspace = true }
 parking_lot = "0.12"
 num-bigint = { workspace = true }
 clap = { workspace = true }
-hocon = "0.9.0"
+hocon = { version = "0.9.0", default-features = false, features = ["serde-support"] }
 eyre = { workspace = true }
 humantime = { workspace = true }
 byte-unit = "5.1.6"
@@ -50,7 +50,6 @@ rustyline = "13.0"
 rpassword = "7.4"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing-opentelemetry = "0.21"
 tracing-log = { workspace = true }
 dashmap = { workspace = true }
 regex = { workspace = true }
@@ -71,9 +70,6 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.15"
 metrics-exporter-influx = "0.2.2"
-opentelemetry = { version = "0.20", features = ["rt-tokio"] }
-opentelemetry-zipkin = { version = "0.19", features = ["reqwest-client"] }
-opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
 sysinfo = "0.28"
 tonic-reflection = "0.14"
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,6 +36,8 @@ hex = { workspace = true }
 parking_lot = "0.12"
 num-bigint = { workspace = true }
 clap = { workspace = true }
+# url-support pulls reqwest 0.11 and the rustls 0.21 chain flagged by Dependabot. The
+# node config loader reads only local and embedded files, so URL includes stay off.
 hocon = { version = "0.9.0", default-features = false, features = ["serde-support"] }
 eyre = { workspace = true }
 humantime = { workspace = true }


### PR DESCRIPTION
## Summary

Dependabot reported 11 open alerts on the default branch. All 11 trace to three packages. This PR removes the dependency chains that carry two of those packages and records the dismissal of the third. No source file changes.

| Package | Alerts | Locked before | Patched | Path into the build |
| --- | --- | --- | --- | --- |
| rustls-webpki 0.102.8 | 2 high, 1 medium, 2 low | direct in `comm/Cargo.toml` | 0.103.13 | declared, never referenced in comm source |
| rustls-webpki 0.101.7 | same advisories, second copy | reqwest 0.11 through hocon and opentelemetry-zipkin | 0.103.13 | transitive only |
| opentelemetry_sdk 0.20.0 and 0.21.2 | 2 medium | direct in `node/Cargo.toml` and through opentelemetry-zipkin | 0.32.1 | the only consumer is a stub that returns Ok |
| protobuf 2.28.0 | 1 medium | rust-bert 0.23 behind the optional rholang `chromadb` feature | 3.7.2 | not in the default build graph |

## Changes

- `comm/Cargo.toml`: remove `webpki` and `rustls-webpki`. No file in the workspace references either crate. Comm uses rustls 0.23, which already brings the patched rustls-webpki 0.103.13.
- `node/Cargo.toml`: remove `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-zipkin`, and `tracing-opentelemetry`. The single consumer, `zipkin_reporter.rs`, is a TODO stub with no imports.
- `node/Cargo.toml`: build hocon with `default-features = false` and `serde-support` only. The default `url-support` feature pulls reqwest 0.11 for `include url(...)` directives. The node config loader reads only local and embedded files. File includes such as `include "default.conf"` stay enabled. A comment above the line records this reason.
- `Cargo.lock`: re-resolved from the manifests only, with no broad `cargo update`. The lock loses 22 packages, including rustls 0.21, hyper-rustls, tokio-rustls 0.24, both vulnerable rustls-webpki copies, and both opentelemetry_sdk copies. Only the patched rustls-webpki 0.103.13 remains.

## Alert disposition

- 10 alerts close when this PR reaches the default branch. They are the rustls-webpki and opentelemetry_sdk alerts, each reported once against `Cargo.lock` and once against the owning manifest.
- The protobuf alert is dismissed on GitHub with the reason `not_used`. rust-bert 0.23 is the latest release and pins a tokenizer that requires protobuf 2, so no patched version exists. The default build and CI never enable the `chromadb` feature, so the crate is outside the resolved graph.
- A reqwest 0.11 entry remains in the lock because rust-bert's `cached-path` pulls it. That entry no longer carries rustls 0.21 and is outside the default graph in the same way as protobuf.

## Verification

- `cargo clippy -p comm -p node --all-targets -- -D warnings` passes with zero warnings after the change.
- The pre-commit hook passed fmt, clippy, test, and deny on each commit.
- The remote alert count dropped from 11 to 10 immediately after the protobuf dismissal, which confirms the dismissal took effect.

## Review remediation

The multi-agent review on this PR returned approval at 80 percent agreement with two major findings, two minor findings, and three suggestions. Each item is resolved as follows.

- **Major: disabling `url-support` removes HOCON URL includes.** Confirmed as intended. The hocon source gates only the `include url(...)` form behind that feature. File includes remain available, and every `include` in the repository config files is a file include. No config uses a URL include.
- **Major: verify the OpenTelemetry stub no longer references removed crates.** Confirmed. The stub has no imports, and clippy on node with all targets passes.
- **Minor: confirm the removed TLS crates are unreferenced, including feature-gated code.** Confirmed by a workspace-wide search for `webpki` across all crate sources, which returns no matches.
- **Minor: lockfile formatting.** No action. The lock is generated by cargo and is not hand-edited.
- **Suggestion: add a comment explaining the hocon feature change.** Done in commit `f5fec8ca2`.
- **Suggestion: add cargo-deny or cargo-audit to CI.** Out of scope for this PR. The pre-commit hook already runs `cargo deny check`.
- **Suggestion: the OpenTelemetry stub may now be dead code.** Left in place. It is the placeholder for the Zipkin reporter port and is outside the scope of a dependency fix.

## Branch notes

The branch started from dev at the PR #394 merge. It merged dev again after PR #395 landed, which brought in the consolidated nextest override and nothing else.
