### PR TITLE
fix(casper): clear low-risk PR #488 follow-up cleanup (issue #44)

### DIFF
--- a/block-storage/src/rust/dag/block_dag_key_value_storage.rs
+++ b/block-storage/src/rust/dag/block_dag_key_value_storage.rs
@@ -1196,9 +1196,7 @@ impl BlockDagKeyValueStorage {
 
         // Latest-message updates are NOT gated on `invalid`. Equivocation blocks
         // (and other invalid blocks) advance the sender's latest message and
-        // register newly-bonded validators just like valid blocks. This matches
-        // the Scala source-of-truth (`BlockDagKeyValueStorage.scala`, where
-        // `newLatestMessages` and `shouldAddAsLatest` never reference `invalid`).
+        // register newly-bonded validators just like valid blocks.
         //
         // Safety argument:
         //   - Fork choice and finalization are unaffected. Parent selection filters
@@ -1211,9 +1209,9 @@ impl BlockDagKeyValueStorage {
         //     or finalization depth.
         //   - Slashing requires invalid blocks to BE in the LMM. The equivocation
         //     detector reads `invalid_latest_messages` and feeds it to
-        //     `prepare_slashing_deploys`. The pre-fix `if invalid { return empty }`
-        //     guard had no Scala counterpart and silently disabled the slashing
-        //     pipeline (no slashes ever issued, equivocators never punished).
+        //     `prepare_slashing_deploys`. Gating the LMM on `invalid` would leave
+        //     the slashing pipeline with nothing to act on — no slashes issued,
+        //     equivocators never punished.
         //   - `justification_follows` validation requires every bonded validator
         //     to appear in a new block's justifications. Without the LMM advancing
         //     on invalid blocks, validators whose latest is invalid would be

--- a/casper/src/rust/blocks/proposer/block_creator.rs
+++ b/casper/src/rust/blocks/proposer/block_creator.rs
@@ -474,9 +474,7 @@ async fn prepare_user_deploys_with_policy(
 
     let mut buffered_deploys: HashSet<Signed<DeployData>> =
         if allow_ordinary_deploys || allow_in_scope_recovery || allow_recovered_deploys {
-            let buffer_guard = rejected_deploy_buffer
-                .lock()
-                .map_err(|e| CasperError::LockError(e.to_string()))?;
+            let buffer_guard = rejected_deploy_buffer.lock()?;
             buffer_guard.read_all()?
         } else {
             HashSet::new()
@@ -530,8 +528,7 @@ async fn prepare_user_deploys_with_policy(
         );
         deploy_storage_guard.remove(expired_buffered.clone())?;
         rejected_deploy_buffer
-            .lock()
-            .map_err(|e| CasperError::LockError(e.to_string()))?
+            .lock()?
             .remove(expired_buffered.clone())?;
         let expired_sigs: HashSet<Bytes> = expired_buffered
             .into_iter()
@@ -593,8 +590,7 @@ async fn prepare_user_deploys_with_policy(
     };
     if !settled_buffered.is_empty() {
         rejected_deploy_buffer
-            .lock()
-            .map_err(|e| CasperError::LockError(e.to_string()))?
+            .lock()?
             .remove(settled_buffered.clone())?;
         tracing::info!(
             target: "f1r3fly.casper.recovery",
@@ -1322,9 +1318,7 @@ async fn prepare_user_deploys_with_policy(
         // unless explicitly removed. Without this, a sustained-load
         // adversary that keeps generating conflicts can grow the buffer
         // unbounded.
-        let mut buffer_guard = rejected_deploy_buffer
-            .lock()
-            .map_err(|e| CasperError::LockError(e.to_string()))?;
+        let mut buffer_guard = rejected_deploy_buffer.lock()?;
         buffer_guard.remove(expired_list)?;
     }
 
@@ -1837,8 +1831,7 @@ fn quarantine_refund_failure_deploy(
         .remove_by_sig(&sig)
         .map_err(CasperError::from)?;
     let removed_from_rejected_buffer = rejected_deploy_buffer
-        .lock()
-        .map_err(|e| CasperError::LockError(e.to_string()))?
+        .lock()?
         .remove_by_sig(&sig)
         .map_err(CasperError::from)?;
 
@@ -1850,9 +1843,7 @@ fn drain_selected_deploys_from_rejected_buffer(
     rejected_deploy_buffer: &Arc<Mutex<KeyValueRejectedDeployBuffer>>,
     deploys: &[Signed<DeployData>],
 ) -> Result<usize, CasperError> {
-    let mut guard = rejected_deploy_buffer
-        .lock()
-        .map_err(|e| CasperError::LockError(e.to_string()))?;
+    let mut guard = rejected_deploy_buffer.lock()?;
     let mut removed = 0usize;
     for deploy in deploys {
         if guard
@@ -1878,9 +1869,7 @@ fn drain_selected_recovered_deploys_from_deploy_storage(
     deploys: &[Signed<DeployData>],
 ) -> Result<usize, CasperError> {
     let selected_recovered: Vec<Signed<DeployData>> = {
-        let guard = rejected_deploy_buffer
-            .lock()
-            .map_err(|e| CasperError::LockError(e.to_string()))?;
+        let guard = rejected_deploy_buffer.lock()?;
         let mut out = Vec::new();
         for deploy in deploys {
             if guard.contains_sig(&deploy.sig).map_err(CasperError::from)? {
@@ -2057,8 +2046,7 @@ fn fresh_local_deploy_stats(
         return Ok(FreshLocalDeployStats::default());
     }
     let buffered_sigs: HashSet<Bytes> = rejected_deploy_buffer
-        .lock()
-        .map_err(|e| CasperError::LockError(e.to_string()))?
+        .lock()?
         .read_all()?
         .into_iter()
         .map(|deploy| deploy.sig)
@@ -2127,8 +2115,7 @@ fn in_scope_local_deploy_stats(
         return Ok(InScopeLocalDeployStats::default());
     }
     let buffered_sigs: HashSet<Bytes> = rejected_deploy_buffer
-        .lock()
-        .map_err(|e| CasperError::LockError(e.to_string()))?
+        .lock()?
         .read_all()?
         .into_iter()
         .map(|deploy| deploy.sig)
@@ -2205,9 +2192,7 @@ fn rejected_buffer_has_recoverable_deploys(
     floor_ctx: Option<&FloorContext>,
 ) -> Result<bool, CasperError> {
     let buffered_deploys = {
-        let buffer_guard = rejected_deploy_buffer
-            .lock()
-            .map_err(|e| CasperError::LockError(e.to_string()))?;
+        let buffer_guard = rejected_deploy_buffer.lock()?;
         if !buffer_guard.non_empty()? {
             return Ok(false);
         }
@@ -3100,7 +3085,7 @@ pub async fn create(
                 next_seq_num,
             );
             tracing::info!(
-                "Recovering merge-rejected slash: invalid_block={}, original_issuer={}, target_activation_epoch={}",
+                "Recovering merge-rejected slash: invalid_block={}, one_of_original_issuers={}, target_activation_epoch={}",
                 pretty_printer::PrettyPrinter::build_string_bytes(&rs.invalid_block_hash),
                 hex::encode(&rs.issuer_public_key.bytes),
                 recovered_target_activation_epoch

--- a/casper/src/rust/errors.rs
+++ b/casper/src/rust/errors.rs
@@ -138,6 +138,13 @@ impl From<String> for CasperError {
     fn from(error: String) -> Self { CasperError::RuntimeError(error) }
 }
 
+/// Conversion from a poisoned `std::sync::Mutex` / `RwLock` guard. Lets
+/// `?` propagate a lock-acquisition failure directly instead of the
+/// per-site `.map_err(|e| CasperError::LockError(e.to_string()))?`.
+impl<T> From<std::sync::PoisonError<T>> for CasperError {
+    fn from(error: std::sync::PoisonError<T>) -> Self { CasperError::LockError(error.to_string()) }
+}
+
 /// Conversion from `std::time::SystemTimeError`. Wraps the underlying
 /// error message into `CasperError::RuntimeError`. Used by `?`
 /// propagation in `construct_deploy::source_deploy_now` and

--- a/casper/src/rust/merging/dag_merger.rs
+++ b/casper/src/rust/merging/dag_merger.rs
@@ -926,15 +926,22 @@ pub fn merge(
         }
     };
 
-    // Late blocks: With the new actualBlocks definition that includes sibling branches,
-    // there are no "late" blocks when scope is provided - all non-ancestor blocks are in actualBlocks.
-    // Late block filtering is now only relevant for legacy code paths without scope.
+    // Late blocks: with the `actual_blocks` definition that includes sibling
+    // branches, there are no "late" blocks when a scope is provided — every
+    // non-ancestor block is already in `actual_blocks`. Late-block filtering
+    // only matters on the `scope: None` path.
+    //
+    // The only production caller (`interpreter_util::compute_parents_post_state`)
+    // always passes `Some(visible_blocks)`. `scope: None` is a legacy /
+    // test-only shape. On that path `disable_late_block_filtering` is the
+    // switch below; when a scope is present the flag is a no-op, since
+    // `scope.is_some()` already forces the empty set.
     let late_blocks: HashSet<BlockHash> = if disable_late_block_filtering || scope.is_some() {
-        // No late blocks when scope is provided (all relevant blocks are in actualBlocks)
         HashSet::new()
     } else {
-        // Legacy: query nonFinalizedBlocks (non-deterministic, but no scope means
-        // this is not a multi-parent merge validation)
+        // Legacy no-scope path: `non_finalized_blocks()` iterates storage in a
+        // non-deterministic order. Acceptable here because this path is never a
+        // multi-parent merge validation (no scope ⇒ no consensus comparison).
         let non_finalized_blocks = dag.non_finalized_blocks()?;
         non_finalized_blocks
             .difference(&actual_blocks)

--- a/casper/src/rust/merging/rejected_slash.rs
+++ b/casper/src/rust/merging/rejected_slash.rs
@@ -30,6 +30,24 @@ impl std::hash::Hash for RejectedSlash {
     }
 }
 
+/// Order a freshly-extracted `RejectedSlash` list for deterministic
+/// downstream use. The extraction site builds the list by iterating a
+/// `HashMap` keyed on the source block hash, so its order is
+/// non-deterministic; the list is then cached in `MergedPreState` and
+/// drives the order of the re-issued recovered slash deploys in the
+/// proposed block body. Sorting by `(invalid_block_hash,
+/// source_block_hash)` makes that order a function of the merge inputs
+/// alone. The pair is unique per entry: the extractor emits at most one
+/// slash per `invalid_block_hash` per source block.
+pub fn sorted_for_body(mut slashes: Vec<RejectedSlash>) -> Vec<RejectedSlash> {
+    slashes.sort_by(|a, b| {
+        a.invalid_block_hash
+            .cmp(&b.invalid_block_hash)
+            .then_with(|| a.source_block_hash.cmp(&b.source_block_hash))
+    });
+    slashes
+}
+
 /// Filter rejected slashes for re-issuance by the merge proposer.
 ///
 /// Two collapses happen here:
@@ -196,6 +214,35 @@ mod tests {
     fn empty_inputs_produce_empty_output() {
         let out = filter_recoverable(Vec::<RejectedSlash>::new(), Vec::<BlockHash>::new());
         assert!(out.is_empty());
+    }
+
+    /// `sorted_for_body` must impose a total order that depends only on
+    /// the merge inputs, not on the `HashMap` iteration order the
+    /// extractor happens to produce. Same set in, same order out, with
+    /// `source_block_hash` breaking ties on `invalid_block_hash`.
+    #[test]
+    fn sorted_for_body_orders_by_invalid_then_source_block() {
+        let mk = |invalid: u8, source: u8| RejectedSlash {
+            invalid_block_hash: Bytes::from(vec![invalid; 32]),
+            issuer_public_key: pk(0),
+            source_block_hash: Bytes::from(vec![source; 32]),
+        };
+        let a = mk(1, 9);
+        let b = mk(1, 3);
+        let c = mk(5, 1);
+
+        let one = sorted_for_body(vec![c.clone(), a.clone(), b.clone()]);
+        let two = sorted_for_body(vec![b.clone(), c.clone(), a.clone()]);
+
+        let key = |s: &RejectedSlash| (s.invalid_block_hash.to_vec(), s.source_block_hash.to_vec());
+        assert_eq!(
+            one.iter().map(key).collect::<Vec<_>>(),
+            two.iter().map(key).collect::<Vec<_>>(),
+            "sorted_for_body output must not depend on input order"
+        );
+        assert_eq!(key(&one[0]), key(&b));
+        assert_eq!(key(&one[1]), key(&a));
+        assert_eq!(key(&one[2]), key(&c));
     }
 
     #[test]

--- a/casper/src/rust/storage/rnode_key_value_store_manager.rs
+++ b/casper/src/rust/storage/rnode_key_value_store_manager.rs
@@ -151,7 +151,7 @@ pub fn rnode_db_mapping(legacy_rspace_paths: Option<bool>) -> Vec<(Db, LmdbEnvCo
         ),
         // Buffer of deploys rejected during multi-parent merge; shares sizing
         // with deploy_storage since its entries are the same value type
-        // (Signed<DeployData>) and it is bounded by `deployLifespan`.
+        // (Signed<DeployData>) and it is bounded by `deploy_lifespan`.
         (
             Db::new("rejected_deploy_buffer".to_string(), None),
             deploy_storage_env_config(),

--- a/casper/src/rust/util/rholang/interpreter_util.rs
+++ b/casper/src/rust/util/rholang/interpreter_util.rs
@@ -2127,7 +2127,10 @@ pub async fn compute_parents_post_state(
                             }
                         }
                     }
-                    out
+                    // `by_block` iteration order is non-deterministic;
+                    // `sorted_for_body` makes the cached list a function of
+                    // the merge inputs alone.
+                    crate::rust::merging::rejected_slash::sorted_for_body(out)
                 };
 
             let computed_state = prost::bytes::Bytes::copy_from_slice(&state.bytes());

--- a/casper/tests/blocks/block_creator_spec.rs
+++ b/casper/tests/blocks/block_creator_spec.rs
@@ -1036,11 +1036,11 @@ async fn buffered_retry_admission_follows_the_recovered_deploys_policy_switch() 
 
 /// Test: "remove block-expired deploys while keeping valid ones in storage"
 ///
-/// With deployLifespan = 50 and currentBlock = 101 (maxBlockNum = 100),
-/// earliestBlockNumber = 101 - 50 = 51
+/// With deploy_lifespan = 50 and current_block = 101 (max_block_num = 100),
+/// earliest_block_number = 101 - 50 = 51
 ///
-/// Expired deploy: validAfterBlockNumber = 0 (<= 51, expired)
-/// Valid deploy: validAfterBlockNumber = 60 (> 51 and < 101, valid)
+/// Expired deploy: valid_after_block_number = 0 (<= 51, expired)
+/// Valid deploy: valid_after_block_number = 60 (> 51 and < 101, valid)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn should_remove_block_expired_deploys_while_keeping_valid_ones() {
     crate::init_logger();
@@ -1083,8 +1083,8 @@ async fn should_remove_block_expired_deploys_while_keeping_valid_ones() {
     );
 
     // Create deploys:
-    // - Expired deploy: validAfterBlockNumber = 0 (<= 51, expired)
-    // - Valid deploy: validAfterBlockNumber = 60 (> 51 and < 101, valid)
+    // - Expired deploy: valid_after_block_number = 0 (<= 51, expired)
+    // - Valid deploy: valid_after_block_number = 60 (> 51 and < 101, valid)
     let expired_deploy = create_deploy(0, None, &validator_sk);
     let valid_deploy = create_deploy(60, None, &validator_sk);
 
@@ -1099,11 +1099,11 @@ async fn should_remove_block_expired_deploys_while_keeping_valid_ones() {
         assert_eq!(deploys_before.len(), 2, "Expected 2 deploys before create");
     }
 
-    // Create snapshot with maxBlockNum = 100
+    // Create snapshot with max_block_num = 100
     let snapshot = create_snapshot(100, validator_id);
 
     // Call BlockCreator.create
-    // The cleanup happens in prepareUserDeploys before block creation
+    // The cleanup happens in prepare_user_deploys before block creation
     // Block creation may fail due to empty parents, but that's after cleanup
     let _ = block_creator::create(
         &snapshot,
@@ -1137,9 +1137,9 @@ async fn should_remove_block_expired_deploys_while_keeping_valid_ones() {
 
 /// Test: "remove both block-expired and time-expired deploys while keeping valid ones"
 ///
-/// - Block-expired deploy (validAfterBlockNumber = 0 is expired)
-/// - Time-expired deploy (validAfterBlockNumber = 60 is valid, but expirationTimestamp is past)
-/// - Valid deploy (validAfterBlockNumber = 60 is valid, no expiration timestamp)
+/// - Block-expired deploy (valid_after_block_number = 0 is expired)
+/// - Time-expired deploy (valid_after_block_number = 60 is valid, but expiration_timestamp is past)
+/// - Valid deploy (valid_after_block_number = 60 is valid, no expiration timestamp)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn should_remove_both_block_expired_and_time_expired_deploys() {
     crate::init_logger();
@@ -1189,9 +1189,9 @@ async fn should_remove_both_block_expired_and_time_expired_deploys() {
         - 60000;
 
     // Create deploys:
-    // - Block-expired deploy (validAfterBlockNumber = 0 is expired)
-    // - Time-expired deploy (validAfterBlockNumber = 60 is valid, but expirationTimestamp is past)
-    // - Valid deploy (validAfterBlockNumber = 60 is valid, no expiration timestamp)
+    // - Block-expired deploy (valid_after_block_number = 0 is expired)
+    // - Time-expired deploy (valid_after_block_number = 60 is valid, but expiration_timestamp is past)
+    // - Valid deploy (valid_after_block_number = 60 is valid, no expiration timestamp)
     let block_expired_deploy = create_deploy(0, None, &validator_sk);
     let time_expired_deploy = create_deploy(60, Some(past_timestamp), &validator_sk);
     let valid_deploy = create_deploy(60, None, &validator_sk);
@@ -1211,7 +1211,7 @@ async fn should_remove_both_block_expired_and_time_expired_deploys() {
         assert_eq!(deploys_before.len(), 3, "Expected 3 deploys before create");
     }
 
-    // Create snapshot with maxBlockNum = 100
+    // Create snapshot with max_block_num = 100
     let snapshot = create_snapshot(100, validator_id);
 
     // Call BlockCreator.create


### PR DESCRIPTION
## Fixes

Refs #44 (does not close it — this is one batch of a 36-item tracker).

Clears the low-risk, still-live items from the PR #488 deferred-review backlog. Full triage of all 36 items (which are live, which are obsolete, which were verified closed by tracing) is in the issue comments.

Scope agreed with the maintainer: the cheap cleanup batch **minus 5** — `filter_slashable_invalid_messages` is now `#[cfg(test)]` and the production slash path (`authorized_slash_candidates`) does not scan `active_validators`, so there is nothing meaningful left to change for 5. 34 stays a separate follow-up.

## What changed (code)

| # | Change |
|---|--------|
| 8 | New `rejected_slash::sorted_for_body` orders a freshly-extracted `RejectedSlash` list by `(invalid_block_hash, source_block_hash)`. `compute_parents_post_state` calls it, so the list cached in `MergedPreState` — and the order of the re-issued recovered slash deploys in the proposed block body — no longer depends on `HashMap` iteration order. |
| 6 | Recovered-slash log field `original_issuer` → `one_of_original_issuers` (after the dedup keyed on `invalid_block_hash`, the surviving record's issuer is only one of them). |
| 18 | `impl<T> From<std::sync::PoisonError<T>> for CasperError`; the 10 `rejected_deploy_buffer.lock().map_err(|e| CasperError::LockError(e.to_string()))?` sites in `block_creator.rs` collapse to `.lock()?`. `block_admission.rs` / `dispatch.rs` sites left for a follow-up (outside this issue's scope). |
| 16a | Dropped the `BlockDagKeyValueStorage.scala` anchor and the "pre-fix `if invalid` guard" narration from the LMM safety comment; kept the fork-choice / slashing / `justification_follows` argument, reworded as a rule. |
| 16d | `deployLifespan` / `maxBlockNum` / `currentBlock` / `earliestBlockNumber` / `validAfterBlockNumber` / `expirationTimestamp` / `prepareUserDeploys` in comments → snake_case. |
| 27 / 28 | `dag_merger::merge` late-block comment: the only production caller always passes `Some(scope)`; `scope: None` is legacy / test-only; `disable_late_block_filtering` is a no-op when a scope is present. |

## What problem it fixes

The `rejected_slashes` list built inside `compute_parents_post_state` was assembled by iterating a `HashMap`, so its order was non-deterministic. That list is cached in `MergedPreState` and drives the order in which a proposer re-issues merge-rejected slash deploys into its block body. Non-deterministic order there breaks crash-recovery idempotency and byte-for-byte reproducibility of a proposer's own block across attempts. The rest of the batch is comments, a log-field rename, and an error-conversion helper.

## How verified

- `cargo build -p casper -p block-storage` — clean.
- `cargo test -p casper --lib` — 354 passed. `cargo test -p block-storage --lib` — 68 passed.
- New unit test `rejected_slash::tests::sorted_for_body_orders_by_invalid_then_source_block` — asserts the output is independent of input order and tie-breaks on `source_block_hash`.
- `cargo test -p casper --test mod -- batch2::slash_recovery_spec merging blocks::block_creator` — 37 passed, 3 pre-existing ignored, 0 failed (exercises the `RejectedSlash` re-issue path end to end).
- No testbed experiment: no node behavior changes beyond the deterministic ordering.
