### PR TITLE
fix(crypto): stop PEM reader dropping base64 lines that contain KEY

### DIFF
--- a/crypto/src/rust/util/certificate_helper.rs
+++ b/crypto/src/rust/util/certificate_helper.rs
@@ -149,7 +149,8 @@ impl CertificateHelper {
         // Remove PEM headers and decode base64
         let pem_lines: Vec<&str> = pem_content
             .lines()
-            .filter(|line| !line.contains("KEY"))
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with("-----"))
             .collect();
         let base64_content = pem_lines.join("");
 

--- a/crypto/tests/util/certificate_helper_spec.rs
+++ b/crypto/tests/util/certificate_helper_spec.rs
@@ -302,6 +302,28 @@ fn test_print_private_key_from_secret_roundtrips_through_read_key_pair() {
 }
 
 #[test]
+fn test_read_key_pair_keeps_base64_body_lines_containing_key() {
+    let pem = "-----BEGIN PRIVATE KEY-----\n\
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgBTKEY6yp79c5dbNy\n\
+hUWSBmo9phQ452/PK1BotDnn9MihRANCAAQZMJSYyZI8LFWGt9m1i3iG32JY+rFv\n\
+tWB90bq4vpoJJMbKQl6ZoXhmeTtpOFxgJ9KMY7lfUz+MKa88M8XSn7Y5\n\
+-----END PRIVATE KEY-----";
+    assert!(pem
+        .lines()
+        .any(|line| !line.starts_with("-----") && line.contains("KEY")));
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let key_path = temp_dir.path().join("key.pem");
+    std::fs::write(&key_path, pem).expect("failed to write key file");
+
+    let (parsed_secret, _) = CertificateHelper::read_key_pair(key_path.to_str().unwrap())
+        .expect("body lines containing KEY must not be dropped");
+    let reprinted = CertificatePrinter::print_private_key_from_secret(&parsed_secret)
+        .expect("private key printing should succeed");
+    assert_eq!(reprinted, pem);
+}
+
+#[test]
 fn test_read_key_pair_error_paths() {
     let missing = CertificateHelper::read_key_pair("/nonexistent/path/key.pem");
     assert!(missing.is_err());


### PR DESCRIPTION
read_key_pair stripped the PEM header and footer by discarding every line containing the substring KEY. A base64 body line can contain KEY by chance, so roughly one generated key per thousand lost a 48-byte chunk and failed PKCS#8 parsing. This surfaced as an intermittent failure of test_print_private_key_from_secret_roundtrips_through_read_key_pair in CI.

Filter on the five-dash armor lines instead, and add a regression test with a fixed PEM whose body line contains KEY.