### PR TITLE
fix(crypto): accept canonical secp256k1:eth name in factory and deserialize

### DIFF
--- a/crypto/src/rust/signatures/signatures_alg.rs
+++ b/crypto/src/rust/signatures/signatures_alg.rs
@@ -67,16 +67,8 @@ impl<'de> Deserialize<'de> for Box<dyn SignaturesAlg> {
 
             fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where E: de::Error {
-                match value {
-                    "secp256k1" => Ok(Box::new(Secp256k1)),
-                    "secp256k1-eth" => Ok(Box::new(Secp256k1Eth)),
-                    #[cfg(feature = "schnorr_secp256k1_experimental")]
-                    "schnorr-secp256k1" => Ok(Box::new(SchnorrSecp256k1)),
-                    #[cfg(feature = "schnorr_secp256k1_experimental")]
-                    "frost-secp256k1" => Ok(Box::new(FrostSecp256k1)),
-                    // "ed25519" => Ok(Box::new(Ed25519)),
-                    _ => Err(de::Error::custom(format!("Unknown algorithm: {}", value))),
-                }
+                SignaturesAlgFactory::apply(value)
+                    .ok_or_else(|| de::Error::custom(format!("Unknown algorithm: {}", value)))
             }
         }
 
@@ -94,7 +86,7 @@ impl SignaturesAlgFactory {
             // https://rchain.atlassian.net/browse/RCHAIN-3560
             // case Ed25519.name => Some(Ed25519)
             "secp256k1" => Some(Box::new(Secp256k1)),
-            "secp256k1-eth" => Some(Box::new(Secp256k1Eth)),
+            "secp256k1:eth" | "secp256k1-eth" => Some(Box::new(Secp256k1Eth)),
             #[cfg(feature = "schnorr_secp256k1_experimental")]
             "schnorr-secp256k1" => Some(Box::new(SchnorrSecp256k1)),
             #[cfg(feature = "schnorr_secp256k1_experimental")]
@@ -113,8 +105,11 @@ mod tests {
         let alg = SignaturesAlgFactory::apply("secp256k1").unwrap();
         assert_eq!(alg.name(), "secp256k1");
 
-        let eth = SignaturesAlgFactory::apply("secp256k1-eth").unwrap();
+        let eth = SignaturesAlgFactory::apply("secp256k1:eth").unwrap();
         assert_eq!(eth.name(), "secp256k1:eth");
+
+        let eth_alias = SignaturesAlgFactory::apply("secp256k1-eth").unwrap();
+        assert_eq!(eth_alias.name(), "secp256k1:eth");
     }
 
     #[test]
@@ -167,13 +162,20 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_accepts_eth_alias() {
-        // Known-bug pin (issue #380): name() emits "secp256k1:eth" but the
-        // factory and Deserialize only accept "secp256k1-eth", so a boxed
-        // Secp256k1Eth does not survive a serde round-trip. This asserts the
-        // alias that DOES deserialize; update the pin when #380 is fixed.
-        let encoded = bincode::serialize("secp256k1-eth").unwrap();
+    fn deserialize_accepts_eth_canonical_name_and_alias() {
+        for name in ["secp256k1:eth", "secp256k1-eth"] {
+            let encoded = bincode::serialize(name).unwrap();
+            let decoded: Box<dyn SignaturesAlg> = bincode::deserialize(&encoded).unwrap();
+            assert_eq!(decoded.name(), "secp256k1:eth");
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_secp256k1_eth() {
+        let alg: Box<dyn SignaturesAlg> = Box::new(Secp256k1Eth);
+        let encoded = bincode::serialize(&alg).unwrap();
         let decoded: Box<dyn SignaturesAlg> = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(decoded.name(), alg.name());
         assert_eq!(decoded.name(), "secp256k1:eth");
     }
 }


### PR DESCRIPTION
**Fixes #380**

## What changed (code)

`crypto/src/rust/signatures/signatures_alg.rs`:

- `SignaturesAlgFactory::apply` now accepts `"secp256k1:eth"` — the canonical name that `Secp256k1Eth::name()` emits — alongside the existing `"secp256k1-eth"`, kept as a backward-compatible alias for persisted block `sigAlgorithm` values and existing HTTP deploy clients.
- The `Deserialize` impl for `Box<dyn SignaturesAlg>` no longer carries its own hand-written name match. It delegates to `SignaturesAlgFactory::apply`, so the deserializer and the factory can no longer drift. Unknown names still produce the same `Unknown algorithm: {value}` error.

No change to `name()` (it already matches the Scala origin and the deploy-signing path in `signed.rs`) and no change to the HTTP endpoint.

## What problem it fixes

`Secp256k1Eth::name()` returns `"secp256k1:eth"`, but the factory and the `Deserialize` impl only matched `"secp256k1-eth"`. A serialized `Box<dyn SignaturesAlg>` holding `Secp256k1Eth` wrote `"secp256k1:eth"` and then failed to deserialize with `Unknown algorithm: secp256k1:eth`. The same mismatch stopped `SignaturesAlgFactory::apply` from resolving a block whose `sigAlgorithm` carried the canonical name (`models/.../casper_message.rs:1023`, `casper/.../validator_identity.rs:31`).

Root cause: two hand-maintained name lists drifted from the one value `name()` returns.

## How verified

- New regression test `serde_roundtrip_preserves_secp256k1_eth` in `signatures_alg.rs`: serialize a `Box<dyn SignaturesAlg>` holding `Secp256k1Eth`, deserialize, assert the name is preserved. Fails on the base commit with `Unknown algorithm: secp256k1:eth`; passes with the fix.
- The pin test `deserialize_accepts_eth_alias` is updated (now `deserialize_accepts_eth_canonical_name_and_alias`) to assert that both `"secp256k1:eth"` and `"secp256k1-eth"` deserialize to `Secp256k1Eth`. `factory_returns_known_algorithms` gains a `"secp256k1:eth"` assertion.
- `cargo test -p crypto` — green in debug and release.
- `cargo test -p models --release`, `cargo test -p node --release` (signature paths) — green.
- `cargo test -p casper --release` — 940 passed; 4 timeout-sensitive `genesis::contracts` tests failed only under full-suite load and all pass in isolation (pre-existing flakiness, unrelated to a signature-name match).
- No testbed experiment: the defect is a deterministic serialization-string mismatch fully covered by the unit regression test.
