### PR TITLE
chore(casper): remove unreachable stale-rejoin recovery path

### DIFF
--- a/casper/src/rust/engine/casper_launch.rs
+++ b/casper/src/rust/engine/casper_launch.rs
@@ -34,7 +34,6 @@ use crate::rust::engine::engine_cell::EngineCell;
 use crate::rust::engine::genesis_ceremony_master::GenesisCeremonyMaster;
 use crate::rust::engine::genesis_validator::GenesisValidator;
 use crate::rust::engine::multi_parent_casper::MultiParentCasperImpl;
-use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::errors::CasperError;
 use crate::rust::estimator::Estimator;
 use crate::rust::genesis::contracts::proof_of_stake::ProofOfStake;
@@ -450,22 +449,6 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> CasperLaunchImpl<T> {
             self.transport_layer.clone(),
             self.rp_conf_ask.clone(),
             self.block_retriever.clone(),
-            Some(RunningRecoveryContext {
-                connections_cell: self.connections_cell.clone(),
-                last_approved_block: self.last_approved_block.clone(),
-                block_store: self.block_store.clone(),
-                block_dag_storage: self.block_dag_storage.clone(),
-                deploy_storage: self.deploy_storage.clone(),
-                rejected_deploy_buffer: self.rejected_deploy_buffer.clone(),
-                casper_buffer_storage: self.casper_buffer_storage.clone(),
-                rspace_state_manager: self.rspace_state_manager.clone(),
-                event_publisher: self.event_publisher.clone(),
-                engine_cell: self.engine_cell.clone(),
-                runtime_manager: self.runtime_manager.clone(),
-                estimator: self.estimator.clone(),
-                casper_shard_conf: self.casper_shard_conf.clone(),
-                heartbeat_signal_ref: self.heartbeat_signal_ref.clone(),
-            }),
             &self.engine_cell,
             &self.event_publisher,
             self.state_items_tx.clone(),

--- a/casper/src/rust/engine/engine.rs
+++ b/casper/src/rust/engine/engine.rs
@@ -3,7 +3,6 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use async_trait::async_trait;
 use block_storage::rust::casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage;
@@ -49,13 +48,6 @@ pub trait Engine: Send + Sync {
     async fn init(&self) -> Result<(), CasperError>;
 
     async fn handle(&self, peer: PeerNode, msg: CasperMessage) -> Result<(), CasperError>;
-
-    async fn recover_stuck_validator(
-        &self,
-        _delay_threshold: Duration,
-    ) -> Result<bool, CasperError> {
-        Ok(false)
-    }
 
     /// Called by the casper loop on each tick while this engine has no
     /// Casper instance, so an engine waiting on pushed ceremony messages
@@ -220,7 +212,6 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'st
     transport: Arc<U>,
     conf: RPConf,
     block_retriever: BlockRetriever<U>,
-    recovery_context: Option<crate::rust::engine::running::RunningRecoveryContext>,
     engine_cell: &EngineCell,
     event_log: &F1r3flyEvents,
     state_items_tx: Option<
@@ -255,7 +246,6 @@ pub async fn transition_to_running<U: TransportLayer + Send + Sync + Clone + 'st
         transport,
         conf,
         block_retriever,
-        recovery_context,
         state_items_tx,
     );
 

--- a/casper/src/rust/engine/genesis_ceremony_master.rs
+++ b/casper/src/rust/engine/genesis_ceremony_master.rs
@@ -163,7 +163,6 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> GenesisCeremonyMaster<T>
                     transport_layer.clone(),
                     rp_conf_ask.clone(),
                     block_retriever.clone(),
-                    None,
                     &engine_cell,
                     event_publisher,
                     // The ceremony master transitions genesis-rooted: its

--- a/casper/src/rust/engine/initializing.rs
+++ b/casper/src/rust/engine/initializing.rs
@@ -45,7 +45,6 @@ use crate::rust::engine::engine::{
 use crate::rust::engine::engine_cell::EngineCell;
 use crate::rust::engine::lfs_block_requester::{self, BlockRequesterOps};
 use crate::rust::engine::lfs_tuple_space_requester::{self, StatePartPath, TupleSpaceRequesterOps};
-use crate::rust::engine::running::RunningRecoveryContext;
 use crate::rust::errors::CasperError;
 use crate::rust::estimator::Estimator;
 use crate::rust::metrics_constants::{
@@ -1542,7 +1541,6 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             .unwrap()
             .take()
             .ok_or_else(|| CasperError::RuntimeError("Estimator not available".to_string()))?;
-        let recovery_estimator = estimator.clone();
 
         // The on-chain fault-tolerance threshold is read and adopted by
         // `hash_set_casper` (the single adoption point shared by all three
@@ -1592,22 +1590,6 @@ impl<T: TransportLayer + Send + Sync + Clone> Initializing<T> {
             Arc::new(self.transport_layer.clone()),
             self.rp_conf_ask.clone(),
             self.block_retriever.clone(),
-            Some(RunningRecoveryContext {
-                connections_cell: self.connections_cell.clone(),
-                last_approved_block: self.last_approved_block.clone(),
-                block_store: self.block_store.clone(),
-                block_dag_storage: self.block_dag_storage.clone(),
-                deploy_storage: self.deploy_storage.clone(),
-                rejected_deploy_buffer: self.rejected_deploy_buffer.clone(),
-                casper_buffer_storage: self.casper_buffer_storage.clone(),
-                rspace_state_manager: self.rspace_state_manager.clone(),
-                event_publisher: self.event_publisher.clone(),
-                engine_cell: self.engine_cell.clone(),
-                runtime_manager: self.runtime_manager.clone(),
-                estimator: recovery_estimator,
-                casper_shard_conf: self.casper_shard_conf.clone(),
-                heartbeat_signal_ref: self.heartbeat_signal_ref.clone(),
-            }),
             &self.engine_cell,
             &self.event_publisher,
             self.state_items_tx.clone(),

--- a/casper/src/rust/engine/running.rs
+++ b/casper/src/rust/engine/running.rs
@@ -7,11 +7,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use block_storage::rust::casperbuffer::casper_buffer_key_value_storage::CasperBufferKeyValueStorage;
-use block_storage::rust::dag::block_dag_key_value_storage::BlockDagKeyValueStorage;
-use block_storage::rust::deploy::key_value_deploy_storage::KeyValueDeployStorage;
-use block_storage::rust::deploy::key_value_rejected_deploy_buffer::KeyValueRejectedDeployBuffer;
-use block_storage::rust::key_value_block_store::KeyValueBlockStore;
 use comm::rust::peer_node::PeerNode;
 use comm::rust::rp::connect::ConnectionsCell;
 use comm::rust::rp::rp_conf::RPConf;
@@ -26,22 +21,18 @@ use models::rust::casper::protocol::casper_message::{
 use rspace_plus_plus::rspace::hashing::blake2b256_hash::Blake2b256Hash;
 use rspace_plus_plus::rspace::state::exporters::rspace_exporter_items::RSpaceExporterItems;
 use rspace_plus_plus::rspace::state::rspace_exporter::RSpaceExporterInstance;
-use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
-use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
 
-use crate::rust::casper::{CasperShardConf, MultiParentCasper};
+use crate::rust::casper::MultiParentCasper;
 use crate::rust::engine::block_retriever::{self, BlockRetriever};
 use crate::rust::engine::engine::{self, Engine};
 use crate::rust::engine::engine_cell::EngineCell;
 use crate::rust::errors::CasperError;
-use crate::rust::estimator::Estimator;
 use crate::rust::finality::floor::floor_of_block;
 use crate::rust::metrics_constants::{
     BLOCK_HASH_RECEIVED_METRIC, BLOCK_REQUEST_RECEIVED_METRIC, RUNNING_METRICS_SOURCE,
 };
 use crate::rust::safety::clique_oracle::FtThreshold;
-use crate::rust::util::rholang::runtime_manager::RuntimeManager;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CasperMessageStatus {
@@ -206,12 +197,6 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for Running<T> {
                                 e
                             ))
                         })?;
-                    let now_ms = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis() as i64;
-                    self.last_peer_block_arrival_ms
-                        .store(now_ms, std::sync::atomic::Ordering::Relaxed);
                 }
                 Ok(())
             }
@@ -346,13 +331,6 @@ impl<T: TransportLayer + Send + Sync + Clone + 'static> Engine for Running<T> {
 
     /// Running always contains casper; enables `EngineDynExt::with_casper(...)`
     /// to mirror Scala `Engine.withCasper` behavior.
-    async fn recover_stuck_validator(
-        &self,
-        delay_threshold: Duration,
-    ) -> Result<bool, CasperError> {
-        self.recover_stuck_validator_inner(delay_threshold).await
-    }
-
     fn with_casper(&self) -> Option<Arc<dyn MultiParentCasper + Send + Sync>> {
         Some(Arc::clone(&self.casper) as Arc<dyn MultiParentCasper + Send + Sync>)
     }
@@ -375,54 +353,13 @@ pub struct Running<T: TransportLayer + Send + Sync> {
     transport: Arc<T>,
     conf: RPConf,
     block_retriever: BlockRetriever<T>,
-    recovery_context: Option<RunningRecoveryContext>,
-    /// Wall-clock of the last peer block accepted for processing. The
-    /// stale-rejoin trigger requires receive-quiescence in addition to
-    /// own-message staleness: a node that keeps receiving blocks is not
-    /// partitioned — it is failing to PROPOSE, and ejecting it into an
-    /// approved-block state rejoin destroys its custody duties.
-    last_peer_block_arrival_ms: Arc<std::sync::atomic::AtomicI64>,
     /// Routes incoming [`casper_message::StoreItemsMessage`]s to the runtime
     /// state requester. `None` on a node that cannot need one (genesis
     /// ceremony); without it those messages are dropped, as they always were.
     state_items_tx: Option<mpsc::Sender<casper_message::StoreItemsMessage>>,
 }
 
-#[derive(Clone)]
-pub struct RunningRecoveryContext {
-    pub connections_cell: ConnectionsCell,
-    pub last_approved_block: Arc<Mutex<Option<ApprovedBlock>>>,
-    pub block_store: KeyValueBlockStore,
-    pub block_dag_storage: BlockDagKeyValueStorage,
-    pub deploy_storage: KeyValueDeployStorage,
-    pub rejected_deploy_buffer: Arc<Mutex<KeyValueRejectedDeployBuffer>>,
-    pub casper_buffer_storage: CasperBufferKeyValueStorage,
-    pub rspace_state_manager: RSpaceStateManager,
-    pub event_publisher: F1r3flyEvents,
-    pub engine_cell: Arc<EngineCell>,
-    pub runtime_manager: Arc<RuntimeManager>,
-    pub estimator: Estimator,
-    pub casper_shard_conf: CasperShardConf,
-    pub heartbeat_signal_ref: crate::rust::heartbeat_signal::HeartbeatSignalRef,
-}
-
 use crate::rust::blocks::block_processor::MAX_BLOCKS_IN_PROCESSING;
-
-/// The stale-rejoin trigger: rejoin-from-approved-block only when the
-/// validator's own latest message is stale AND no peer block has arrived
-/// for the same window. Own-staleness alone is not a partition signal — a
-/// node that keeps receiving and validating peer blocks has a working
-/// network and a local PROPOSE problem, and ejecting it into a state
-/// rejoin abandons its owner-custody duties for the rejoin's duration
-/// (observed as an 80-minute self-eviction in the ucc ca7197d8 specimen,
-/// where every validator was propose-wedged but fully connected).
-fn should_rejoin_from_approved_block(
-    own_latest_age_ms: i64,
-    arrival_age_ms: i64,
-    threshold_ms: i64,
-) -> bool {
-    own_latest_age_ms >= threshold_ms && arrival_age_ms >= threshold_ms
-}
 
 impl<T: TransportLayer + Send + Sync> Running<T> {
     /// The floor and frontier of the block we are about to hand over as a sync
@@ -506,13 +443,8 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
         transport: Arc<T>,
         conf: RPConf,
         block_retriever: BlockRetriever<T>,
-        recovery_context: Option<RunningRecoveryContext>,
         state_items_tx: Option<mpsc::Sender<casper_message::StoreItemsMessage>>,
     ) -> Self {
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
         Running {
             block_processing_queue_tx,
             blocks_in_processing,
@@ -524,8 +456,6 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
             transport,
             conf,
             block_retriever,
-            recovery_context,
-            last_peer_block_arrival_ms: Arc::new(std::sync::atomic::AtomicI64::new(now_ms)),
             state_items_tx,
         }
     }
@@ -535,94 +465,6 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
         let buffer_contains = self.casper.buffer_contains(&hash);
         let dag_contains = self.casper.dag_contains(&hash);
         Ok(blocks_in_processing || buffer_contains || dag_contains)
-    }
-
-    async fn recover_stuck_validator_inner(
-        &self,
-        delay_threshold: Duration,
-    ) -> Result<bool, CasperError>
-    where
-        T: Clone + 'static,
-    {
-        let Some(recovery_context) = &self.recovery_context else {
-            return Ok(false);
-        };
-        let Some(validator_id) = self.casper.get_validator() else {
-            return Ok(false);
-        };
-
-        let validator = validator_id.public_key.bytes.clone();
-        let dag = self.casper.block_dag().await?;
-        let latest_hash = match dag.latest_message_hash(&validator) {
-            Some(hash) => hash,
-            None => return Ok(false),
-        };
-        if latest_hash == dag.last_finalized_block() {
-            return Ok(false);
-        }
-
-        let latest_block = match self.casper.block_store().get(&latest_hash)? {
-            Some(block) => block,
-            None => return Ok(false),
-        };
-
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as i64;
-        let latest_age_ms = now_ms.saturating_sub(latest_block.header.timestamp);
-        let arrival_age_ms = now_ms.saturating_sub(
-            self.last_peer_block_arrival_ms
-                .load(std::sync::atomic::Ordering::Relaxed),
-        );
-        if !should_rejoin_from_approved_block(
-            latest_age_ms,
-            arrival_age_ms,
-            delay_threshold.as_millis() as i64,
-        ) {
-            return Ok(false);
-        }
-
-        let init = Arc::new(|| {
-            Box::pin(async { Ok(()) })
-                as Pin<Box<dyn Future<Output = Result<(), CasperError>> + Send>>
-        });
-
-        tracing::warn!(
-            "Validator latest message {} has been stale for {}ms; rejoining from approved block.",
-            PrettyPrinter::build_string_bytes(&latest_hash),
-            latest_age_ms
-        );
-
-        engine::transition_to_initializing(
-            &self.block_processing_queue_tx,
-            &self.blocks_in_processing,
-            &recovery_context.casper_shard_conf,
-            &Some(validator_id),
-            init,
-            true,
-            self.disable_state_exporter,
-            &self.transport,
-            &self.conf,
-            &recovery_context.connections_cell,
-            &recovery_context.last_approved_block,
-            &recovery_context.block_store,
-            &recovery_context.block_dag_storage,
-            &recovery_context.deploy_storage,
-            &recovery_context.rejected_deploy_buffer,
-            &recovery_context.casper_buffer_storage,
-            &recovery_context.rspace_state_manager,
-            recovery_context.event_publisher.clone(),
-            self.block_retriever.clone(),
-            &recovery_context.engine_cell,
-            &recovery_context.runtime_manager,
-            &recovery_context.estimator,
-            &recovery_context.heartbeat_signal_ref,
-            self.state_items_tx.clone(),
-        )
-        .await?;
-
-        Ok(true)
     }
 
     pub async fn handle_block_hash_message(
@@ -908,26 +750,5 @@ impl<T: TransportLayer + Send + Sync> Running<T> {
 
         tracing::info!("Store items sent to {}", peer);
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::should_rejoin_from_approved_block;
-
-    /// A propose-wedged but connected validator must NOT rejoin: its own
-    /// latest message is stale, yet peer blocks keep arriving — the network
-    /// is alive and the fault is local to proposing.
-    #[test]
-    fn a_receiving_validator_with_a_stale_own_message_must_not_rejoin() {
-        assert!(!should_rejoin_from_approved_block(120_000, 500, 60_000));
-    }
-
-    /// Genuine quiescence: own message stale AND nothing arriving for the
-    /// window — the partition signal the rejoin exists for.
-    #[test]
-    fn a_quiescent_stale_validator_rejoins() {
-        assert!(should_rejoin_from_approved_block(120_000, 90_000, 60_000));
-        assert!(!should_rejoin_from_approved_block(500, 90_000, 60_000));
     }
 }

--- a/casper/tests/engine/running_spec.rs
+++ b/casper/tests/engine/running_spec.rs
@@ -13,9 +13,7 @@ use casper::rust::casper::{
 };
 use casper::rust::engine::engine::Engine;
 use casper::rust::engine::engine_cell::EngineCell;
-use casper::rust::engine::running::{
-    update_fork_choice_tips_if_stuck, Running, RunningRecoveryContext,
-};
+use casper::rust::engine::running::{update_fork_choice_tips_if_stuck, Running};
 use casper::rust::errors::CasperError;
 use casper::rust::validator_identity::ValidatorIdentity;
 use models::casper::ApprovedBlockRequestProto;
@@ -407,29 +405,10 @@ mod tests {
             fixture.transport_layer.clone(),
             fixture.rp_conf_ask.clone(),
             fixture.block_retriever.clone(),
-            Some(RunningRecoveryContext {
-                connections_cell: fixture.connections_cell.clone(),
-                last_approved_block: fixture.last_approved_block.clone(),
-                block_store: fixture.block_store.clone(),
-                block_dag_storage: fixture.block_dag_storage.clone(),
-                deploy_storage: fixture.deploy_storage.clone(),
-                rejected_deploy_buffer: fixture.rejected_deploy_buffer.clone(),
-                casper_buffer_storage: fixture.casper_buffer_storage.clone(),
-                rspace_state_manager: fixture.rspace_state_manager.clone(),
-                event_publisher: fixture.event_publisher.clone(),
-                engine_cell: engine_cell.clone(),
-                runtime_manager: fixture.runtime_manager.clone(),
-                estimator: fixture.estimator.clone(),
-                casper_shard_conf: fixture.casper_shard_conf.clone(),
-                heartbeat_signal_ref: casper::rust::heartbeat_signal::new_heartbeat_signal_ref(),
-            }),
             None,
         );
         engine_cell.set(Arc::new(running)).await;
 
-        // The rejoin requires receive-quiescence in addition to the stale
-        // own message: no peer block has arrived since construction, so
-        // aging past the threshold makes the node genuinely quiescent.
         tokio::time::sleep(Duration::from_millis(1_100)).await;
 
         update_fork_choice_tips_if_stuck(
@@ -519,22 +498,6 @@ mod tests {
             fixture.transport_layer.clone(),
             fixture.rp_conf_ask.clone(),
             fixture.block_retriever.clone(),
-            Some(RunningRecoveryContext {
-                connections_cell: fixture.connections_cell.clone(),
-                last_approved_block: fixture.last_approved_block.clone(),
-                block_store: fixture.block_store.clone(),
-                block_dag_storage: fixture.block_dag_storage.clone(),
-                deploy_storage: fixture.deploy_storage.clone(),
-                rejected_deploy_buffer: fixture.rejected_deploy_buffer.clone(),
-                casper_buffer_storage: fixture.casper_buffer_storage.clone(),
-                rspace_state_manager: fixture.rspace_state_manager.clone(),
-                event_publisher: fixture.event_publisher.clone(),
-                engine_cell: engine_cell.clone(),
-                runtime_manager: fixture.runtime_manager.clone(),
-                estimator: fixture.estimator.clone(),
-                casper_shard_conf: fixture.casper_shard_conf.clone(),
-                heartbeat_signal_ref: casper::rust::heartbeat_signal::new_heartbeat_signal_ref(),
-            }),
             None,
         );
         engine_cell.set(Arc::new(running)).await;

--- a/casper/tests/engine/setup.rs
+++ b/casper/tests/engine/setup.rs
@@ -489,7 +489,6 @@ impl TestFixture {
             rp_conf.clone(),
             block_retriever.clone(),
             None,
-            None,
         );
 
         Self {

--- a/casper/tests/helper/test_node.rs
+++ b/casper/tests/helper/test_node.rs
@@ -15,7 +15,7 @@ use casper::rust::casper::{Casper, CasperShardConf, MultiParentCasper};
 use casper::rust::engine::block_retriever::{BlockRetriever, RequestState, RequestedBlocks};
 use casper::rust::engine::engine_cell::EngineCell;
 use casper::rust::engine::multi_parent_casper::MultiParentCasperImpl;
-use casper::rust::engine::running::{Running, RunningRecoveryContext};
+use casper::rust::engine::running::Running;
 use casper::rust::errors::CasperError;
 use casper::rust::estimator::Estimator;
 use casper::rust::genesis::genesis::Genesis;
@@ -43,7 +43,6 @@ use models::rust::casper::protocol::casper_message::{
     ApprovedBlock, ApprovedBlockCandidate, BlockMessage, DeployData,
 };
 use rspace_plus_plus::rspace::history::Either;
-use rspace_plus_plus::rspace::state::rspace_state_manager::RSpaceStateManager;
 use shared::rust::shared::f1r3fly_events::F1r3flyEvents;
 use tokio::sync::mpsc;
 
@@ -1016,17 +1015,12 @@ impl TestNode {
             .await
             .unwrap();
         // Use create_with_history to ensure tests can reset to genesis state root hash
-        let (runtime_manager, rho_history_repository) = RuntimeManager::create_with_history(
+        let (runtime_manager, _) = RuntimeManager::create_with_history(
             rspace_store,
             mergeable_store,
             std::sync::Arc::new(Genesis::default_mergeable_tags()),
             rholang::rust::interpreter::external_services::ExternalServices::noop(),
         );
-        let rspace_state_manager = RSpaceStateManager::new(
-            rho_history_repository.exporter(),
-            rho_history_repository.importer(),
-        );
-
         let connections_cell = ConnectionsCell::new();
         let _clique_oracle = CliqueOracleImpl;
         let estimator = Estimator::apply();
@@ -1107,8 +1101,6 @@ impl TestNode {
             floor_seed: None,
             sigs: vec![],
         };
-        let last_approved_block = Arc::new(Mutex::new(Some(_approved_block.clone())));
-
         let shard_conf = CasperShardConf {
             fault_tolerance_threshold: 0.0,
             shard_name: shard_id.clone(),
@@ -1195,22 +1187,6 @@ impl TestNode {
             tle.clone(),                     // transport
             rp_conf.clone(),                 // conf
             block_retriever.clone(),         // block_retriever
-            Some(RunningRecoveryContext {
-                connections_cell: connections_cell.clone(),
-                last_approved_block: last_approved_block.clone(),
-                block_store: block_store.clone(),
-                block_dag_storage: block_dag_storage.clone(),
-                deploy_storage: deploy_storage.lock().clone(),
-                rejected_deploy_buffer: rejected_deploy_buffer.clone(),
-                casper_buffer_storage: casper_buffer_storage.clone(),
-                rspace_state_manager: rspace_state_manager.clone(),
-                event_publisher: event_publisher.clone(),
-                engine_cell: Arc::new(engine_cell.clone()),
-                runtime_manager: Arc::new(runtime_manager.clone()),
-                estimator: estimator.clone(),
-                casper_shard_conf: casper.casper_shard_conf.clone(),
-                heartbeat_signal_ref: casper.heartbeat_signal_ref.clone(),
-            }),
             None,
         );
         engine_cell.set(Arc::new(running_engine)).await;


### PR DESCRIPTION
Removes the rejoin-from-approved-block recovery path, which has no callers.

- `e456644a6` added the path with its trigger inside `update_fork_choice_tips_if_stuck`; #224 (`ec1c7dcbf`) removed that trigger when it moved stall recovery into the heartbeat proposer's synchrony-recovery machinery; the receive-quiescence guard (`7bdb22f9c`) was authored on a parallel branch, so the merged result kept the whole path unreachable.
- Deleted: `Engine::recover_stuck_validator` (trait default + `Running` impl), `recover_stuck_validator_inner`, `should_rejoin_from_approved_block` + its unit tests, `RunningRecoveryContext`, and the `last_peer_block_arrival_ms` field whose only reader was this path. `transition_to_running` and `Running::new` lose the context parameter; the three construction sites and test fixtures shrink accordingly.
- Kept: the replacement design and its coverage — `update_fork_choice_tips_if_stuck`, `minority_fork_recovery_spec.rs`, and the two `running_spec` tests pinning stay-Running behavior (tips request, no ApprovedBlockRequest).

Context: #21 (closed not planned) records why the rejoin design was superseded.
