### PR TITLE
fix(ci): isolate scheduled dependency audits by branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,3 +20,4 @@ Dockerfile          @F1R3FLY-io/ci-maintainers
 /Cross.toml         @F1R3FLY-io/ci-maintainers
 /rust-toolchain.toml @F1R3FLY-io/ci-maintainers
 /scripts/ci/        @F1R3FLY-io/ci-maintainers
+/scripts/supply-chain/ @F1R3FLY-io/ci-maintainers

--- a/.github/workflows/deny-schedule.yml
+++ b/.github/workflows/deny-schedule.yml
@@ -1,27 +1,69 @@
+# Scheduled supply-chain audit.
+#
+# The main CI `deny` job only runs on push / pull_request, so a newly-published
+# RustSec advisory against an existing dependency goes unnoticed during quiet
+# periods. This weekly cron closes that gap by running cargo-deny against the
+# long-lived branches even when no one has pushed.
+#
+# NOTE: GitHub only fires `schedule` events from the workflow file on the
+# repository's default branch (master). This file must be present on master for
+# the cron to run. The master run audits its own commit and dispatches a
+# separate run of this workflow on dev, so each branch is audited by its own
+# workflow file against its own commit and no branch is checked out under
+# another branch's workflow definition.
 name: Scheduled cargo-deny
 
 on:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # Runs triggered with the workflow token notify nobody, so this job waits
+  # for the dispatched dev run and fails with it. A dev audit failure then
+  # fails this scheduled run and reaches the people who receive its
+  # notifications. Only `schedule` dispatches, so the dev run cannot re-enter.
   dispatch-dev:
     name: Dispatch dev dependency audit
     if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     permissions:
       actions: write
     steps:
       - name: Dispatch the audit in the dev branch context
+        id: dispatch
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run deny-schedule.yml --repo "$GITHUB_REPOSITORY" --ref dev
+        run: |
+          before="$(date -u +%s)"
+          gh workflow run deny-schedule.yml --repo "$GITHUB_REPOSITORY" --ref dev
+          run_id=""
+          for _ in $(seq 1 12); do
+            sleep 10
+            run_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/deny-schedule.yml/runs?branch=dev&event=workflow_dispatch&per_page=10" \
+              | jq -r --argjson before "$before" '
+                [.workflow_runs[]
+                  | select((.created_at | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) >= $before)]
+                | sort_by(.run_number) | last | .id // empty')"
+            [ -n "$run_id" ] && break
+          done
+          [ -n "$run_id" ] || { echo "::error::the dev audit run did not start"; exit 1; }
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "Dispatched dev audit run ${run_id}."
 
+      - name: Wait for the dev audit result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ steps.dispatch.outputs.run_id }}
+        run: gh run watch "$RUN_ID" --repo "$GITHUB_REPOSITORY" --exit-status
+
+  # Checks out only the commit that carries this workflow file, so the audit
+  # script and the workflow always come from the same commit. A branch that
+  # drops the script while keeping the workflow fails loudly by design.
   deny:
     name: cargo-deny (${{ github.ref_name }})
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master'
@@ -29,13 +71,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout the audit event commit
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-02-09
 
@@ -49,7 +91,7 @@ jobs:
 
       - name: Upload supply-chain evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: supply-chain-${{ github.ref_name }}
           path: target/supply-chain/

--- a/.github/workflows/deny-schedule.yml
+++ b/.github/workflows/deny-schedule.yml
@@ -1,75 +1,57 @@
-# Scheduled supply-chain audit.
-#
-# The main CI `deny` job only runs on push / pull_request, so a newly-published
-# RustSec advisory against an existing dependency goes unnoticed during quiet
-# periods. This weekly cron closes that gap by running cargo-deny against the
-# long-lived branches even when no one has pushed.
-#
-# NOTE: GitHub only fires `schedule` events from the workflow file on the
-# repository's default branch (master). This file must be present on master for
-# the cron to run; the matrix then checks each branch independently.
 name: Scheduled cargo-deny
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  dispatch-dev:
+    name: Dispatch dev dependency audit
+    if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch the audit in the dev branch context
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run deny-schedule.yml --repo "$GITHUB_REPOSITORY" --ref dev
+
   deny:
-    name: cargo-deny (${{ matrix.branch }})
+    name: cargo-deny (${{ github.ref_name }})
+    if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: [dev, master]
     steps:
-      - name: Checkout ${{ matrix.branch }}
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - name: Checkout the audit event commit
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
-          ref: ${{ matrix.branch }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
-      # Guarded on existence because this workflow checks out dev and master
-      # by ref while running the default branch's workflow file. A branch that
-      # does not carry the supply-chain tooling yet must not fail its scheduled
-      # check. The skip is reported as a notice so the gap stays visible.
-      - name: Detect supply-chain tooling
-        id: tooling
-        shell: bash
-        run: |
-          if [ -f scripts/ci/check-supply-chain.sh ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::${{ matrix.branch }} does not carry scripts/ci/check-supply-chain.sh; scheduled check skipped"
-          fi
-
       - name: Install Rust
-        if: steps.tooling.outputs.present == 'true'
-        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
         with:
           toolchain: nightly-2026-02-09
 
       - name: Install verified cargo-deny
-        if: steps.tooling.outputs.present == 'true'
         run: |
           bash scripts/ci/check-supply-chain.sh install --install-dir "$RUNNER_TEMP/cargo-deny"
           echo "$RUNNER_TEMP/cargo-deny" >> "$GITHUB_PATH"
 
       - name: Check all dependency graphs
-        if: steps.tooling.outputs.present == 'true'
         run: bash scripts/ci/check-supply-chain.sh check
 
       - name: Upload supply-chain evidence
-        if: always() && steps.tooling.outputs.present == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: supply-chain-${{ matrix.branch }}
+          name: supply-chain-${{ github.ref_name }}
           path: target/supply-chain/
           retention-days: 90
           if-no-files-found: error

--- a/scripts/supply-chain/tests/repository.rs
+++ b/scripts/supply-chain/tests/repository.rs
@@ -209,14 +209,13 @@ fn scheduled_dispatch_has_no_checkout_or_branch_code_execution() {
     assert!(job.contains("GH_TOKEN: ${{ github.token }}"));
     assert!(!job.contains("uses:"));
     assert!(!job.contains("contents: write"));
-    let commands: Vec<_> = job
-        .lines()
-        .filter_map(|line| line.trim().strip_prefix("run: "))
-        .collect();
-    assert_eq!(commands, [
-        "gh workflow run deny-schedule.yml --repo \"$GITHUB_REPOSITORY\" --ref dev"
-    ]);
-    assert_eq!(job.matches("run:").count(), 1);
+    assert!(!job.contains("actions/checkout"));
+    assert_eq!(job.matches("gh workflow run").count(), 1);
+    assert!(
+        job.contains("gh workflow run deny-schedule.yml --repo \"$GITHUB_REPOSITORY\" --ref dev")
+    );
+    assert!(job.contains("gh run watch \"$RUN_ID\" --repo \"$GITHUB_REPOSITORY\" --exit-status"));
+    assert!(job.contains("::error::the dev audit run did not start"));
     assert!(!job.contains("continue-on-error"));
 }
 

--- a/scripts/supply-chain/tests/repository.rs
+++ b/scripts/supply-chain/tests/repository.rs
@@ -169,6 +169,77 @@ fn deny_workflows_use_the_rust_launcher_and_keep_evidence() {
     assert!(launcher.contains("-p supply-chain"));
 }
 
+fn scheduled_job(name: &str) -> String {
+    let workflow = fs::read_to_string(root().join(".github/workflows/deny-schedule.yml")).unwrap();
+    let marker = format!("\n  {name}:\n");
+    workflow
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("Missing scheduled audit job: {name}"))
+        .1
+        .lines()
+        .take_while(|line| line.trim().is_empty() || line.starts_with("    "))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn scheduled_audit_executes_only_the_event_commit() {
+    let job = scheduled_job("deny");
+    assert_eq!(job.matches("uses: actions/checkout@").count(), 1);
+    assert!(job.contains("ref: ${{ github.sha }}"));
+    assert!(job.contains("persist-credentials: false"));
+    assert!(!job.contains("matrix."));
+    assert!(!job.contains("actions: write"));
+    assert!(!job.contains("GH_TOKEN:"));
+    assert!(job.contains("if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master'"));
+    assert!(job.contains("check-supply-chain.sh install"));
+    assert!(job.contains("check-supply-chain.sh check"));
+    assert!(job.contains("if: always()"));
+    assert!(job.contains("if-no-files-found: error"));
+    assert!(!job.contains("tooling.outputs.present"));
+}
+
+#[test]
+fn scheduled_dispatch_has_no_checkout_or_branch_code_execution() {
+    let job = scheduled_job("dispatch-dev");
+    assert!(
+        job.contains("if: github.event_name == 'schedule' && github.ref == 'refs/heads/master'")
+    );
+    assert!(job.contains("actions: write"));
+    assert!(job.contains("GH_TOKEN: ${{ github.token }}"));
+    assert!(!job.contains("uses:"));
+    assert!(!job.contains("contents: write"));
+    let commands: Vec<_> = job
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("run: "))
+        .collect();
+    assert_eq!(commands, [
+        "gh workflow run deny-schedule.yml --repo \"$GITHUB_REPOSITORY\" --ref dev"
+    ]);
+    assert_eq!(job.matches("run:").count(), 1);
+    assert!(!job.contains("continue-on-error"));
+}
+
+#[test]
+fn manual_audits_do_not_accept_an_independent_checkout_reference() {
+    let workflow = fs::read_to_string(root().join(".github/workflows/deny-schedule.yml")).unwrap();
+    assert!(workflow.contains("  workflow_dispatch:\n"));
+    assert!(workflow.contains("  schedule:\n"));
+    assert!(!workflow.contains("inputs:"));
+    assert!(!workflow.contains("workflow_call:"));
+    assert!(workflow.contains("permissions:\n  contents: read\n"));
+    assert_eq!(workflow.matches("actions: write").count(), 1);
+}
+
+#[test]
+fn rust_supply_chain_sources_require_ci_owner_review() {
+    let owners = fs::read_to_string(root().join(".github/CODEOWNERS")).unwrap();
+    assert!(owners.lines().any(|line| {
+        line.split_whitespace().collect::<Vec<_>>()
+            == ["/scripts/supply-chain/", "@F1R3FLY-io/ci-maintainers"]
+    }));
+}
+
 #[test]
 fn docker_build_remains_frozen_offline_and_contains_the_workspace_tool() {
     let text = fs::read_to_string(root().join("node/Dockerfile")).unwrap();


### PR DESCRIPTION
## Summary

The scheduled cargo-deny workflow ran the default branch's workflow file and checked out `dev` and `master` by ref from a matrix. A branch was audited under another branch's workflow definition, and a tooling-presence guard turned a missing script into a silent skip.

This change audits each branch with its own workflow file against its own commit.

## Changes

- **`deny` job**: checks out only the event commit (`ref: ${{ github.sha }}`) with `persist-credentials: false`, and runs only on `dev` and `master`. The matrix and the tooling-presence guard are removed. The audit script and the workflow file now always come from the same commit, so a branch that drops the script while keeping the workflow fails loudly.
- **`dispatch-dev` job**: GitHub fires `schedule` only from the default branch, so the scheduled master run dispatches a `workflow_dispatch` run of this workflow on `dev`. The job has no checkout and no `uses:` step, scopes `actions: write` to itself, and runs only on the `schedule` event, so the dispatched run cannot re-enter. It then waits on the dispatched run with `gh run watch --exit-status`, so a dev audit failure fails the scheduled master run and reaches its notification recipients.
- **Tests**: `scripts/supply-chain/tests/repository.rs` pins the new shape. The `deny` job must execute only the event commit with no dispatch credentials. The `dispatch-dev` job must dispatch exactly once, wait on the result, and never check out code. The workflow must not accept a caller-supplied checkout reference.
- **CODEOWNERS**: `/scripts/supply-chain/` now requires review from `@F1R3FLY-io/ci-maintainers`.

## Review remediations

The multi-agent review reported three major findings. Two were valid and are fixed in the follow-up commit. See the remediation comment for the disposition of each finding.

## Verification

- `cargo test -p supply-chain --test repository`: 12 passed
- Pre-commit fmt, clippy, test, and deny checks pass
