### PR TITLE
fix(casper): a genesis validator that missed the ceremony pulls the approved block

### DIFF
--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -57,6 +57,14 @@ pub trait Engine: Send + Sync {
         Ok(false)
     }
 
+    /// Called by the casper loop on each tick while this engine has no
+    /// Casper instance. Default: nothing. Pre-genesis engines that wait on
+    /// PUSHED ceremony messages override this to PULL: a genesis validator
+    /// whose first bootstrap dial lost the container-start race misses both
+    /// the UnapprovedBlock broadcast and the ApprovedBlock send, and no
+    /// further push ever comes — without a pull it waits forever.
+    async fn on_no_casper_tick(&self) -> Result<(), CasperError> { Ok(()) }
+
     /// Returns the casper instance as an Arc if this engine wraps one.
     /// Returns None for engines that don't have casper (NoopEngine, Initializing, etc.)
     /// The Arc allows ownership transfer and use across async boundaries.

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -58,11 +58,8 @@ pub trait Engine: Send + Sync {
     }
 
     /// Called by the casper loop on each tick while this engine has no
-    /// Casper instance. Default: nothing. Pre-genesis engines that wait on
-    /// PUSHED ceremony messages override this to PULL: a genesis validator
-    /// whose first bootstrap dial lost the container-start race misses both
-    /// the UnapprovedBlock broadcast and the ApprovedBlock send, and no
-    /// further push ever comes — without a pull it waits forever.
+    /// Casper instance, so an engine waiting on pushed ceremony messages
+    /// can pull when the push window was missed.
     async fn on_no_casper_tick(&self) -> Result<(), CasperError> { Ok(()) }
 
     /// Returns the casper instance as an Arc if this engine wraps one.

--- a/casper/src/rust/engine/genesis_validator.rs
+++ b/casper/src/rust/engine/genesis_validator.rs
@@ -67,6 +67,9 @@ pub struct GenesisValidator<T: TransportLayer + Send + Sync + Clone + 'static> {
 
     // Bounded set of seen UnapprovedBlock candidates to avoid unbounded memory growth.
     seen_candidates: Arc<Mutex<SeenCandidates>>,
+    /// Last ApprovedBlock pull, throttling `on_no_casper_tick`'s recovery
+    /// request to one per interval rather than one per loop tick.
+    approved_block_pull_last: Arc<Mutex<Option<std::time::Instant>>>,
     /// Shared reference to heartbeat signal for triggering immediate wake on deploy
     heartbeat_signal_ref: crate::rust::heartbeat_signal::HeartbeatSignalRef,
     /// Handed through to Initializing on late-joiner recovery: a genesis
@@ -174,6 +177,7 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> GenesisValidator<T> {
             seen_candidates: Arc::new(Mutex::new(SeenCandidates::new(
                 genesis_seen_candidates_max_entries(),
             ))),
+            approved_block_pull_last: Arc::new(Mutex::new(None)),
             heartbeat_signal_ref,
             state_items_tx,
         }
@@ -317,6 +321,40 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> GenesisValidator<T> {
 #[async_trait]
 impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for GenesisValidator<T> {
     async fn init(&self) -> Result<(), CasperError> { Ok(()) }
+
+    /// A genesis validator whose first bootstrap dial lost the
+    /// container-start race misses both the UnapprovedBlock broadcast and
+    /// the one-shot ApprovedBlock send, and the signing flow gives it no
+    /// way out — no push ever comes again. Pull instead: ask bootstrap for
+    /// the ApprovedBlock; the response lands in `handle` and takes the
+    /// existing `handle_approved_block_late` recovery. Throttled so the
+    /// loop's tick cadence does not become the request cadence; a send
+    /// failure only warns — the next interval retries.
+    async fn on_no_casper_tick(&self) -> Result<(), CasperError> {
+        const APPROVED_BLOCK_PULL_INTERVAL: std::time::Duration =
+            std::time::Duration::from_secs(10);
+        {
+            let mut last = self.approved_block_pull_last.lock().unwrap();
+            if let Some(at) = *last {
+                if at.elapsed() < APPROVED_BLOCK_PULL_INTERVAL {
+                    return Ok(());
+                }
+            }
+            *last = Some(std::time::Instant::now());
+        }
+        tracing::info!(
+            "Genesis validator has seen no ceremony message; pulling the \
+             ApprovedBlock from bootstrap"
+        );
+        if let Err(err) = self
+            .transport_layer
+            .request_approved_block(&self.rp_conf_ask, None)
+            .await
+        {
+            tracing::warn!("ApprovedBlock pull from bootstrap failed: {}", err);
+        }
+        Ok(())
+    }
 
     /// Scala equivalent: `override def handle(peer: PeerNode, msg: CasperMessage): F[Unit]`
     async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError> {

--- a/casper/src/rust/engine/genesis_validator.rs
+++ b/casper/src/rust/engine/genesis_validator.rs
@@ -22,6 +22,7 @@ use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockRequest, BlockMessage, CasperMessage, NoApprovedBlockAvailable,
     UnapprovedBlock,
 };
+use models::rust::casper::protocol::packet_type_tag::ToPacket;
 use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
@@ -67,8 +68,6 @@ pub struct GenesisValidator<T: TransportLayer + Send + Sync + Clone + 'static> {
 
     // Bounded set of seen UnapprovedBlock candidates to avoid unbounded memory growth.
     seen_candidates: Arc<Mutex<SeenCandidates>>,
-    /// Last ApprovedBlock pull, throttling `on_no_casper_tick`'s recovery
-    /// request to one per interval rather than one per loop tick.
     approved_block_pull_last: Arc<Mutex<Option<std::time::Instant>>>,
     /// Shared reference to heartbeat signal for triggering immediate wake on deploy
     heartbeat_signal_ref: crate::rust::heartbeat_signal::HeartbeatSignalRef,
@@ -322,14 +321,11 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> GenesisValidator<T> {
 impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for GenesisValidator<T> {
     async fn init(&self) -> Result<(), CasperError> { Ok(()) }
 
-    /// A genesis validator whose first bootstrap dial lost the
-    /// container-start race misses both the UnapprovedBlock broadcast and
-    /// the one-shot ApprovedBlock send, and the signing flow gives it no
-    /// way out — no push ever comes again. Pull instead: ask bootstrap for
-    /// the ApprovedBlock; the response lands in `handle` and takes the
-    /// existing `handle_approved_block_late` recovery. Throttled so the
-    /// loop's tick cadence does not become the request cadence; a send
-    /// failure only warns — the next interval retries.
+    /// A validator that missed the ceremony's pushed messages pulls the
+    /// ApprovedBlock from bootstrap; the response takes the existing
+    /// `handle_approved_block_late` recovery. One send per throttle
+    /// interval — the casper loop awaits this tick inline, so a retrying
+    /// send against an unreachable bootstrap would stall the loop.
     async fn on_no_casper_tick(&self) -> Result<(), CasperError> {
         const APPROVED_BLOCK_PULL_INTERVAL: std::time::Duration =
             std::time::Duration::from_secs(10);
@@ -342,15 +338,24 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for GenesisValida
             }
             *last = Some(std::time::Instant::now());
         }
+        let Some(bootstrap) = self.rp_conf_ask.bootstrap.clone() else {
+            return Ok(());
+        };
         tracing::info!(
             "Genesis validator has seen no ceremony message; pulling the \
              ApprovedBlock from bootstrap"
         );
-        if let Err(err) = self
-            .transport_layer
-            .request_approved_block(&self.rp_conf_ask, None)
-            .await
-        {
+        let packet = models::casper::ApprovedBlockRequestProto {
+            identifier: "".to_string(),
+            trim_state: true,
+        }
+        .mk_packet();
+        let msg = comm::rust::rp::protocol_helper::packet(
+            &self.rp_conf_ask.local,
+            &self.rp_conf_ask.network_id,
+            packet,
+        );
+        if let Err(err) = self.transport_layer.send(&bootstrap, &msg).await {
             tracing::warn!("ApprovedBlock pull from bootstrap failed: {}", err);
         }
         Ok(())

--- a/casper/tests/engine/genesis_validator_spec.rs
+++ b/casper/tests/engine/genesis_validator_spec.rs
@@ -202,6 +202,65 @@ impl GenesisValidatorSpec {
         );
     }
 
+    /// The pull must be a SINGLE send attempt: the casper loop awaits the
+    /// tick inline, so a retrying send against an unreachable bootstrap
+    /// stalls the loop — and the retriever maintenance riding it. The 10s
+    /// throttle owns the retry cadence; a failed attempt just waits for it.
+    async fn a_failed_pull_returns_immediately_instead_of_retrying_inline() {
+        let _event_bus = shared::rust::shared::f1r3fly_events::F1r3flyEvents::new();
+
+        let fixture = TestFixture::new().await;
+        fixture.transport_layer.set_responses(|_, _| {
+            Err(comm::rust::errors::CommError::ProtocolException(
+                "connection refused".to_string(),
+            ))
+        });
+
+        let genesis_validator = GenesisValidator::new(
+            fixture.block_processing_queue_tx.clone(),
+            fixture.blocks_in_processing.clone(),
+            fixture.casper_shard_conf.clone(),
+            fixture.validator_id.clone(),
+            fixture.bap.clone(),
+            fixture.transport_layer.clone(),
+            fixture.rp_conf_ask.clone(),
+            fixture.connections_cell.clone(),
+            fixture.last_approved_block.clone(),
+            fixture.event_publisher.clone(),
+            fixture.block_retriever.clone(),
+            fixture.engine_cell.clone(),
+            fixture.block_store.clone(),
+            fixture.block_dag_storage.clone(),
+            fixture.deploy_storage.clone(),
+            fixture.rejected_deploy_buffer.clone(),
+            fixture.casper_buffer_storage.clone(),
+            fixture.rspace_state_manager.clone(),
+            fixture.runtime_manager.clone(),
+            fixture.estimator.clone(),
+            casper::rust::heartbeat_signal::new_heartbeat_signal_ref(),
+            None,
+        );
+        fixture.engine_cell.set(Arc::new(genesis_validator)).await;
+        let engine = fixture.engine_cell.get().await;
+
+        let ticked = tokio::time::timeout(Duration::from_secs(2), engine.on_no_casper_tick()).await;
+
+        assert!(
+            ticked.is_ok(),
+            "the tick must return promptly when bootstrap is unreachable; \
+             an inline retry loop stalls the casper loop"
+        );
+        ticked
+            .unwrap()
+            .expect("a failed pull must not error the tick");
+        assert_eq!(
+            fixture.transport_layer.request_count(),
+            1,
+            "exactly one send attempt per tick; the throttle owns the retry cadence"
+        );
+        fixture.transport_layer.reset();
+    }
+
     /// Regression test for the late-joiner race fixed in PR #489.
     ///
     /// A genesis validator that joins boot's connections AFTER all
@@ -440,4 +499,10 @@ async fn transitions_to_initializing_on_late_approved_block() {
 async fn a_validator_that_missed_the_whole_ceremony_pulls_the_approved_block() {
     GenesisValidatorSpec::a_validator_that_missed_the_whole_ceremony_pulls_the_approved_block()
         .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn a_failed_pull_returns_immediately_instead_of_retrying_inline() {
+    GenesisValidatorSpec::a_failed_pull_returns_immediately_instead_of_retrying_inline().await;
 }

--- a/casper/tests/engine/genesis_validator_spec.rs
+++ b/casper/tests/engine/genesis_validator_spec.rs
@@ -129,6 +129,79 @@ impl GenesisValidatorSpec {
         test.await;
     }
 
+    /// The CI-observed shape (run 34153662463, shard b78263a0-s5): the
+    /// validator's first bootstrap dial loses the container-start race, so
+    /// it misses the UnapprovedBlock broadcast AND the one-shot
+    /// ApprovedBlock send, then connects and receives NOTHING — no push
+    /// ever comes again. The casper loop's no-casper tick must make the
+    /// engine PULL the approved block from bootstrap; the pull is
+    /// throttled, so rapid ticks send one request, not one per tick.
+    async fn a_validator_that_missed_the_whole_ceremony_pulls_the_approved_block() {
+        let _event_bus = shared::rust::shared::f1r3fly_events::F1r3flyEvents::new();
+
+        let fixture = TestFixture::new().await;
+
+        let genesis_validator = GenesisValidator::new(
+            fixture.block_processing_queue_tx.clone(),
+            fixture.blocks_in_processing.clone(),
+            fixture.casper_shard_conf.clone(),
+            fixture.validator_id.clone(),
+            fixture.bap.clone(),
+            fixture.transport_layer.clone(),
+            fixture.rp_conf_ask.clone(),
+            fixture.connections_cell.clone(),
+            fixture.last_approved_block.clone(),
+            fixture.event_publisher.clone(),
+            fixture.block_retriever.clone(),
+            fixture.engine_cell.clone(),
+            fixture.block_store.clone(),
+            fixture.block_dag_storage.clone(),
+            fixture.deploy_storage.clone(),
+            fixture.rejected_deploy_buffer.clone(),
+            fixture.casper_buffer_storage.clone(),
+            fixture.rspace_state_manager.clone(),
+            fixture.runtime_manager.clone(),
+            fixture.estimator.clone(),
+            casper::rust::heartbeat_signal::new_heartbeat_signal_ref(),
+            None,
+        );
+        fixture.engine_cell.set(Arc::new(genesis_validator)).await;
+        let engine = fixture.engine_cell.get().await;
+
+        // The exact CI sequence: no UnapprovedBlock, no ApprovedBlock —
+        // only the loop ticking against an engine with no casper.
+        for _ in 0..3 {
+            engine
+                .on_no_casper_tick()
+                .await
+                .expect("no-casper tick must not error");
+        }
+
+        let pull_requests: Vec<_> = fixture
+            .transport_layer
+            .get_all_requests()
+            .into_iter()
+            .filter(|request| {
+                matches!(
+                    request.msg.message.as_ref(),
+                    Some(models::routing::protocol::Message::Packet(packet))
+                        if packet.type_id == "ApprovedBlockRequest"
+                )
+            })
+            .collect();
+
+        assert!(
+            !pull_requests.is_empty(),
+            "a genesis validator that missed the ceremony must pull the \
+             approved block from bootstrap instead of waiting forever"
+        );
+        assert_eq!(
+            pull_requests.len(),
+            1,
+            "rapid ticks inside the throttle window must send one pull"
+        );
+    }
+
     /// Regression test for the late-joiner race fixed in PR #489.
     ///
     /// A genesis validator that joins boot's connections AFTER all
@@ -360,4 +433,11 @@ async fn should_not_respond_to_any_other_message() {
 #[serial]
 async fn transitions_to_initializing_on_late_approved_block() {
     GenesisValidatorSpec::transitions_to_initializing_on_late_approved_block().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn a_validator_that_missed_the_whole_ceremony_pulls_the_approved_block() {
+    GenesisValidatorSpec::a_validator_that_missed_the_whole_ceremony_pulls_the_approved_block()
+        .await;
 }

--- a/node/src/rust/runtime/setup.rs
+++ b/node/src/rust/runtime/setup.rs
@@ -744,6 +744,11 @@ pub async fn setup_node_program<T: TransportLayer + Send + Sync + Clone + 'stati
                     }
                 } else {
                     warn!("Casper engine present but Casper not initialized yet");
+                    // Pre-genesis engines wait on pushed ceremony messages; the
+                    // tick lets them PULL when the push window was missed.
+                    if let Err(err) = engine.on_no_casper_tick().await {
+                        warn!("no-casper tick failed: {}", err);
+                    }
                 }
 
                 // Maintain RequestedBlocks for Casper

--- a/node/src/rust/runtime/setup.rs
+++ b/node/src/rust/runtime/setup.rs
@@ -744,8 +744,6 @@ pub async fn setup_node_program<T: TransportLayer + Send + Sync + Clone + 'stati
                     }
                 } else {
                     warn!("Casper engine present but Casper not initialized yet");
-                    // Pre-genesis engines wait on pushed ceremony messages; the
-                    // tick lets them PULL when the push window was missed.
                     if let Err(err) = engine.on_no_casper_tick().await {
                         warn!("no-casper tick failed: {}", err);
                     }


### PR DESCRIPTION
Fixes the genesis-ceremony join race behind dev run 34153662463's amd64-docker failure (`test_validator_failure_recovery`: validator1 never reached Running in 300s). Forensics on that shard (b78263a0-s5): validator1's first bootstrap dial lost the container-start race by ~400ms (TCP refused; boot's listener came up at 19:14:38.4, the dial was 19:14:38.0), so it missed the UnapprovedBlock broadcast at 19:14:39; v2+v3 met `required_sigs=2` at 19:14:41 and the ceremony completed without it; boot's one-shot ApprovedBlock sends at 19:14:49-51 went to the peers connected then. Validator1 connected to everyone at 19:14:58 and then received nothing, forever — the GenesisValidator engine waits on pushed ceremony messages, and no further push exists.

The fix is a pull, using only existing machinery:

- `Engine` gains a defaulted `on_no_casper_tick` hook, called by the casper loop's existing no-casper arm (the same ~750ms tick that was already logging "Casper engine present but Casper not initialized yet" throughout validator1's stall).
- `GenesisValidator` overrides it with a throttled (10s) `ApprovedBlockRequest` to bootstrap. The response flows through the existing `handle_approved_block_late` recovery into `Initializing` — the path the observer engines already use, which is why the readonly in the same shard recovered (boot re-sent to it on request at 19:14:59) while validator1 hung.

Red-first: the new spec reproduces the CI sequence exactly — no ceremony message ever pushed, only no-casper ticks — and pre-fix the engine sends nothing forever; post-fix it pulls once per throttle window. The existing push-recovery spec (`transitions_to_initializing_on_late_approved_block`) covers the second half of the journey.

Co-Authored-By: Claude <noreply@anthropic.com>
